### PR TITLE
@置換で無限ループが発生するバグの修正

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
     parser: '@typescript-eslint/parser',
     parserOptions: {
         sourceType: 'module',
-        ecmaVersion: 2019,
+        ecmaVersion: "esnext",
         tsconfigRootDir: __dirname,
         project: ['./tsconfig.eslint.json'],
     },

--- a/src/util.ts
+++ b/src/util.ts
@@ -155,15 +155,6 @@ const hex2rgba = (hex: string) => {
   });
 };
 /**
- * replaceAll
- */
-const replaceAll = (string: string, target: string, replace: string) => {
-  while (string.indexOf(target) !== -1) {
-    string = string.replace(target, replace);
-  }
-  return string;
-};
-/**
  * CAと思われるコメントのレイヤーを分離する
  * @param {formattedComment[]} rawData
  */
@@ -303,7 +294,7 @@ const parseCommandAndNicoScript = (
         if (i.match(/["'\u300c]/) && quote === "") {
           quote = i;
         } else if (i.match(/["']/) && quote === i && last_i !== "\\") {
-          result.push(replaceAll(string, "\\n", "\n"));
+          result.push(string.replaceAll("\\n", "\n"));
           quote = "";
           string = "";
         } else if (i.match(/\u300d/) && quote === "\u300c") {
@@ -404,8 +395,7 @@ const parseCommandAndNicoScript = (
         comment.content.indexOf(item.keyword) !== -1)
     ) {
       if (item.range === "\u5358") {
-        comment.content = replaceAll(
-          comment.content,
+        comment.content = comment.content.replaceAll(
           item.keyword,
           item.replace
         );
@@ -551,7 +541,6 @@ export {
   hex2rgb,
   hex2rgba,
   getStrokeColor,
-  replaceAll,
   changeCALayer,
   getConfig,
   isFlashComment,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     /* Basic Options */
     "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
     "module": "esnext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
-    "lib": ["es2016","dom"],                             /* Specify library files to be included in the compilation. */
+    "lib": ["esnext","dom"],                             /* Specify library files to be included in the compilation. */
     "allowJs": true /* Allow javascript files to be compiled. */,
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
ecma versionを2016 -> esnextに更新
独自実装だったreplaceAllをstring.prototype.replaceAllに置換