### PR TITLE
dump 0.2.21

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -34,22 +34,19 @@
                                     <li>
                                         <a href="#p_options">options</a>
                                         <ul>
-                                            <li><a href="#p_useLegacy">useLegacy</a></li>
-                                            <li><a href="#p_formatted">formatted</a></li>
-                                            <li><a href="#p_video">video</a></li>
-                                            <li><a href="#p_showCollision">showCollision</a></li>
-                                            <li><a href="#p_showFPS">showFPS</a></li>
-                                            <li><a href="#p_showCommentCount">showCommentCount</a></li>
+                                            <li><a href="#p_debug">debug</a></li>
                                             <li><a href="#p_drawAllImageOnLoad">drawAllImageOnLoad</a></li>
+                                            <li><a href="#p_enableLegacyPiP">enableLegacyPiP</a></li>
+                                            <li><a href="#p_format">format</a></li>
+                                            <li><a href="#p_formatted">formatted</a></li>
+                                            <li><a href="#p_keepCA">keepCA</a></li>
+                                            <li><a href="#p_showCollision">showCollision</a></li>
+                                            <li><a href="#p_showCommentCount">showCommentCount</a></li>
+                                            <li><a href="#p_showFPS">showFPS</a></li>
+                                            <li><a href="#p_useLegacy">useLegacy</a></li>
+                                            <li><a href="#p_video">video</a></li>
                                         </ul>
                                     </li>
-                                </ul>
-                            </li>
-                            <li>
-                                <a href="#Attributes">Attributes</a>
-                                <ul>
-                                    <li><a href="#a_showFPS">showFPS</a></li>
-                                    <li><a href="#a_showCommentCount">showCommentCount</a></li>
                                 </ul>
                             </li>
                             <li>
@@ -70,14 +67,14 @@
     <section id="title">
         <h1><span class="package_name">niconicomments</span> documentation</h1>
     </section>
-    <section id="patent">
-        <h2><span class="important">[重要]このライブラリを使用される方へ</span></h2>
+    <section id="patent" class="warn">
+        <h2>[重要]このライブラリを使用される方へ</h2>
         <p>ニコニコ運営が画面にコメントを流すアドオンを特許侵害だと騒ぎ立てて潰して回っているようです</p>
         <p>このライブラリ本体は描画部分のみのため特許侵害に当たるとは考えていませんが、ニコニコ動画運営(とその近辺の人)に叩かれる可能性があります</p>
         <p>(すでに一部OSSに被害が出ています)</p>
         <p>また、このライブラリを使用するかどうかに関わらず、リアルタイムでコメントを取得、画面を描画、コメントの投稿という一連の流れを実装した場合、ニコニコの特許を侵害する可能性があります</p>
         <p>詳しくはこちら<a href="https://github.com/xpadev-net/niconicomments/blob/master/ABOUT_PATENT.md">ニコニコが保有する特許について</a>を参照してください</p>
-        <p><span class="important">※当ライブラリを削除する予定は一切ありません</span></p>
+        <p>※当ライブラリを削除する予定は一切ありません</p>
     </section>
     <section id="about">
         <h2>About</h2>
@@ -112,101 +109,141 @@
     </section>
     <section id="class">
         <h2>Class</h2>
-        <h4 id="NiconiComments">class <span class="red">NiconiComments</span>(canvas<span class="type">:HTMLCanvasElement</span>, data<span class="type">:[]</span>, options<span class="type">:options</span>)</h4>
+        <h4 id="NiconiComments">class <span class="red">NiconiComments</span>(canvas<span class="type">:HTMLCanvasElement</span>, data<span class="type">:[]</span>, options<span class="type">:<a href="./type/modules/_types_types.html#InitOptions">InitOptions</a></span>)</h4>
         <div class="item">
-            <p>このライブラリの本体です。</p>
-            <p>すべての処理はこのクラスのみで完結します。</p>
+            <p>このライブラリの本体です</p>
             <h3 id="Parameters">Parameters</h3>
             <div class="item">
                 <h4 id="p_canvas">canvas<span class="type">:HTMLCanvasElement</span></h4>
                 <div class="item">
-                    <p>コメント描画用のキャンバスElementを渡してください。</p>
-                    <p>このライブラリはキャンバスサイズが1920x1080である前提で描画を行います。</p>
-                    <p>サイズ設定をミスるとコメントが正常に描画されません。</p>
+                    <p>コメント描画用のキャンバスElementを渡してください</p>
+                    <p>このライブラリはキャンバスサイズが1920x1080である前提で描画を行います</p>
+                    <p>サイズ設定をミスるとコメントが正常に描画されません</p>
                 </div>
                 <h4 id="p_data">data<span class="type">:[]</span></h4>
                 <div class="item">
-                    <p>ニコニコのコメントAPIが吐き出したデータか、独自フォーマットのコメントデータを渡してください。</p>
-                    <p>独自フォーマットのデータを渡す際は、<span class="yellow">formatted</span>を<span class="yellow">true</span>にする必要があります</p>
+                    <p>コメントデータを渡してください</p>
+                    <p>対応フォーマットは<a href="#p_format">format</a>を確認してください</p>
                 </div>
-                <h4 id="p_options">options<span class="type">:options</span></h4>
+                <h4 id="p_options">options<span class="type">:<a href="./type/modules/_types_types.html#Options">InitOptions</a></span></h4>
                 <div class="item">
-                    <h4 id="p_useLegacy">useLegacy<span class="type">:boolean</span> = <span class="yellow">false</span></h4>
+                    <h4 id="p_debug">debug<span class="type">:boolean</span> = <span class="yellow">false</span></h4>
                     <div class="item">
-                        <p>公式プレイヤー互換モードを有効にするか指定します</p>
-                        <p>デフォルト(<span class="yellow">false</span>)の場合はsans-serifを使用します。</p>
-                        <p>この場合、windows環境において、macOSに近い表示になります。</p>
-                        <p><span class="yellow">true</span>の場合は公式プレイヤーと同じフォントを使用します。</p>
-                    </div>
-                    <h4 id="p_formatted">formatted<span class="type">:boolean</span> = <span class="yellow">false</span></h4>
-                    <div class="item">
-                        <p>コメントデータが独自フォーマットかを指定します。</p>
-                        <p>デフォルト(<span class="yellow">false</span>)の場合は独自フォーマットに変換を行ってから処理を行います。</p>
-                        <p><span class="yellow">true</span>の場合はそのまま処理を行います。</p>
-                    </div>
-                    <h4 id="p_video">video<span class="type">:HTMLVideoElement | null</span> = <span class="yellow">null</span></h4>
-                    <div class="item">
-                        <p><span class="important">niconicomments 0.2.12以前をご利用の方へ</span></p>
-                        <p><span class="important">この機能を使用して動画を表示すると特許侵害になる可能性があります</span></p>
-                        <p><span class="important">描画される動画を16:9に変換するなど各自で対応をお願いします</span></p>
-                        <p><span class="important">0.2.13以降は描画方法を変更しているため問題ありません</span></p>
-                        <p>背景に描画する動画を指定します</p>
-                        <p>デフォルト(<span class="yellow">null</span>)の場合は描画を行いません</p>
-                        <p>指定されている場合は、背景に指定された動画を描画し、その上にコメントを描画します</p>
-                        <p>この機能を応用すると、Picture in Pictureにもコメントを表示できるようになります</p>
-                    </div>
-                    <h4 id="p_showCollision">showCollision<span class="type">:boolean</span> = <span class="yellow">false</span></h4>
-                    <div class="item">
-                        <p>コメントの当たり判定を描画するか指定します</p>
-                        <p>デフォルト(<span class="yellow">false</span>)の場合は描画を行いません</p>
-                        <p><span class="yellow">true</span>の場合は、コメントの当たり判定と行の区切りを描画します。</p>
-                        <p>初期化後に設定の変更を行う場合は描画済みコメントの削除が必要になります</p>
-                    </div>
-                    <h4 id="p_showFPS">showFPS<span class="type">:boolean</span> = <span class="yellow">false</span></h4>
-                    <div class="item">
-                        <p>FPSを画面上に描画するか指定します</p>
-                        <p>デフォルト(<span class="yellow">false</span>)の場合は描画を行いません</p>
-                        <p><span class="yellow">true</span>の場合は、過去0.5秒間のデータをもとにFPSを計算し、描画します。</p>
-                        <p>初期化後も随時設定の変更が可能です</p>
-                    </div>
-                    <h4 id="p_showCommentCount">showCommentCount<span class="type">:boolean</span> = <span class="yellow">false</span></h4>
-                    <div class="item">
-                        <p>描画されているコメント数を画面上に描画するか指定します</p>
-                        <p>デフォルト(<span class="yellow">false</span>)の場合は描画を行いません</p>
-                        <p><span class="yellow">true</span>の場合は、画面内に描画されているコメントの総数を描画します。</p>
-                        <p>初期化後も随時設定の変更が可能です</p>
+                        <p>処理の所要時間をブラウザコンソールに出力します</p>
+                        <p>デフォルト(<span class="yellow">false</span>)の場合は出力を行いません</p>
                     </div>
                     <h4 id="p_drawAllImageOnLoad">drawAllImageOnLoad<span class="type">:boolean</span> = <span class="yellow">false</span></h4>
                     <div class="item">
                         <p>コメントの描画をどのタイミングで行うかを指定します</p>
                         <p>デフォルト(<span class="yellow">false</span>)の場合は初めてコメントが画面に描画されるタイミングで生成されます</p>
-                        <p><span class="yellow">true</span>の場合は、初期化時にすべてのコメントを生成します。</p>
+                        <p><span class="yellow">true</span>の場合は、初期化時にすべてのコメントを生成します</p>
                     </div>
-                </div>
-            </div>
-            <h3 id="Attributes">Attributes</h3>
-            <div class="item">
-                <h4 id="a_showFPS">showFPS<span class="type">:boolean</span> = <span class="yellow">false</span></h4>
-                <div class="item">
-                    <p>FPSを画面上に描画するか指定します</p>
-                    <p>デフォルト(<span class="yellow">false</span>)の場合は描画を行いません</p>
-                    <p><span class="yellow">true</span>の場合は、過去0.5秒間のデータをもとにFPSを計算し、描画します。</p>
-                    <p>初期化後も随時設定の変更が可能です</p>
-                </div>
-                <h4 id="a_showCommentCount">showCommentCount<span class="type">:boolean</span> = <span class="yellow">false</span></h4>
-                <div class="item">
-                    <p>描画されているコメント数を画面上に描画するか指定します</p>
-                    <p>デフォルト(<span class="yellow">false</span>)の場合は描画を行いません</p>
-                    <p><span class="yellow">true</span>の場合は、画面内に描画されているコメントの総数を描画します。</p>
-                    <p>初期化後も随時設定の変更が可能です</p>
+                    <h4 id="p_enableLegacyPiP">enableLegacyPiP<span class="type">:boolean</span> = <span class="yellow">false</span></h4>
+                    <div class="item">
+                        <p><span class="note">初期化後も随時設定の変更が可能です</span></p>
+                        <p>PiPの出力形式を変更します</p>
+                        <p>デフォルト(<span class="yellow">false</span>)の場合は画面全体を覆うように動画を描画します</p>
+                        <p><span class="yellow">true</span>の場合は画面内に全体が収まるように動画を描画します</p>
+                    </div>
+                    <h4 id="p_format">format<span class="type">:<a href="./type/modules/_types_types.html#inputFormatType">inputFormatType</a></span> = <span class="green">"legacy"</span></h4>
+                    <div class="item">
+                        <p>入力フォーマットを指定します</p>
+                        <p>対応しているフォーマットは以下のとおりです</p>
+                        <table>
+                            <thead>
+                            <tr>
+                                <th>名前</th>
+                                <th>dataのtype</th>
+                                <th>備考</th>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr>
+                                <td>niconicome</td>
+                                <td class="type">XMLDocument</td>
+                                <td>XMLをDOMParserでparseFromStringしたものを渡してください</td>
+                            </tr>
+                            <tr>
+                                <td>formatted</td>
+                                <td class="type"><a href="./type/modules/_types_types.html#formattedComment">formattedComment</a>[] |
+                                    <a href="./type/modules/_types_types.html#formattedLegacyComment">formattedLegacyComment</a>[]</td>
+                                <td>user_idとlayerが含まれない場合はformattedLegacyCommentになります</td>
+                            </tr>
+                            <tr>
+                                <td>legacy</td>
+                                <td class="type"><a href="./type/modules/_types_types.html#rawApiResponse">rawApiResponse</a>[]</td>
+                                <td>legacy apiのレスポンスをそのまま渡してください</td>
+                            </tr>
+                            <tr>
+                                <td>owner</td>
+                                <td class="type"><a href="./type/modules/_types_types.html#ownerComment">ownerComment</a>[]</td>
+                                <td>投稿者コメント編集画面のエディータのjsonをそのまま渡してください</td>
+                            </tr>
+                            <tr>
+                                <td>v1</td>
+                                <td class="type"><a href="./type/modules/_types_types.html#v1Thread">v1Thread</a>[]</td>
+                                <td>v1 apiのdata以下threadsの内容を渡してください</td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <h4 id="p_formatted">formatted<span class="type">:boolean</span> = <span class="yellow">false</span></h4>
+                    <div class="item deprecated">
+                        <p><span class="warn">このオプションは非推奨です。<a href="#p_format">format</a>オプションを使用してください</span></p>
+                        <p>コメントデータが独自フォーマットかを指定します</p>
+                        <p>デフォルト(<span class="yellow">false</span>)の場合は独自フォーマットに変換を行ってから処理を行います</p>
+                        <p><span class="yellow">true</span>の場合はそのまま処理を行います</p>
+                    </div>
+                    <h4 id="p_keepCA">keepCA<span class="type">:boolean</span> = <span class="yellow">false</span></h4>
+                    <div class="item">
+                        <p>別のCAや関係ないコメントによってCA(主に積み絵)が崩壊するのを抑制します</p>
+                        <p>デフォルト(<span class="yellow">false</span>)の場合は通常通り位置決定を行います</p>
+                        <p><span class="yellow">true</span>の場合はCAを投稿していると推定されるユーザーのレイヤーを分けて位置決定をおこないます</p>
+                    </div>
+                    <h4 id="p_showCollision">showCollision<span class="type">:boolean</span> = <span class="yellow">false</span></h4>
+                    <div class="item">
+                        <p><span class="note">初期化後も随時設定の変更が可能です</span></p>
+                        <p>コメントの当たり判定を描画するか指定します</p>
+                        <p>デフォルト(<span class="yellow">false</span>)の場合は描画を行いません</p>
+                        <p><span class="yellow">true</span>の場合は、コメントの当たり判定と行の区切りを描画します</p>
+                    </div>
+                    <h4 id="p_showCommentCount">showCommentCount<span class="type">:boolean</span> = <span class="yellow">false</span></h4>
+                    <div class="item">
+                        <p><span class="note">初期化後も随時設定の変更が可能です</span></p>
+                        <p>描画されているコメント数を画面上に描画するか指定します</p>
+                        <p>デフォルト(<span class="yellow">false</span>)の場合は描画を行いません</p>
+                        <p><span class="yellow">true</span>の場合は、画面内に描画されているコメントの総数を描画します</p>
+                    </div>
+                    <h4 id="p_showFPS">showFPS<span class="type">:boolean</span> = <span class="yellow">false</span></h4>
+                    <div class="item">
+                        <p><span class="note">初期化後も随時設定の変更が可能です</span></p>
+                        <p>FPSを画面上に描画するか指定します</p>
+                        <p>デフォルト(<span class="yellow">false</span>)の場合は描画を行いません</p>
+                        <p><span class="yellow">true</span>の場合は、過去0.5秒間のデータをもとにFPSを計算し、描画します</p>
+                    </div>
+                    <h4 id="p_useLegacy">useLegacy<span class="type">:boolean</span> = <span class="yellow">false</span></h4>
+                    <div class="item">
+                        <p>公式プレイヤー互換モードを有効にするか指定します</p>
+                        <p>デフォルト(<span class="yellow">false</span>)の場合はsans-serifを使用します</p>
+                        <p>この場合、windows環境において、macOSに近い表示になります</p>
+                        <p><span class="yellow">true</span>の場合は公式プレイヤーと同じフォントを使用します</p>
+                    </div>
+                    <h4 id="p_video">video<span class="type">:HTMLVideoElement | null</span> = <span class="yellow">null</span></h4>
+                    <div class="item">
+                        <p><span class="note">初期化後も随時設定の変更が可能です</span></p>
+                        <p>背景に描画する動画を指定します</p>
+                        <p>デフォルト(<span class="yellow">null</span>)の場合は描画を行いません</p>
+                        <p>指定されている場合は、背景に指定された動画を描画し、その上にコメントを描画します</p>
+                        <p>この機能を応用すると、Picture in Pictureにもコメントを表示できるようになります</p>
+                    </div>
                 </div>
             </div>
             <h3 id="Methods">Methods</h3>
             <div class="item">
                 <h4 id="m_drawCanvas">drawCanvas(vpos<span class="type">:number</span>)<span class="type">:void</span></h4>
                 <div class="item">
-                    <p>vpos(動画のcurrentTime*100)を元にキャンバスにコメントを描画します。</p>
-                    <p>vposは<span class="yellow">整数(int)</span>である必要があります。</p>
+                    <p>vpos(動画のcurrentTime*100)を元にキャンバスにコメントを描画します</p>
+                    <p>vposは<span class="yellow">整数(int)</span>である必要があります</p>
                 </div>
                 <h4 id="m_clear">clear()<span class="type">:void</span></h4>
                 <div class="item">

--- a/docs/style.css
+++ b/docs/style.css
@@ -67,6 +67,9 @@ ul {
     padding: 10px 0;
     margin-left: 10px
 }
+.item.deprecated{
+    color: #999;
+}
 
 span.red {
     color: #f07178
@@ -104,4 +107,60 @@ span.type {
 span.important{
     color: red;
     font-size: 1.5em;
+}
+span.warn::before{
+    content:"⚠";
+    width: 20px;
+    height: 20px;
+    text-align: center;
+    display: inline-block;
+    margin-right: 5px;
+}
+.warn{
+    color: #880000;
+    background: #ffcccc;
+    padding: 5px;
+    border: solid 1px #FF0000;
+    margin: 5px 0;
+    display: inline-block;
+}
+.warn a{
+    color: unset;
+}
+span.note::before{
+    content:"i";
+    width: 20px;
+    height: 20px;
+    text-align: center;
+    background: #9CDCFE;
+    color: #0000ff;
+    border: solid #0000FF 1px;
+    border-radius: 50%;
+    display: inline-block;
+    margin-right: 5px;
+}
+.note{
+    color: black;
+    background: #cccccc;
+    padding: 5px;
+    border: solid 1px #666666;
+    margin: 5px 0;
+    display: inline-block;
+}
+table{
+    border-collapse:  collapse;
+}
+table .type{
+    color: #ccc;
+    font-size: .75em;
+    line-height: inherit;
+    padding: 0 2px;
+    text-align: center;
+}
+.type a{
+    color: unset;
+}
+td,th{
+    border: solid 1px white;
+    padding: 2px 5px;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,24 @@
 {
   "name": "@xpadev-net/niconicomments",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@xpadev-net/niconicomments",
-      "version": "0.2.20",
+      "version": "0.2.21",
       "license": "MIT",
       "devDependencies": {
         "@babel/preset-env": "^7.18.2",
         "@rollup/plugin-babel": "^5.3.0",
-        "@rollup/plugin-typescript": "^8.3.2",
-        "rollup": "^2.75.6",
-        "typedoc": "^0.22.17",
+        "@rollup/plugin-node-resolve": "^13.3.0",
+        "@rollup/plugin-typescript": "^8.3.3",
+        "copyfiles": "^2.4.1",
+        "rollup": "^2.75.7",
+        "rollup-plugin-dts": "^4.2.2",
+        "typedoc": "^0.22.18",
         "typedoc-plugin-missing-exports": "^0.22.6",
-        "typescript": "^4.7.3"
+        "typescript": "^4.7.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1662,10 +1665,30 @@
         }
       }
     },
+    "node_modules/@rollup/plugin-node-resolve": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.3.0.tgz",
+      "integrity": "sha512-Lus8rbUo1eEcnS4yTFKLZrVumLPY+YayBdWXgFSHYhTT2iJbMhoaaBL3xl5NCdeRytErGr8tZ0L71BMRmnlwSw==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^3.1.0",
+        "@types/resolve": "1.17.1",
+        "deepmerge": "^4.2.2",
+        "is-builtin-module": "^3.1.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.42.0"
+      }
+    },
     "node_modules/@rollup/plugin-typescript": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.3.2.tgz",
-      "integrity": "sha512-MtgyR5LNHZr3GyN0tM7gNO9D0CS+Y+vflS4v/PHmrX17JCkHUYKvQ5jN5o3cz1YKllM3duXUqu3yOHwMPUxhDg==",
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.3.3.tgz",
+      "integrity": "sha512-55L9SyiYu3r/JtqdjhwcwaECXP7JeJ9h1Sg1VWRJKIutla2MdZQodTgcCNybXLMCnqpNLEhS2vGENww98L1npg==",
       "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^3.1.0",
@@ -1678,6 +1701,11 @@
         "rollup": "^2.14.0",
         "tslib": "*",
         "typescript": ">=3.7.0"
+      },
+      "peerDependenciesMeta": {
+        "tslib": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -1702,6 +1730,30 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
+      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==",
+      "dev": true
+    },
+    "node_modules/@types/resolve": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+      "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/ansi-styles": {
       "version": "3.2.1",
@@ -1807,6 +1859,18 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -1850,6 +1914,17 @@
         "node": ">=4"
       }
     },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -1865,6 +1940,12 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
     "node_modules/convert-source-map": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -1873,6 +1954,67 @@
       "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/copyfiles": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.1.tgz",
+      "integrity": "sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.0.5",
+        "minimatch": "^3.0.3",
+        "mkdirp": "^1.0.4",
+        "noms": "0.0.0",
+        "through2": "^2.0.1",
+        "untildify": "^4.0.0",
+        "yargs": "^16.1.0"
+      },
+      "bin": {
+        "copyfiles": "copyfiles",
+        "copyup": "copyfiles"
+      }
+    },
+    "node_modules/copyfiles/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/copyfiles/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/copyfiles/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/core-js-compat": {
@@ -1898,6 +2040,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -1913,6 +2061,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/define-properties": {
@@ -1935,6 +2092,12 @@
       "version": "1.4.148",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.148.tgz",
       "integrity": "sha512-8MJk1bcQUAYkuvCyWZxaldiwoDG0E0AMzBGA6cv3WfuvJySiPgfidEPBFCRRH3cZm6SVZwo/oRlK1ehi1QNEIQ==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
     "node_modules/escalade": {
@@ -2004,6 +2167,15 @@
       "peer": true,
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -2109,6 +2281,18 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "node_modules/is-builtin-module": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.1.0.tgz",
+      "integrity": "sha512-OV7JjAgOTfAFJmHZLvpSTb4qi0nIILDV1gWPYDnDJUTNFM5aGlRAhk4QcT8i7TuAleeEV5Fdkqn3t4mS+Q11fg==",
+      "dev": true,
+      "dependencies": {
+        "builtin-modules": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
@@ -2120,6 +2304,27 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "dev": true
+    },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2170,6 +2375,18 @@
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
       "dev": true
     },
+    "node_modules/magic-string": {
+      "version": "0.26.2",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.2.tgz",
+      "integrity": "sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/marked": {
       "version": "4.0.16",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.16.tgz",
@@ -2194,6 +2411,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -2205,6 +2434,16 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.5.tgz",
       "integrity": "sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q==",
       "dev": true
+    },
+    "node_modules/noms": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
+      "integrity": "sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "~1.0.31"
+      }
     },
     "node_modules/object-keys": {
       "version": "1.1.1",
@@ -2242,6 +2481,15 @@
         "wrappy": "1"
       }
     },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -2264,6 +2512,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
       }
     },
     "node_modules/regenerate": {
@@ -2343,6 +2609,15 @@
         "jsesc": "bin/jsesc"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
@@ -2361,9 +2636,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.75.6",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.75.6.tgz",
-      "integrity": "sha512-OEf0TgpC9vU6WGROJIk1JA3LR5vk/yvqlzxqdrE2CzzXnqKXNzbAwlWUXis8RS3ZPe7LAq+YUxsRa0l3r27MLA==",
+      "version": "2.75.7",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.75.7.tgz",
+      "integrity": "sha512-VSE1iy0eaAYNCxEXaleThdFXqZJ42qDBatAwrfnPlENEZ8erQ+0LYX4JXOLPceWfZpV1VtZwZ3dFCuOZiSyFtQ==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -2375,12 +2650,33 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rollup-plugin-dts": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-4.2.2.tgz",
+      "integrity": "sha512-A3g6Rogyko/PXeKoUlkjxkP++8UDVpgA7C+Tdl77Xj4fgEaIjPSnxRmR53EzvoYy97VMVwLAOcWJudaVAuxneQ==",
+      "dev": true,
+      "dependencies": {
+        "magic-string": "^0.26.1"
+      },
+      "engines": {
+        "node": ">=v12.22.11"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Swatinem"
+      },
+      "optionalDependencies": {
+        "@babel/code-frame": "^7.16.7"
+      },
+      "peerDependencies": {
+        "rollup": "^2.55",
+        "typescript": "^4.1"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/semver": {
       "version": "6.3.0",
@@ -2400,6 +2696,44 @@
         "jsonc-parser": "^3.0.0",
         "vscode-oniguruma": "^1.6.1",
         "vscode-textmate": "5.2.0"
+      }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
+    },
+    "node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/supports-color": {
@@ -2426,6 +2760,46 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true
+    },
+    "node_modules/through2/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/through2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -2440,12 +2814,13 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
       "dev": true,
+      "optional": true,
       "peer": true
     },
     "node_modules/typedoc": {
-      "version": "0.22.17",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.17.tgz",
-      "integrity": "sha512-h6+uXHVVCPDaANzjwzdsj9aePBjZiBTpiMpBBeyh1zcN2odVsDCNajz8zyKnixF93HJeGpl34j/70yoEE5BfNg==",
+      "version": "0.22.18",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz",
+      "integrity": "sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==",
       "dev": true,
       "dependencies": {
         "glob": "^8.0.3",
@@ -2474,9 +2849,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
-      "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -2526,6 +2901,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
+    },
     "node_modules/vscode-oniguruma": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
@@ -2538,11 +2928,106 @@
       "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
       "dev": true
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
     }
   },
   "dependencies": {
@@ -3687,10 +4172,24 @@
         "@rollup/pluginutils": "^3.1.0"
       }
     },
+    "@rollup/plugin-node-resolve": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.3.0.tgz",
+      "integrity": "sha512-Lus8rbUo1eEcnS4yTFKLZrVumLPY+YayBdWXgFSHYhTT2iJbMhoaaBL3xl5NCdeRytErGr8tZ0L71BMRmnlwSw==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "@types/resolve": "1.17.1",
+        "deepmerge": "^4.2.2",
+        "is-builtin-module": "^3.1.0",
+        "is-module": "^1.0.0",
+        "resolve": "^1.19.0"
+      }
+    },
     "@rollup/plugin-typescript": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.3.2.tgz",
-      "integrity": "sha512-MtgyR5LNHZr3GyN0tM7gNO9D0CS+Y+vflS4v/PHmrX17JCkHUYKvQ5jN5o3cz1YKllM3duXUqu3yOHwMPUxhDg==",
+      "version": "8.3.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-8.3.3.tgz",
+      "integrity": "sha512-55L9SyiYu3r/JtqdjhwcwaECXP7JeJ9h1Sg1VWRJKIutla2MdZQodTgcCNybXLMCnqpNLEhS2vGENww98L1npg==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.1.0",
@@ -3712,6 +4211,27 @@
       "version": "0.0.39",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.0.tgz",
+      "integrity": "sha512-cHlGmko4gWLVI27cGJntjs/Sj8th9aYwplmZFwmmgYQQvL5NUsgVJG7OddLvNfLqYS31KFN0s3qlaD9qCaxACA==",
+      "dev": true
+    },
+    "@types/resolve": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+      "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true
     },
     "ansi-styles": {
@@ -3790,6 +4310,12 @@
         "picocolors": "^1.0.0"
       }
     },
+    "builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true
+    },
     "call-bind": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
@@ -3817,6 +4343,17 @@
         "supports-color": "^5.3.0"
       }
     },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
     "color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -3832,6 +4369,12 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
     "convert-source-map": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -3840,6 +4383,56 @@
       "peer": true,
       "requires": {
         "safe-buffer": "~5.1.1"
+      }
+    },
+    "copyfiles": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/copyfiles/-/copyfiles-2.4.1.tgz",
+      "integrity": "sha512-fereAvAvxDrQDOXybk3Qu3dPbOoKoysFMWtkY3mv5BsL8//OSZVL5DCLYqgRfY5cWirgRzlC+WSrxp6Bo3eNZg==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.5",
+        "minimatch": "^3.0.3",
+        "mkdirp": "^1.0.4",
+        "noms": "0.0.0",
+        "through2": "^2.0.1",
+        "untildify": "^4.0.0",
+        "yargs": "^16.1.0"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "1.1.11",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "glob": {
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+          "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.1.1",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
       }
     },
     "core-js-compat": {
@@ -3860,6 +4453,12 @@
         }
       }
     },
+    "core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
+    },
     "debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -3868,6 +4467,12 @@
       "requires": {
         "ms": "2.1.2"
       }
+    },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "dev": true
     },
     "define-properties": {
       "version": "1.1.4",
@@ -3883,6 +4488,12 @@
       "version": "1.4.148",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.148.tgz",
       "integrity": "sha512-8MJk1bcQUAYkuvCyWZxaldiwoDG0E0AMzBGA6cv3WfuvJySiPgfidEPBFCRRH3cZm6SVZwo/oRlK1ehi1QNEIQ==",
+      "dev": true
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
     "escalade": {
@@ -3934,6 +4545,12 @@
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
       "peer": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
     },
     "get-intrinsic": {
       "version": "1.1.1",
@@ -4011,6 +4628,15 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "is-builtin-module": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.1.0.tgz",
+      "integrity": "sha512-OV7JjAgOTfAFJmHZLvpSTb4qi0nIILDV1gWPYDnDJUTNFM5aGlRAhk4QcT8i7TuAleeEV5Fdkqn3t4mS+Q11fg==",
+      "dev": true,
+      "requires": {
+        "builtin-modules": "^3.0.0"
+      }
+    },
     "is-core-module": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
@@ -4019,6 +4645,24 @@
       "requires": {
         "has": "^1.0.3"
       }
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true
+    },
+    "is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -4057,6 +4701,15 @@
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
       "dev": true
     },
+    "magic-string": {
+      "version": "0.26.2",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.26.2.tgz",
+      "integrity": "sha512-NzzlXpclt5zAbmo6h6jNc8zl2gNRGHvmsZW4IvZhTC4W7k4OlLP+S5YLussa/r3ixNT66KOQfNORlXHSOy/X4A==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
     "marked": {
       "version": "4.0.16",
       "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.16.tgz",
@@ -4072,6 +4725,12 @@
         "brace-expansion": "^2.0.1"
       }
     },
+    "mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -4083,6 +4742,16 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.5.tgz",
       "integrity": "sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q==",
       "dev": true
+    },
+    "noms": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/noms/-/noms-0.0.0.tgz",
+      "integrity": "sha512-lNDU9VJaOPxUmXcLb+HQFeUgQQPtMI24Gt6hgfuMHRJgMRHMF/qZ4HJD3GDru4sSw9IQl2jPjAYnQrdIeLbwow==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "~1.0.31"
+      }
     },
     "object-keys": {
       "version": "1.1.1",
@@ -4111,6 +4780,12 @@
         "wrappy": "1"
       }
     },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true
+    },
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -4128,6 +4803,24 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
     },
     "regenerate": {
       "version": "1.4.2",
@@ -4196,6 +4889,12 @@
         }
       }
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true
+    },
     "resolve": {
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
@@ -4208,20 +4907,29 @@
       }
     },
     "rollup": {
-      "version": "2.75.6",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.75.6.tgz",
-      "integrity": "sha512-OEf0TgpC9vU6WGROJIk1JA3LR5vk/yvqlzxqdrE2CzzXnqKXNzbAwlWUXis8RS3ZPe7LAq+YUxsRa0l3r27MLA==",
+      "version": "2.75.7",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.75.7.tgz",
+      "integrity": "sha512-VSE1iy0eaAYNCxEXaleThdFXqZJ42qDBatAwrfnPlENEZ8erQ+0LYX4JXOLPceWfZpV1VtZwZ3dFCuOZiSyFtQ==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "rollup-plugin-dts": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-4.2.2.tgz",
+      "integrity": "sha512-A3g6Rogyko/PXeKoUlkjxkP++8UDVpgA7C+Tdl77Xj4fgEaIjPSnxRmR53EzvoYy97VMVwLAOcWJudaVAuxneQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.16.7",
+        "magic-string": "^0.26.1"
       }
     },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "semver": {
       "version": "6.3.0",
@@ -4240,6 +4948,38 @@
         "vscode-textmate": "5.2.0"
       }
     },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "dev": true
+    },
+    "string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -4255,6 +4995,48 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
     },
+    "through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -4266,12 +5048,13 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
       "dev": true,
+      "optional": true,
       "peer": true
     },
     "typedoc": {
-      "version": "0.22.17",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.17.tgz",
-      "integrity": "sha512-h6+uXHVVCPDaANzjwzdsj9aePBjZiBTpiMpBBeyh1zcN2odVsDCNajz8zyKnixF93HJeGpl34j/70yoEE5BfNg==",
+      "version": "0.22.18",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.18.tgz",
+      "integrity": "sha512-NK9RlLhRUGMvc6Rw5USEYgT4DVAUFk7IF7Q6MYfpJ88KnTZP7EneEa4RcP+tX1auAcz7QT1Iy0bUSZBYYHdoyA==",
       "dev": true,
       "requires": {
         "glob": "^8.0.3",
@@ -4289,9 +5072,9 @@
       "requires": {}
     },
     "typescript": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.3.tgz",
-      "integrity": "sha512-WOkT3XYvrpXx4vMMqlD+8R8R37fZkjyLGlxavMc4iB8lrl8L0DeTcHbYgw/v0N/z9wAFsgBhcsF0ruoySS22mA==",
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
@@ -4322,6 +5105,18 @@
       "integrity": "sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==",
       "dev": true
     },
+    "untildify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+      "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
+    },
     "vscode-oniguruma": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.2.tgz",
@@ -4334,10 +5129,80 @@
       "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
       "dev": true
     },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        }
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
+    },
+    "y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "requires": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      }
+    },
+    "yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "name": "@xpadev-net/niconicomments",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "description": "NiconiComments is a comment drawing library that is somewhat compatible with the official Nico Nico Douga player.",
   "main": "dist/bundle.js",
-  "types": "dist/dts/main.d.ts",
+  "types": "dist/dts/types.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "rollup -c rollup.config.js",
     "watch": "rollup -c rollup.config.js -w",
-    "typedoc": "typedoc --options tsdoc.json --out ./docs/type/ ./src/main.ts",
-    "tsc": "tsc --emitDeclarationOnly",
-    "prepublishOnly": "npm run tsc&&npm run build"
+    "typedoc": "typedoc --entryPointStrategy Expand --options tsdoc.json --out ./docs/type/ ./src/",
+    "copy-dts": "npx copyfiles -u 2 src/@types/*.d.ts dist/dts",
+    "prepublishOnly": "npm run copy-dts&&npm run build"
   },
   "repository": {
     "type": "git",
@@ -25,18 +25,20 @@
   },
   "files": [
     "dist/bundle.js",
-    "dist/dts/main.d.ts",
-    "dist/dts/main.d.ts.map"
+    "dist/dts/types.d.ts"
   ],
   "homepage": "https://xpadev.net/niconicomments/docs/",
   "license": "MIT",
   "devDependencies": {
     "@babel/preset-env": "^7.18.2",
     "@rollup/plugin-babel": "^5.3.0",
-    "@rollup/plugin-typescript": "^8.3.2",
-    "rollup": "^2.75.6",
-    "typedoc": "^0.22.17",
+    "@rollup/plugin-node-resolve": "^13.3.0",
+    "@rollup/plugin-typescript": "^8.3.3",
+    "copyfiles": "^2.4.1",
+    "rollup": "^2.75.7",
+    "rollup-plugin-dts": "^4.2.2",
+    "typedoc": "^0.22.18",
     "typedoc-plugin-missing-exports": "^0.22.6",
-    "typescript": "^4.7.3"
+    "typescript": "^4.7.4"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,5 +1,6 @@
 import babel from "@rollup/plugin-babel";
 import typescript from "@rollup/plugin-typescript";
+import { nodeResolve } from '@rollup/plugin-node-resolve';
 import pkg from "./package.json";
 import * as path from "path";
 const banner = `/*!
@@ -22,5 +23,6 @@ export default {
             babelHelpers: "bundled",
             configFile: path.resolve(__dirname, ".babelrc.js"),
         }),
+        nodeResolve(),
     ]
 }

--- a/src/@types/types.d.ts
+++ b/src/@types/types.d.ts
@@ -70,6 +70,16 @@ type formattedComment = {
     "user_id": number,
     "layer": number,
 }
+type formattedLegacyComment = {
+    "id": number,
+    "vpos": number,
+    "content": string,
+    "date": number,
+    "date_usec": number,
+    "owner": boolean,
+    "premium": boolean,
+    "mail": string[],
+}
 type formattedCommentWithFont = formattedComment & {
     "loc": string,
     "size": string,
@@ -118,7 +128,7 @@ type v1Thread = {
     "id": string,
     "fork": string,
     "commentCount": number,
-    "comments": v1Comment[]
+    "comments": { [key: string]:v1Comment }
 }
 type v1Comment = {
     "id": string,

--- a/src/@types/types.d.ts
+++ b/src/@types/types.d.ts
@@ -1,0 +1,156 @@
+
+type InitOptions = {
+    useLegacy?: boolean,
+    formatted?: boolean,
+    video?: HTMLVideoElement | null
+    showCollision?: boolean,
+    showFPS?: boolean,
+    showCommentCount?: boolean,
+    drawAllImageOnLoad?: boolean,
+    debug?: boolean,
+    enableLegacyPiP?: boolean,
+    keepCA?: boolean
+}
+type Options = {
+    useLegacy: boolean,
+    formatted: boolean,
+    video: HTMLVideoElement | null,
+    showCollision: boolean,
+    showFPS: boolean,
+    showCommentCount: boolean,
+    drawAllImageOnLoad: boolean,
+    debug: boolean,
+    enableLegacyPiP: boolean,
+    keepCA: boolean
+}
+type rawApiResponse = {
+    [key: string]: apiPing | apiThread | apiLeaf | apiGlobalNumRes | apiChat
+}
+type apiPing = {
+    "content": string
+}
+type apiThread = {
+    "resultcode": number,
+    "thread": string,
+    "server_time": number,
+    "ticket": string,
+    "revision": number
+}
+type apiLeaf = {
+    "thread": string,
+    "count": number
+}
+type apiGlobalNumRes = {
+    "thread": string,
+    "num_res": number
+}
+type apiChat = {
+    "thread": string,
+    "no": number,
+    "vpos": number,
+    "date": number,
+    "date_usec": number,
+    "nicoru": number,
+    "premium": number,
+    "anonymity": number,
+    "user_id": string,
+    "mail": string,
+    "content": string,
+    "deleted": number
+}
+type formattedComment = {
+    "id": number,
+    "vpos": number,
+    "content": string,
+    "date": number,
+    "date_usec": number,
+    "owner": boolean,
+    "premium": boolean,
+    "mail": string[],
+    "user_id": number,
+    "layer": number,
+}
+type formattedCommentWithFont = formattedComment & {
+    "loc": string,
+    "size": string,
+    "fontSize": number,
+    "font": string,
+    "color": string,
+    "full": boolean,
+    "ender": boolean,
+    "_live": boolean,
+    "long": number,
+    "invisible": boolean
+}
+type formattedCommentWithSize = formattedCommentWithFont & {
+    "height": number,
+    "width": number,
+    "width_max": number,
+    "width_min": number,
+    "lineHeight": number
+}
+type parsedComment = formattedCommentWithSize & {
+    posY: number,
+    image?: HTMLCanvasElement | boolean
+}
+type measureTextResult = {
+    "width": number,
+    "width_max": number,
+    "width_min": number,
+    "height": number,
+    "resized": boolean,
+    "fontSize": number,
+    "lineHeight": number
+}
+type T_fontSize = {
+    [key: string]: {
+        "default": number,
+        "resized": number
+    }
+}
+type T_doubleResizeMaxWidth = {
+    [key: string]: {
+        "legacy": number,
+        "default": number
+    }
+}
+type v1Thread = {
+    "id": string,
+    "fork": string,
+    "commentCount": number,
+    "comments": v1Comment[]
+}
+type v1Comment = {
+    "id": string,
+    "no": number,
+    "vposMs": number,
+    "body": string,
+    "commands": string[],
+    "userId": string,
+    "isPremium": boolean,
+    "score": number,
+    "postedAt": string,
+    "nicoruCount": number,
+    "nicoruId": null,
+    "source": string,
+    "isMyPost": boolean
+}
+type ownerComment = {
+    "time": string,
+    "command": string,
+    "comment": string
+}
+type niconicomeChat = {
+    "thread": number,
+    "no": number,
+    "vpos": number,
+    "date": number,
+    "date_usec": number,
+    "anonymity": number,
+    "user_id": string,
+    "mail": string,
+    "leaf": number,
+    "premium": number,
+    "score": number,
+    "content": string
+}

--- a/src/@types/types.d.ts
+++ b/src/@types/types.d.ts
@@ -1,7 +1,8 @@
-
+type inputFormatType = "niconicome"|"formatted"|"legacy"|"owner"|"v1"|"default";
 type InitOptions = {
     useLegacy?: boolean,
     formatted?: boolean,
+    format?: inputFormatType,
     video?: HTMLVideoElement | null
     showCollision?: boolean,
     showFPS?: boolean,
@@ -14,6 +15,7 @@ type InitOptions = {
 type Options = {
     useLegacy: boolean,
     formatted: boolean,
+    format: inputFormatType,
     video: HTMLVideoElement | null,
     showCollision: boolean,
     showFPS: boolean,
@@ -149,18 +151,4 @@ type ownerComment = {
     "time": string,
     "command": string,
     "comment": string
-}
-type niconicomeChat = {
-    "thread": number,
-    "no": number,
-    "vpos": number,
-    "date": number,
-    "date_usec": number,
-    "anonymity": number,
-    "user_id": string,
-    "mail": string,
-    "leaf": number,
-    "premium": number,
-    "score": number,
-    "content": string
 }

--- a/src/inputParser.ts
+++ b/src/inputParser.ts
@@ -1,0 +1,50 @@
+import typeGuard from "@/typeGuard";
+
+const convert = (data: any, type: string) => {
+    if (type.match(/^formatted|legacy|niconicome|owner|v1$/)){
+
+    }
+}
+
+const fromLegacy = () => {
+
+    let data_: formattedComment[] = [];
+    for (let i = 0; i < data.length; i++) {
+        let val = data[i];
+        if (!val) continue;
+        for (let key in val) {
+            let value = val[key];
+            if (typeGuard.legacy.apiChat(value) && value["deleted"] !== 1) {
+                let tmpParam: any = {
+                    "id": value["no"],
+                    "vpos": value["vpos"],
+                    "content": value["content"],
+                    "date": value["date"],
+                    "date_usec": value["date_usec"],
+                    "owner": !value["user_id"],
+                    "premium": value["premium"] === 1,
+                    "mail": []
+                };
+                if (value["mail"]) {
+                    tmpParam["mail"] = value["mail"].split(/[\s　]/g);
+                }
+                if (value["content"].startsWith("/") && !value["user_id"]) {
+                    tmpParam["mail"].push("invisible");
+                }
+                data_.push(tmpParam);
+            }
+        }
+    }
+    data_.sort((a, b) => {
+        if (a.vpos < b.vpos) return -1;
+        if (a.vpos > b.vpos) return 1;
+        if (a.date < b.date) return -1;
+        if (a.date > b.date) return 1;
+        if (a.date_usec < b.date_usec) return -1;
+        if (a.date_usec > b.date_usec) return 1;
+        return 0;
+    });
+    return data_;
+}
+
+export default convert;

--- a/src/inputParser.ts
+++ b/src/inputParser.ts
@@ -1,35 +1,67 @@
 import typeGuard from "@/typeGuard";
 
 const convert = (data: any, type: string) => {
-    if (type.match(/^formatted|legacy|niconicome|owner|v1$/)){
-
+    if (data instanceof DOMParser) {
+        return fromNiconicome(data);
+    } else if (typeGuard.formatted.legacyComments(data)&&type==="formatted") {
+        return fromFormatted(data);
+    } else if (typeGuard.legacy.rawApiResponses(data)&&type==="legacy") {
+        return fromLegacy(data);
+    } else if (typeGuard.owner.comments(data)&&type==="owner") {
+        return fromOwner(data);
+    } else if (typeGuard.v1.threads(data)) {
+        return fromV1(data);
+    }else{
+        throw new Error("unknown input format");
     }
 }
+const fromNiconicome = (data: DOMParser): formattedComment[] => {
 
-const fromLegacy = () => {
+}
 
-    let data_: formattedComment[] = [];
+const fromFormatted = (data: formattedComment[]|formattedLegacyComment[]):formattedComment[] => {
+    const tmpData = data as formattedComment[];
+    if (!typeGuard.formatted.comments(data)) {
+        for (let i in tmpData) {
+            tmpData[i]!.layer = -1;
+            tmpData[i]!.user_id = 0;
+        }
+    }
+    return tmpData;
+}
+
+const fromLegacy = (data: rawApiResponse[]):formattedComment[] => {
+    let data_: formattedComment[] = [], userList: string[] = [];
     for (let i = 0; i < data.length; i++) {
         let val = data[i];
         if (!val) continue;
         for (let key in val) {
             let value = val[key];
-            if (typeGuard.legacy.apiChat(value) && value["deleted"] !== 1) {
+            if (typeGuard.legacy.apiChat(value) && value.deleted !== 1) {
                 let tmpParam: any = {
-                    "id": value["no"],
-                    "vpos": value["vpos"],
-                    "content": value["content"],
-                    "date": value["date"],
-                    "date_usec": value["date_usec"],
-                    "owner": !value["user_id"],
-                    "premium": value["premium"] === 1,
-                    "mail": []
+                    "id": value.no,
+                    "vpos": value.vpos,
+                    "content": value.content,
+                    "date": value.date,
+                    "date_usec": value.date_usec,
+                    "owner": !value.user_id,
+                    "premium": value.premium === 1,
+                    "mail": [],
+                    "user_id": -1,
+                    "layer": -1
                 };
-                if (value["mail"]) {
-                    tmpParam["mail"] = value["mail"].split(/[\s　]/g);
+                if (value.mail) {
+                    tmpParam.mail = value.mail.split(/[\s　]/g);
                 }
-                if (value["content"].startsWith("/") && !value["user_id"]) {
-                    tmpParam["mail"].push("invisible");
+                if (value.content.startsWith("/") && !value.user_id) {
+                    tmpParam.mail.push("invisible");
+                }
+                let isUserExist = userList.indexOf(value.mail)
+                if (isUserExist === -1) {
+                    tmpParam.user_id = userList.length;
+                    userList.push(value.user_id);
+                } else {
+                    tmpParam.user_id = isUserExist;
                 }
                 data_.push(tmpParam);
             }
@@ -46,5 +78,104 @@ const fromLegacy = () => {
     });
     return data_;
 }
+
+const fromOwner = (data: ownerComment[]): formattedComment[] => {
+    let data_: formattedComment[] = [];
+    for (let i = 0; i < data.length; i++) {
+        let value = data[i]!;
+        let tmpParam: formattedComment = {
+            "id": i,
+            "vpos": time2vpos(value.time),
+            "content": value.comment,
+            "date": i,
+            "date_usec": 0,
+            "owner": true,
+            "premium": true,
+            "mail": [],
+            "user_id": -1,
+            "layer": -1
+        };
+        if (value.command) {
+            tmpParam.mail = value.command.split(/[\s　]/g);
+        }
+        if (tmpParam.content.startsWith("/")) {
+            tmpParam.mail.push("invisible");
+        }
+        data_.push(tmpParam);
+    }
+    data_.sort((a, b) => {
+        if (a.vpos < b.vpos) return -1;
+        if (a.vpos > b.vpos) return 1;
+        if (a.date < b.date) return -1;
+        if (a.date > b.date) return 1;
+        if (a.date_usec < b.date_usec) return -1;
+        if (a.date_usec > b.date_usec) return 1;
+        return 0;
+    });
+    return data_;
+}
+
+const fromV1 = (data: v1Thread[]): formattedComment[] => {
+    let data_: formattedComment[] = [], userList: string[] = [];
+    for (let i = 0; i < data.length; i++) {
+        const val = data[i]!.comments,forkName = data[i]!.fork;
+        for (let key in val) {
+            let value: v1Comment = val[key]!;
+            let tmpParam: formattedComment = {
+                "id": value.no,
+                "vpos": Math.floor(value.vposMs*10),
+                "content": value.body,
+                "date": date2time(value.postedAt),
+                "date_usec": 0,
+                "owner": forkName==="owner",
+                "premium": value.isPremium,
+                "mail": value.commands,
+                "user_id": -1,
+                "layer": -1
+            };
+            if (tmpParam.content.startsWith("/") && tmpParam.owner) {
+                tmpParam.mail.push("invisible");
+            }
+            let isUserExist = userList.indexOf(value.userId)
+            if (isUserExist === -1) {
+                tmpParam.user_id = userList.length;
+                userList.push(value.userId);
+            } else {
+                tmpParam.user_id = isUserExist;
+            }
+            data_.push(tmpParam);
+        }
+    }
+    data_.sort((a, b) => {
+        if (a.vpos < b.vpos) return -1;
+        if (a.vpos > b.vpos) return 1;
+        if (a.date < b.date) return -1;
+        if (a.date > b.date) return 1;
+        if (a.date_usec < b.date_usec) return -1;
+        if (a.date_usec > b.date_usec) return 1;
+        return 0;
+    });
+    return data_;
+
+}
+
+const time2vpos = (time_str: string): number => {
+    const time = time_str.match(/^(\d+):(\d+)\.(\d+)|(\d+):(\d+)|(\d+)\.(\d+)|(\d+)$/);
+    if (time){
+        if (time[1]){
+            return (Number(time[1])*60+Number(time[2]))*100+Number(time[3]);
+        }else if(time[4]){
+            return (Number(time[4])*60+Number(time[5]))*100;
+        }else if(time[6]){
+            return Number(time[6])*100+Number(time[7]);
+        }else if(time[8]){
+            return Number(time[8])*100;
+        }
+    }
+    return 0;
+}
+
+const date2time = (date: string): number =>
+    Math.floor(new Date(date).getTime()/1000);
 
 export default convert;

--- a/src/inputParser.ts
+++ b/src/inputParser.ts
@@ -1,36 +1,94 @@
-import typeGuard from "@/typeGuard";
+import typeGuard from "./typeGuard";
 
-const convert = (data: any, type: string) => {
-    if (data instanceof DOMParser) {
-        return fromNiconicome(data);
-    } else if (typeGuard.formatted.legacyComments(data)&&type==="formatted") {
-        return fromFormatted(data);
-    } else if (typeGuard.legacy.rawApiResponses(data)&&type==="legacy") {
-        return fromLegacy(data);
-    } else if (typeGuard.owner.comments(data)&&type==="owner") {
-        return fromOwner(data);
-    } else if (typeGuard.v1.threads(data)) {
-        return fromV1(data);
-    }else{
+/**
+ * 入力されたデータを内部用のデータに変換
+ * @param data {any} 入力データ(niconicome/formatted/legacy/owner/v1)
+ * @param type {inputFormatType} 誤検出防止のため入力フォーマットは書かせる
+ * @return {formattedComment[]} 変換後のデータを返す
+ */
+const convert2formattedComment = (data: any, type: inputFormatType): formattedComment[] => {
+    let result: formattedComment[] = [];
+    if (typeGuard.niconicome.xmlDocument(data) && type === "niconicome") {
+        result = fromNiconicome(data);
+    } else if (typeGuard.formatted.legacyComments(data) && type === "formatted") {
+        result = fromFormatted(data);
+    } else if (typeGuard.legacy.rawApiResponses(data) && type === "legacy") {
+        result = fromLegacy(data);
+    } /*else if (typeGuard.legacyOwner.comments(data) && type === "legacyOwner") {
+        result = fromLegacyOwner(data);
+    }*/ else if (typeGuard.owner.comments(data) && type === "owner") {
+        result = fromOwner(data);
+    } else if (typeGuard.v1.threads(data) && type === "v1") {
+        result = fromV1(data);
+    } else {
         throw new Error("unknown input format");
     }
-}
-const fromNiconicome = (data: DOMParser): formattedComment[] => {
-
+    return sort(result);
 }
 
-const fromFormatted = (data: formattedComment[]|formattedLegacyComment[]):formattedComment[] => {
+/**
+ * niconicomeが吐き出すコメントデータを処理する
+ * @param data {XMLDocument} 吐き出されたxmlをDOMParserでparseFromStringしたもの
+ * @return {formattedComment[]}
+ */
+const fromNiconicome = (data: XMLDocument): formattedComment[] => {
+    let data_: formattedComment[] = [], userList: string[] = [];
+    for (let item of Array.from(data.documentElement.children)) {
+        if (item.nodeName !== "chat") continue;
+        let tmpParam: formattedComment = {
+            id: Number(item.getAttribute("no")),
+            vpos: Number(item.getAttribute("vpos")),
+            content: item.innerHTML,
+            date: Number(item.getAttribute("date")),
+            date_usec: Number(item.getAttribute("date_usec")),
+            owner: !item.getAttribute("user_id"),
+            premium: item.getAttribute("premium") === "1",
+            mail: [],
+            user_id: -1,
+            layer: -1
+        };
+        if (item.getAttribute("mail")) {
+            tmpParam.mail = item.getAttribute("mail")!.split(/[\s　]/g);
+        }
+        if (tmpParam.content.startsWith("/") && tmpParam.owner) {
+            tmpParam.mail.push("invisible");
+        }
+        let isUserExist = userList.indexOf(item.getAttribute("user_id")!)
+        if (isUserExist === -1) {
+            tmpParam.user_id = userList.length;
+            userList.push(item.getAttribute("user_id")!);
+        } else {
+            tmpParam.user_id = isUserExist;
+        }
+        data_.push(tmpParam);
+    }
+    return data_
+}
+
+/**
+ * 内部処理用フォーマットを処理する
+ * 旧版だとデータにlayerとuser_idが含まれないので追加する
+ * @param data {formattedComment[] | formattedLegacyComment[]}
+ * @return {formattedComment[]}
+ */
+const fromFormatted = (data: formattedComment[] | formattedLegacyComment[]): formattedComment[] => {
     const tmpData = data as formattedComment[];
     if (!typeGuard.formatted.comments(data)) {
         for (let i in tmpData) {
             tmpData[i]!.layer = -1;
             tmpData[i]!.user_id = 0;
+            if (!tmpData[i]!.date_usec) tmpData[i]!.date_usec = 0;
         }
     }
     return tmpData;
 }
 
-const fromLegacy = (data: rawApiResponse[]):formattedComment[] => {
+/**
+ * ニコニコ公式のlegacy apiから帰ってきたデータ処理する
+ * @param data {rawApiResponse[]}
+ * @return {formattedComment[]}
+ */
+const fromLegacy = (data: rawApiResponse[]): formattedComment[] => {
     let data_: formattedComment[] = [], userList: string[] = [];
     for (let i = 0; i < data.length; i++) {
         let val = data[i];
@@ -38,17 +96,17 @@ const fromLegacy = (data: rawApiResponse[]):formattedComment[] => {
         for (let key in val) {
             let value = val[key];
             if (typeGuard.legacy.apiChat(value) && value.deleted !== 1) {
-                let tmpParam: any = {
-                    "id": value.no,
-                    "vpos": value.vpos,
-                    "content": value.content,
-                    "date": value.date,
-                    "date_usec": value.date_usec,
-                    "owner": !value.user_id,
-                    "premium": value.premium === 1,
-                    "mail": [],
-                    "user_id": -1,
-                    "layer": -1
+                let tmpParam: formattedComment = {
+                    id: value.no,
+                    vpos: value.vpos,
+                    content: value.content,
+                    date: value.date,
+                    date_usec: value.date_usec || 0,
+                    owner: !value.user_id,
+                    premium: value.premium === 1,
+                    mail: [],
+                    user_id: -1,
+                    layer: -1
                 };
                 if (value.mail) {
                     tmpParam.mail = value.mail.split(/[\s　]/g);
@@ -67,33 +125,69 @@ const fromLegacy = (data: rawApiResponse[]):formattedComment[] => {
             }
         }
     }
-    data_.sort((a, b) => {
-        if (a.vpos < b.vpos) return -1;
-        if (a.vpos > b.vpos) return 1;
-        if (a.date < b.date) return -1;
-        if (a.date > b.date) return 1;
-        if (a.date_usec < b.date_usec) return -1;
-        if (a.date_usec > b.date_usec) return 1;
-        return 0;
-    });
     return data_;
 }
 
+/**
+ * 旧プレイヤーの投稿者コメントのエディターのデータを処理する
+ * ※一番左の数値の単位がvposか秒かわからないので実装保留
+ * @param data {string}
+ * @return {formattedComment[]}
+ */
+/*const fromLegacyOwner = (data: string): formattedComment[] => {
+    let data_: formattedComment[] = [], comments = data.split("\n");
+    for (let i = 0; i < comments.length; i++) {
+        let commentData = comments[i]!.split(":");
+        if (commentData.length < 3) {
+            continue;
+        } else if (commentData.length > 3) {
+            for (let j = 3; j < commentData.length; j++) {
+                commentData[2] += ":" + commentData[j];
+            }
+        }
+        let tmpParam: formattedComment = {
+            id: i,
+            vpos: Number(commentData[0]),
+            content: commentData[2]!,
+            date: i,
+            date_usec: 0,
+            owner: true,
+            premium: true,
+            mail: [],
+            user_id: -1,
+            layer: -1
+        };
+        if (commentData[1]) {
+            tmpParam.mail = commentData[1].split(/[\s　]/g);
+        }
+        if (tmpParam.content.startsWith("/")) {
+            tmpParam.mail.push("invisible");
+        }
+        data_.push(tmpParam);
+    }
+    return data_;
+}*/
+
+/**
+ * 投稿者コメントのエディターのデータを処理する
+ * @param data {ownerComment[]}
+ * @return {formattedComment[]}
+ */
 const fromOwner = (data: ownerComment[]): formattedComment[] => {
     let data_: formattedComment[] = [];
     for (let i = 0; i < data.length; i++) {
         let value = data[i]!;
         let tmpParam: formattedComment = {
-            "id": i,
-            "vpos": time2vpos(value.time),
-            "content": value.comment,
-            "date": i,
-            "date_usec": 0,
-            "owner": true,
-            "premium": true,
-            "mail": [],
-            "user_id": -1,
-            "layer": -1
+            id: i,
+            vpos: time2vpos(value.time),
+            content: value.comment,
+            date: i,
+            date_usec: 0,
+            owner: true,
+            premium: true,
+            mail: [],
+            user_id: -1,
+            layer: -1
         };
         if (value.command) {
             tmpParam.mail = value.command.split(/[\s　]/g);
@@ -103,35 +197,32 @@ const fromOwner = (data: ownerComment[]): formattedComment[] => {
         }
         data_.push(tmpParam);
     }
-    data_.sort((a, b) => {
-        if (a.vpos < b.vpos) return -1;
-        if (a.vpos > b.vpos) return 1;
-        if (a.date < b.date) return -1;
-        if (a.date > b.date) return 1;
-        if (a.date_usec < b.date_usec) return -1;
-        if (a.date_usec > b.date_usec) return 1;
-        return 0;
-    });
     return data_;
 }
 
+/**
+ * ニコニコ公式のv1 apiから帰ってきたデータ処理する
+ * data内threadsのデータを渡されることを想定
+ * @param data {v1Thread[]}
+ * @return {formattedComment[]}
+ */
 const fromV1 = (data: v1Thread[]): formattedComment[] => {
     let data_: formattedComment[] = [], userList: string[] = [];
     for (let i = 0; i < data.length; i++) {
-        const val = data[i]!.comments,forkName = data[i]!.fork;
+        const val = data[i]!.comments, forkName = data[i]!.fork;
         for (let key in val) {
             let value: v1Comment = val[key]!;
             let tmpParam: formattedComment = {
-                "id": value.no,
-                "vpos": Math.floor(value.vposMs*10),
-                "content": value.body,
-                "date": date2time(value.postedAt),
-                "date_usec": 0,
-                "owner": forkName==="owner",
-                "premium": value.isPremium,
-                "mail": value.commands,
-                "user_id": -1,
-                "layer": -1
+                id: value.no,
+                vpos: Math.floor(value.vposMs * 10),
+                content: value.body,
+                date: date2time(value.postedAt),
+                date_usec: 0,
+                owner: forkName === "owner",
+                premium: value.isPremium,
+                mail: value.commands,
+                user_id: -1,
+                layer: -1
             };
             if (tmpParam.content.startsWith("/") && tmpParam.owner) {
                 tmpParam.mail.push("invisible");
@@ -146,7 +237,17 @@ const fromV1 = (data: v1Thread[]): formattedComment[] => {
             data_.push(tmpParam);
         }
     }
-    data_.sort((a, b) => {
+    return data_;
+
+}
+
+/**
+ * 共通処理
+ * 投稿時間、日時順にソート
+ * @param data
+ */
+const sort = (data: formattedComment[]): formattedComment[] => {
+    data.sort((a: formattedComment, b: formattedComment) => {
         if (a.vpos < b.vpos) return -1;
         if (a.vpos > b.vpos) return 1;
         if (a.date < b.date) return -1;
@@ -155,27 +256,37 @@ const fromV1 = (data: v1Thread[]): formattedComment[] => {
         if (a.date_usec > b.date_usec) return 1;
         return 0;
     });
-    return data_;
-
+    return data;
 }
 
+/**
+ * 投稿者コメントのエディターは秒数の入力フォーマットに割りと色々対応しているのでvposに変換
+ * @param time_str {string} 分:秒.秒・分:秒・秒.秒・秒
+ * @return {number} vpos
+ */
 const time2vpos = (time_str: string): number => {
     const time = time_str.match(/^(\d+):(\d+)\.(\d+)|(\d+):(\d+)|(\d+)\.(\d+)|(\d+)$/);
-    if (time){
-        if (time[1]){
-            return (Number(time[1])*60+Number(time[2]))*100+Number(time[3]);
-        }else if(time[4]){
-            return (Number(time[4])*60+Number(time[5]))*100;
-        }else if(time[6]){
-            return Number(time[6])*100+Number(time[7]);
-        }else if(time[8]){
-            return Number(time[8])*100;
+    if (time) {
+        if (time[1] !== undefined && time[2] !== undefined && time[3] !== undefined) {
+            return (Number(time[1]) * 60 + Number(time[2])) * 100 + Number(time[3]) / Math.pow(10, time[3]!.length - 2);
+        } else if (time[4] !== undefined && time[5] !== undefined) {
+            return (Number(time[4]) * 60 + Number(time[5])) * 100;
+        } else if (time[6] !== undefined && time[7] !== undefined) {
+            return Number(time[6]) * 100 + Number(time[7]) / Math.pow(10, time[7]!.length - 2);
+        } else if (time[8] !== undefined) {
+            return Number(time[8]) * 100;
         }
     }
     return 0;
 }
 
-const date2time = (date: string): number =>
-    Math.floor(new Date(date).getTime()/1000);
 
-export default convert;
+/**
+ * v1 apiのpostedAtはISO 8601のtimestampなのでDate関数を使ってunix timestampに変換
+ * @param date {string} ISO 8601 timestamp
+ * @return {number} unix timestamp
+ */
+const date2time = (date: string): number =>
+    Math.floor(new Date(date).getTime() / 1000);
+
+export default convert2formattedComment;

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import typeGuard from "@/typeGuard";
+import convert2formattedComment from "./inputParser";
 
 let isDebug: boolean = false;
 
@@ -10,8 +10,8 @@ class NiconiComments {
     private readonly fontSize: T_fontSize;
     private readonly lineHeight: T_fontSize;
     private readonly doubleResizeMaxWidth: T_doubleResizeMaxWidth;
-    private video: HTMLVideoElement | null;
-    private showCollision: boolean;
+    public video: HTMLVideoElement | null;
+    public showCollision: boolean;
     public showFPS: boolean;
     public showCommentCount: boolean;
     public enableLegacyPiP: boolean;
@@ -37,30 +37,21 @@ class NiconiComments {
      * @param {[]} data - 描画用のコメント
      * @param initOptions
      */
-    constructor(canvas: HTMLCanvasElement, data: (rawApiResponse | formattedComment)[], initOptions: InitOptions = {
-        useLegacy: false,
-        formatted: false,
-        video: null,
-        showCollision: false,
-        showFPS: false,
-        showCommentCount: false,
-        drawAllImageOnLoad: false,
-        debug: false,
-        enableLegacyPiP: false,
-        keepCA: false
-    }) {
-        const options: Options = Object.assign({
-            useLegacy: false,
-            formatted: false,
-            video: null,
-            showCollision: false,
-            showFPS: false,
-            showCommentCount: false,
+    constructor(canvas: HTMLCanvasElement, data: (rawApiResponse | formattedComment)[], initOptions: InitOptions = {}) {
+        const defaultOptions: Options = {
             drawAllImageOnLoad: false,
+            format: "default",
+            formatted: false,
             debug: false,
             enableLegacyPiP: false,
-            keepCA: false
-        },initOptions) ;
+            keepCA: false,
+            showCollision: false,
+            showCommentCount: false,
+            showFPS: false,
+            useLegacy: false,
+            video: null,
+        };
+        const options: Options = Object.assign(defaultOptions,initOptions) ;
         isDebug = options.debug;
         const constructorStart = performance.now();
 
@@ -112,7 +103,17 @@ class NiconiComments {
                 default: 2650
             }
         };
-        let parsedData: formattedComment[] = options.formatted ? data as formattedComment[] : this.parseData(data as rawApiResponse[]);
+        let formatType = options.format;
+
+        //Deprecated Warning
+        if (options.formatted){
+            console.warn("Deprecated: options.formatted is no longer recommended. Please use options.format");
+        }
+        if (formatType === "default"){
+            formatType = options.formatted?"formatted":"legacy";
+        }
+
+        let parsedData = convert2formattedComment(data, formatType);
         this.video = options.video ? options.video : null;
         this.showCollision = options.showCollision;
         this.showFPS = options.showFPS;
@@ -137,62 +138,6 @@ class NiconiComments {
             this.fpsCount = 0;
         }, 500);
         logger(`constructor complete: ${performance.now() - constructorStart}ms`);
-    }
-
-    /**
-     * ニコニコが吐き出したデータを処理しやすいように変換する
-     * @param {[]} data - ニコニコが吐き出したコメントデータ
-     * @returns {*[]} - 独自フォーマットのコメントデータ
-     */
-    parseData(data: rawApiResponse[]) {
-        const parseDataStart = performance.now();
-        let data_: formattedComment[] = [], userList: string[] = [];
-        for (let i = 0; i < data.length; i++) {
-            let val = data[i];
-            if (!val) continue;
-            for (let key in val) {
-                let value = val[key];
-                if (typeGuard.legacy.apiChat(value) && value["deleted"] !== 1) {
-                    let tmpParam: any = {
-                        "id": value["no"],
-                        "vpos": value["vpos"],
-                        "content": value["content"],
-                        "date": value["date"],
-                        "date_usec": value["date_usec"],
-                        "owner": !value["user_id"],
-                        "premium": value["premium"] === 1,
-                        "mail": [],
-                        "user_id": -1,
-                        "layer": -1
-                    };
-                    if (value["mail"]) {
-                        tmpParam["mail"] = value["mail"].split(/[\s　]/g);
-                    }
-                    if (value["content"].startsWith("/") && !value["user_id"]) {
-                        tmpParam["mail"].push("invisible");
-                    }
-                    let isUserExist = userList.indexOf(value["user_id"])
-                    if (isUserExist === -1) {
-                        tmpParam.user_id = userList.length;
-                        userList.push(value.user_id);
-                    } else {
-                        tmpParam.user_id = isUserExist;
-                    }
-                    data_.push(tmpParam);
-                }
-            }
-        }
-        data_.sort((a, b) => {
-            if (a.vpos < b.vpos) return -1;
-            if (a.vpos > b.vpos) return 1;
-            if (a.date < b.date) return -1;
-            if (a.date > b.date) return 1;
-            if (a.date_usec < b.date_usec) return -1;
-            if (a.date_usec > b.date_usec) return 1;
-            return 0;
-        });
-        logger(`parseData complete: ${performance.now() - parseDataStart}ms`);
-        return data_;
     }
 
     /**
@@ -943,6 +888,7 @@ class NiconiComments {
             for (let i in this.timeline[vpos]) {
                 let index = this.timeline[vpos]![Number(i) as number] as number;
                 let comment = this.data[index];
+                if (vpos > 23000&&vpos < 23100)console.log(comment)
                 if (!comment || comment.invisible) {
                     continue;
                 }
@@ -1074,21 +1020,27 @@ const logger = (msg: any) => {
 
 const changeCALayer = (rawData: formattedComment[]): formattedComment[] => {
     const userList:{[key:number]:number} = {};
-    const data:formattedComment[] = [],index: string[] = [];
+    const data:formattedComment[] = [],index: { [key: string]: formattedComment } = {};
     for (let i in rawData) {
         const value: formattedComment = rawData[i]!;
         if (value.user_id===undefined||value.user_id === -1)continue;
         if(userList[value.user_id]===undefined)userList[value.user_id]=0;
-        if (value.mail.indexOf("ca")>-1||value.mail.indexOf("patissier")>-1||value.mail.indexOf("ender")>-1){
+        if (value.mail.indexOf("ca")>-1||value.mail.indexOf("patissier")>-1||value.mail.indexOf("ender")>-1||value.mail.indexOf("full")>-1){
             userList[value.user_id]+=5;
         }
         if ((value.content.match(/\r\n|\n|\r/g)||[]).length>2){
-            userList[value.user_id]+=1;
+            userList[value.user_id]+=(value.content.match(/\r\n|\n|\r/g)||[]).length/2;
         }
-        let key = `${value.content}@@${Array.from(new Set(value.mail.sort())).filter((e)=>!e.match(/@[\d.]+|184|device:.+|patissier|ca/)).join("")}@@${Math.floor(value.vpos*10)}`;
-        if (index.indexOf(key)===-1){
-            index.push(key);
+        let key = `${value.content}@@${Array.from(new Set(JSON.parse(JSON.stringify(value.mail)).sort() as string[])).filter((e)=>!e.match(/@[\d.]+|184|device:.+|patissier|ca/)).join("")}`, lastComment = index[key];
+        if (lastComment!==undefined){
+            if (value.vpos > 29800&&30200 > value.vpos)console.log(value.vpos - lastComment.vpos , Math.abs(value.date-lastComment.date))
+            if (value.vpos - lastComment.vpos > 100|| Math.abs(value.date-lastComment.date)<3600){
+                data.push(value);
+                index[key]=value;
+            }
+        }else{
             data.push(value);
+            index[key]=value;
         }
     }
     for (let i in data) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,118 +1,4 @@
-type InitOptions = {
-    useLegacy?: boolean,
-    formatted?: boolean,
-    video?: HTMLVideoElement | null
-    showCollision?: boolean,
-    showFPS?: boolean,
-    showCommentCount?: boolean,
-    drawAllImageOnLoad?: boolean,
-    debug?: boolean,
-    enableLegacyPiP?: boolean,
-    keepCA?: boolean
-}
-type Options = {
-    useLegacy: boolean,
-    formatted: boolean,
-    video: HTMLVideoElement | null,
-    showCollision: boolean,
-    showFPS: boolean,
-    showCommentCount: boolean,
-    drawAllImageOnLoad: boolean,
-    debug: boolean,
-    enableLegacyPiP: boolean,
-    keepCA: boolean
-}
-type rawApiResponse = {
-    [key: string]: apiPing | apiThread | apiLeaf | apiGlobalNumRes | apiChat
-}
-type apiPing = {
-    "content": string
-}
-type apiThread = {
-    "resultcode": number,
-    "thread": string,
-    "server_time": number,
-    "ticket": string,
-    "revision": number
-}
-type apiLeaf = {
-    "thread": string,
-    "count": number
-}
-type apiGlobalNumRes = {
-    "thread": string,
-    "num_res": number
-}
-type apiChat = {
-    "thread": string,
-    "no": number,
-    "vpos": number,
-    "date": number,
-    "date_usec": number,
-    "nicoru": number,
-    "premium": number,
-    "anonymity": number,
-    "user_id": string,
-    "mail": string,
-    "content": string,
-    "deleted": number
-}
-type formattedComment = {
-    "id": number,
-    "vpos": number,
-    "content": string,
-    "date": number,
-    "date_usec": number,
-    "owner": boolean,
-    "premium": boolean,
-    "mail": string[],
-    "user_id": number,
-    "layer": number,
-}
-type formattedCommentWithFont = formattedComment & {
-    "loc": string,
-    "size": string,
-    "fontSize": number,
-    "font": string,
-    "color": string,
-    "full": boolean,
-    "ender": boolean,
-    "_live": boolean,
-    "long": number,
-    "invisible": boolean
-}
-type formattedCommentWithSize = formattedCommentWithFont & {
-    "height": number,
-    "width": number,
-    "width_max": number,
-    "width_min": number,
-    "lineHeight": number
-}
-type parsedComment = formattedCommentWithSize & {
-    posY: number,
-    image?: HTMLCanvasElement | boolean
-}
-type measureTextResult = {
-    "width": number,
-    "width_max": number,
-    "width_min": number,
-    "height": number,
-    "resized": boolean,
-    "fontSize": number,
-    "lineHeight": number
-}
-type T_fontSize = {
-    [key: string]: {
-        "default": number,
-        "resized": number
-    }
-}
-type T_doubleResizeMaxWidth = {
-    [key: string]: {
-        "legacy": number,
-        "default": number
-    }
-}
+import typeGuard from "@/typeGuard";
 
 let isDebug: boolean = false;
 
@@ -266,7 +152,7 @@ class NiconiComments {
             if (!val) continue;
             for (let key in val) {
                 let value = val[key];
-                if (isApiChat(value) && value["deleted"] !== 1) {
+                if (typeGuard.legacy.apiChat(value) && value["deleted"] !== 1) {
                     let tmpParam: any = {
                         "id": value["no"],
                         "vpos": value["vpos"],
@@ -1181,8 +1067,6 @@ const replaceAll = (string: string, target: string, replace: string) => {
     }
     return string;
 }
-const isApiChat = (item: any): item is apiChat =>
-    item.no && item.vpos && item.content
 
 const logger = (msg: any) => {
     if (isDebug) console.debug(msg);

--- a/src/main.ts
+++ b/src/main.ts
@@ -173,7 +173,7 @@ class NiconiComments {
             drawAllImageOnLoad: false,
             debug: false,
             enableLegacyPiP: false,
-            keepCA: true
+            keepCA: false
         },initOptions) ;
         isDebug = options.debug;
         const constructorStart = performance.now();

--- a/src/typeGuard.ts
+++ b/src/typeGuard.ts
@@ -1,0 +1,74 @@
+const typeGuard = {
+    formatted: {
+        comment: (i: any): i is formattedComment =>
+            typeVerify(i, ["id", "vpos", "content", "date", "date_usec", "owner", "premium", "mail"]),
+        comments: (i: any): i is formattedComment[] => {
+            if (typeof i !== "object") return false;
+            for (let item of i) {
+                if (!typeGuard.formatted.comment(item)) return false;
+            }
+            return true;
+        }
+    },
+    legacy: {
+        rawApiResponses: (i: any): i is rawApiResponse[] => {
+            if (typeof i !== "object") return false;
+            for (let item of i) {
+                if (!(typeGuard.legacy.apiChat(item) || typeGuard.legacy.apiGlobalNumRes(item) || typeGuard.legacy.apiLeaf(item) || typeGuard.legacy.apiPing(item) || typeGuard.legacy.apiThread(item))) {
+                    return false
+                }
+            }
+            return true
+        },
+        apiChat: (i: any): i is apiChat =>
+            typeVerify(i, ["anonymity", "content", "date", "date_usec", "no", "thread", "vpos"]),
+        apiGlobalNumRes: (i: any): i is apiGlobalNumRes =>
+            typeVerify(i, ["num_res", "thread"]),
+        apiLeaf: (i: any): i is apiLeaf =>
+            typeVerify(i, ["count", "thread"]),
+        apiPing: (i: any): i is apiPing =>
+            typeVerify(i, ["content"]),
+        apiThread: (i: any): i is apiThread =>
+            typeVerify(i, ["resultcode", "revision", "server_time", "thread", "ticket"]),
+    },
+    niconicome:{
+
+    },
+    owner: {
+        comment: (i: any): i is ownerComment =>
+            typeVerify(i, ["time", "command", "comment"]),
+        comments: (i: any): i is ownerComment[] => {
+            if (typeof i !== "object") return false;
+            for (let item of i) {
+                if (!typeGuard.owner.comment(item)) return false;
+            }
+            return true;
+        }
+
+    },
+    v1: {
+        comment: (i: any): i is apiThread =>
+            typeVerify(i, ["id", "no", "vposMs", "body", "commands", "userId", "isPremium", "score", "postedAt", "nicoruCount", "nicoruId", "source", "isMyPost"]),
+        thread: (i: any): i is v1Thread => {
+            if (!typeVerify(i, ["id", "fork", "commentCount", "comments"])) return false;
+            for (let item of i.comments) {
+                if (!typeGuard.v1.comment(item)) return false;
+            }
+            return true;
+        },
+        threads: (i: any): i is v1Thread[] => {
+            if (typeof i !== "object") return false;
+            for (let item of i) {
+                if (!typeGuard.v1.thread(item)) return false;
+            }
+            return true;
+        },
+    }
+}
+const typeVerify = (item: any, keys: string[]): boolean => {
+    for (let key of keys) {
+        if (item[key] === undefined) return false;
+    }
+    return true
+}
+export default typeGuard;

--- a/src/typeGuard.ts
+++ b/src/typeGuard.ts
@@ -1,11 +1,20 @@
 const typeGuard = {
     formatted: {
         comment: (i: any): i is formattedComment =>
-            typeVerify(i, ["id", "vpos", "content", "date", "date_usec", "owner", "premium", "mail"]),
+            typeVerify(i, ["id", "vpos", "content", "date", "date_usec", "owner", "premium", "mail", "user_id", "layer"]),
         comments: (i: any): i is formattedComment[] => {
             if (typeof i !== "object") return false;
             for (let item of i) {
                 if (!typeGuard.formatted.comment(item)) return false;
+            }
+            return true;
+        },
+        legacyComment: (i: any): i is formattedLegacyComment =>
+            typeVerify(i, ["id", "vpos", "content", "date", "date_usec", "owner", "premium", "mail"]),
+        legacyComments: (i: any): i is formattedLegacyComment[] => {
+            if (typeof i !== "object") return false;
+            for (let item of i) {
+                if (!typeGuard.formatted.legacyComment(item)) return false;
             }
             return true;
         }
@@ -30,9 +39,6 @@ const typeGuard = {
             typeVerify(i, ["content"]),
         apiThread: (i: any): i is apiThread =>
             typeVerify(i, ["resultcode", "revision", "server_time", "thread", "ticket"]),
-    },
-    niconicome:{
-
     },
     owner: {
         comment: (i: any): i is ownerComment =>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "./dist/",                        /* Redirect output structure to the directory. */
-    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
     // "composite": true,                     /* Enable project compilation */
     "removeComments": true,                /* Do not emit comments to output. */
     // "noEmit": true /* Do not emit outputs. */,
@@ -45,7 +45,7 @@
       "@/*": ["src/*"]
     } /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */,
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    //"typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,


### PR DESCRIPTION
## 機能追加
- 新しい入力フォーマットへの対応
  - niconicome
  - v1 api
  - 投稿者コメントエディター

これに伴いoptionにformatを追加、formattedを非推奨に変更

## 機能改善
- 入力データの型チェックを追加
従来入力のチェックを行ってこなかったが、それが原因でkeepCAを有効にすると古いformattedデータを入力したときに何も表示されないバグが発生した
そのため、渡されたデータの型チェックを追加し、正しくないデータに対してはエラーを投げるように変更
- 型定義ファイルを変更
今まで一つしかファイルが無かったため問題なかったが、複数になったので型定義を@types/types.d.tsに変更
これによりTypeDocも多少見やすくなったはず
- ドキュメント更新
少し前から更新されてなかったので最新版に合わせて更新

## 不具合修正
- keepCA有効化時に一部コメントの色が変わる
重複判定時に使用したsortが破壊的だったため、本来の意図したコマンドが適用されていなかった
そのため、JSONを使用したdeep copyを行ってからsortするように変更
