### PR TITLE
[修正] XMLを読み込む際にエンコードされた文字がデコードされない

### DIFF
--- a/src/inputParser.ts
+++ b/src/inputParser.ts
@@ -79,7 +79,7 @@ const fromXMLDocument = (data: XMLDocument): FormattedComment[] => {
     const tmpParam: FormattedComment = {
       id: Number(item.getAttribute("no")) || index++,
       vpos: Number(item.getAttribute("vpos")),
-      content: item.innerHTML,
+      content: item.textContent ?? "",
       date: Number(item.getAttribute("date")) || 0,
       date_usec: Number(item.getAttribute("date_usec")) || 0,
       owner: !item.getAttribute("user_id"),


### PR DESCRIPTION
>あと不具合としてxmlでエスケープされている文字(>や&など)が変換されずにそのままコメントとして出力されてしまうというものを発見しましたので報告しておきます 
https://egg.5ch.net/test/read.cgi/software/1675220449/652

innerHTMLだと`&lt;`などがそのまま`&lt;`として解釈されてしまうため、textContentを用いて`<`になるようにする