### PR TITLE
feat: remove IRenderer dependencies to DOM

### DIFF
--- a/src/@types/renderer.ts
+++ b/src/@types/renderer.ts
@@ -1,6 +1,4 @@
 export interface IRenderer {
-  readonly canvas: HTMLCanvasElement;
-  readonly video?: HTMLVideoElement;
   destroy(): void;
   drawVideo(enableLegacyPip: boolean): void;
   getFont(): string;

--- a/src/renderer/canvas.ts
+++ b/src/renderer/canvas.ts
@@ -62,6 +62,12 @@ class CanvasRenderer implements IRenderer {
     width?: number,
     height?: number,
   ) {
+    if (!(image instanceof CanvasRenderer)) {
+      throw new TypeError(
+        "CanvasRenderer.drawImage: 'image' argument must be an instance of CanvasRenderer.",
+      );
+    }
+
     if (width === undefined || height === undefined)
       this.context.drawImage(image.canvas, x, y);
     else this.context.drawImage(image.canvas, x, y, width, height);


### PR DESCRIPTION
## チケットへのリンク

- なし (ごめんなさい…)

## やったこと

- IRenderer から DOM に依存したプロパティを削除しました

## やらないこと

- 型の厳格化
  - 本来は IRenderer.drawImage の image は this にするべきですが、そうなると IRenderer が関わる全ファイルにジェネリクスを入れる改修が必要になる & そもそも実現可能か怪しい (継承周りの都合) ので、一旦実行時にハネるだけで許容することにしました (複数 renderer が実行時に並列する use-case が思い付かなかったので)

## できるようになること（ユーザ目線）

- 理論上は DOM に依存していないレンダラを実装することが可能になりました

## できなくなること（ユーザ目線）

- なし

## 動作確認

- `pnpm run check-types` でエラーが出ないことを確認

## その他

- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）
