### PR TITLE
枠をつける独自コマンドを追加

### DIFF
--- a/src/@types/types.d.ts
+++ b/src/@types/types.d.ts
@@ -16,6 +16,7 @@ type formattedCommentWithFont = {
   font: commentFont;
   color: string;
   strokeColor?: string;
+  wakuColor?: string;
   full: boolean;
   ender: boolean;
   _live: boolean;
@@ -117,6 +118,7 @@ type parsedCommand = {
   fontSize: number | undefined;
   color: string | undefined;
   strokeColor?: string;
+  wakuColor?: string;
   font: commentFont | undefined;
   full: boolean;
   ender: boolean;

--- a/src/comments/FlashComment.ts
+++ b/src/comments/FlashComment.ts
@@ -458,6 +458,16 @@ class FlashComment implements IComment {
       }
       this.context.drawImage(this.image, posX, posY);
     }
+    if (this.comment.wakuColor){
+      const scale = getConfig(config.commentScale, false);
+      this.context.strokeStyle = this.comment.wakuColor;
+      this.context.strokeRect(
+        posX,
+        posY,
+        this.comment.width,
+        this.comment.height
+      );
+    }
     if (showCollision) {
       this.context.strokeStyle = "rgba(255,0,255,1)";
       this.context.strokeRect(

--- a/src/comments/HTML5Comment.ts
+++ b/src/comments/HTML5Comment.ts
@@ -290,6 +290,16 @@ class HTML5Comment implements IComment {
       }
       this.context.drawImage(this.image, posX, posY);
     }
+    if (this.comment.wakuColor){
+      const scale = getConfig(config.commentScale, false);
+      this.context.strokeStyle = this.comment.wakuColor;
+      this.context.strokeRect(
+        posX,
+        posY,
+        this.comment.width,
+        this.comment.height
+      );
+    }
     if (showCollision) {
       const scale = getConfig(config.commentScale, false);
       this.context.strokeStyle = "rgba(0,255,255,1)";

--- a/src/util.ts
+++ b/src/util.ts
@@ -454,6 +454,7 @@ const parseCommand = (comment: formattedComment): parsedCommand => {
     fontSize: undefined,
     color: undefined,
     strokeColor: undefined,
+    wakuColor: undefined,
     font: undefined,
     full: false,
     ender: false,
@@ -474,6 +475,15 @@ const parseCommand = (comment: formattedComment): parsedCommand => {
         result.strokeColor = colors[match[1]];
       } else if (typeGuard.comment.colorCode(match[1])) {
         result.strokeColor = match[1].slice(1);
+      }
+    } else if (
+      result.wakuColor === undefined &&
+      (match = command.match(/^nico:waku:(.+)$/))
+    ){
+      if (typeGuard.comment.color(match[1])) {
+        result.wakuColor = colors[match[1]];
+      } else if (typeGuard.comment.colorCode(match[1])) {
+        result.wakuColor = match[1].slice(1);
       }
     } else if (result.loc === undefined && typeGuard.comment.loc(command)) {
       result.loc = command;


### PR DESCRIPTION
## やったこと

`nico:waku:(color|color code)`をコマンドに付与することで指定色の枠をコメントにつけることを可能に
なお枠は`showCollision`で出てくる青枠と同じもの

## できるようになること（ユーザ目線）

同上

## 動作確認

Niconicomments@v0.2.45
Chrome@110.0.5481.177
macOS Monterey@12.6.3

## その他

コマンド実装は`nico:stroke`を、枠実装は`showCollision`をほとんどコッピったので多分大丈夫とは思います。
