### PR TITLE
[修正] 1920x1080未満のcanvasを使用すると画面の一部が消去されない

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -282,8 +282,7 @@ class NiconiComments {
           [];
       if (arrayEqual(current, last)) return false;
     }
-    const size = this.renderer.getSize();
-    this.renderer.clearRect(0, 0, size.width, size.height);
+    this.renderer.clearRect(0, 0, config.canvasWidth, config.canvasHeight);
     this.lastVpos = vpos;
     this._drawVideo();
     for (const plugin of plugins) {


### PR DESCRIPTION
<img width="761" alt="image" src="https://github.com/xpadev-net/niconicomments/assets/96982836/8a387e48-f65d-490f-af6d-ec931c75f6a7">
canvasのサイズ分のみ消去され、それより外側の領域が消去されない