### PR TITLE
[実装] xml2js形式のサポート

### DIFF
--- a/src/@types/format.xml2js.ts
+++ b/src/@types/format.xml2js.ts
@@ -1,0 +1,27 @@
+import type { Output } from "valibot";
+import { array, object, optional, string } from "valibot";
+
+export const ZXml2jsChatItem = object({
+  _: string(),
+  $: object({
+    no: optional(string()),
+    vpos: string(),
+    date: optional(string(), "0"),
+    date_usec: optional(string(), "0"),
+    user_id: optional(string()),
+    owner: optional(string(), ""),
+    premium: optional(string(), ""),
+    mail: optional(string(), ""),
+  }),
+});
+export type Xml2jsChatItem = Output<typeof ZXml2jsChatItem>;
+
+export const ZXml2jsChat = object({
+  chat: array(ZXml2jsChatItem),
+});
+export type Xml2jsChat = Output<typeof ZXml2jsChat>;
+
+export const ZXml2jsPacket = object({
+  packet: ZXml2jsChat,
+});
+export type Xml2jsPacket = Output<typeof ZXml2jsPacket>;

--- a/src/@types/options.ts
+++ b/src/@types/options.ts
@@ -1,3 +1,6 @@
+import type { Output } from "valibot";
+import { literal, union } from "valibot";
+
 import type {
   Config,
   FormattedComment,
@@ -6,19 +9,25 @@ import type {
   RawApiResponse,
   V1Thread,
 } from "@/@types/";
+import type { Xml2jsPacket } from "@/@types/format.xml2js";
 
-export type InputFormatType =
-  | "XMLDocument"
-  | "niconicome"
-  | "formatted"
-  | "legacy"
-  | "legacyOwner"
-  | "owner"
-  | "v1"
-  | "empty"
-  | "default";
+export const ZInputFormatType = union([
+  literal("XMLDocument"),
+  literal("niconicome"),
+  literal("xml2js"),
+  literal("formatted"),
+  literal("legacy"),
+  literal("legacyOwner"),
+  literal("owner"),
+  literal("v1"),
+  literal("empty"),
+  literal("default"),
+]);
+export type InputFormatType = Output<typeof ZInputFormatType>;
+
 export type InputFormat =
   | XMLDocument
+  | Xml2jsPacket
   | FormattedComment[]
   | FormattedLegacyComment[]
   | RawApiResponse[]

--- a/src/input/index.ts
+++ b/src/input/index.ts
@@ -6,6 +6,7 @@ import { LegacyParser } from "./legacy";
 import { LegacyOwnerParser } from "./legacyOwner";
 import { OwnerParser } from "./owner";
 import { V1Parser } from "./v1";
+import { Xml2jsParser } from "./xml2js";
 import { XmlDocumentParser } from "./xmlDocument";
 
 export const parsers: InputParser[] = [
@@ -15,5 +16,6 @@ export const parsers: InputParser[] = [
   LegacyOwnerParser,
   OwnerParser,
   V1Parser,
+  Xml2jsParser,
   XmlDocumentParser,
 ];

--- a/src/input/xml2js.ts
+++ b/src/input/xml2js.ts
@@ -1,0 +1,46 @@
+import { parse } from "valibot";
+
+import type { FormattedComment, InputParser } from "@/@types";
+import type { Xml2jsPacket } from "@/@types/format.xml2js";
+import { ZXml2jsPacket } from "@/@types/format.xml2js";
+
+export const Xml2jsParser: InputParser = {
+  key: ["xml2js"],
+  parse: (input) => {
+    return fromXml2js(parse(ZXml2jsPacket, input));
+  },
+};
+
+const fromXml2js = (data: Xml2jsPacket): FormattedComment[] => {
+  const data_: FormattedComment[] = [],
+    userList: string[] = [];
+  let index = data.packet.chat.length;
+  for (const item of data.packet.chat) {
+    const tmpParam: FormattedComment = {
+      id: Number(item.$.no) || index++,
+      vpos: Number(item.$.vpos),
+      content: item._,
+      date: Number(item.$.date),
+      date_usec: Number(item.$.date_usec),
+      owner: !(item.$.owner === "0" || item.$.user_id),
+      premium: item.$.premium === "1",
+      mail: item.$.mail.split(/\s+/g),
+      user_id: -1,
+      layer: -1,
+      is_my_post: false,
+    };
+    if (tmpParam.content.startsWith("/") && tmpParam.owner) {
+      tmpParam.mail.push("invisible");
+    }
+    const userId = item.$.user_id ?? "";
+    const isUserExist = userList.indexOf(userId);
+    if (isUserExist === -1) {
+      tmpParam.user_id = userList.length;
+      userList.push(userId);
+    } else {
+      tmpParam.user_id = isUserExist;
+    }
+    data_.push(tmpParam);
+  }
+  return data_;
+};

--- a/src/inputParser.ts
+++ b/src/inputParser.ts
@@ -12,12 +12,9 @@ const convert2formattedComment = (
   data: unknown,
   type: InputFormatType,
 ): FormattedComment[] => {
-  for (const parser of parsers) {
-    if (parser.key.includes(type)) {
-      return sort(parser.parse(data));
-    }
-  }
-  throw new InvalidFormatError();
+  const parser = parsers.find((parser) => parser.key.includes(type));
+  if (!parser) throw new InvalidFormatError();
+  return sort(parser.parse(data));
 };
 
 /**

--- a/src/typeGuard.ts
+++ b/src/typeGuard.ts
@@ -1,4 +1,13 @@
-import { array, custom, is, literal, regex, string, union } from "valibot";
+import {
+  array,
+  custom,
+  is,
+  literal,
+  regex,
+  safeParse,
+  string,
+  union,
+} from "valibot";
 
 import type {
   ApiChat,
@@ -25,6 +34,7 @@ import type {
   V1Comment,
   V1Thread,
 } from "@/@types/";
+import { ZInputFormatType } from "@/@types/";
 import {
   ZApiChat,
   ZApiGlobalNumRes,
@@ -199,11 +209,7 @@ const typeGuard = {
         keepCA: isBoolean,
         scale: isNumber,
         config: isObject,
-        format: (i: unknown) =>
-          typeof i === "string" &&
-          !!RegExp(
-            /^(XMLDocument|niconicome|formatted|legacy|legacyOwner|owner|v1|default|empty)$/,
-          ).exec(i),
+        format: (i) => safeParse(ZInputFormatType, i).success,
         video: (i: unknown) =>
           typeof i === "object" && (i as HTMLVideoElement).nodeName === "VIDEO",
       };


### PR DESCRIPTION
- jsdomによるXMLDocumentはかなりパフォーマンスが悪いので代替としてxml2jsを対応フォーマットに追加