### PR TITLE
fix: remove dts-bundle-generator from build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "npx rimraf dist&&npm run build:ts&&npm run build:dts",
     "build:ts": "rollup -c rollup.config.mjs",
-    "build:dts": "npx copyfiles -u 2 src/@types/*.d.ts dist/dts/@types/&&node ./util/resolve-path-alias.js&&rollup -c rollup.config.dts.mjs&& npx dts-bundle-generator --external-inlines=valibot -o dist/bundle.d.ts dist/bundle_.d.ts",
+    "build:dts": "npx copyfiles -u 2 src/@types/*.d.ts dist/dts/@types/&&node ./util/resolve-path-alias.js&&rollup -c rollup.config.dts.mjs",
     "watch": "rollup -c rollup.config.mjs -w",
     "typedoc": "typedoc --entryPointStrategy Expand --out ./docs/type/ ./src/",
     "prepublishOnly": "npm run build",
@@ -56,7 +56,6 @@
     "@typescript-eslint/eslint-plugin": "^6.17.0",
     "@typescript-eslint/parser": "^6.17.0",
     "copyfiles": "^2.4.1",
-    "dts-bundle-generator": "^9.2.1",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-jsdoc": "^48.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,6 @@ devDependencies:
   copyfiles:
     specifier: ^2.4.1
     version: 2.4.1
-  dts-bundle-generator:
-    specifier: ^9.2.1
-    version: 9.2.1
   eslint:
     specifier: ^8.56.0
     version: 8.56.0
@@ -2014,15 +2011,6 @@ packages:
       wrap-ansi: 7.0.0
     dev: true
 
-  /cliui@8.0.1:
-    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
-    engines: {node: '>=12'}
-    dependencies:
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      wrap-ansi: 7.0.0
-    dev: true
-
   /color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
     dependencies:
@@ -2160,15 +2148,6 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       esutils: 2.0.3
-    dev: true
-
-  /dts-bundle-generator@9.2.1:
-    resolution: {integrity: sha512-sMyIGJcn+FSc4f4VzRgX4muZS2uG91c/DjC++HkpZJyudGedSpGNR5bY9HEkSyyYFay0ERzjoDM7uKgUycaRvw==}
-    engines: {node: '>=14.0.0'}
-    hasBin: true
-    dependencies:
-      typescript: 5.3.3
-      yargs: 17.7.2
     dev: true
 
   /eastasianwidth@0.2.0:
@@ -3825,11 +3804,6 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /yargs-parser@21.1.1:
-    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
-    engines: {node: '>=12'}
-    dev: true
-
   /yargs@16.2.0:
     resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
     engines: {node: '>=10'}
@@ -3841,19 +3815,6 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 20.2.9
-    dev: true
-
-  /yargs@17.7.2:
-    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
-    engines: {node: '>=12'}
-    dependencies:
-      cliui: 8.0.1
-      escalade: 3.1.1
-      get-caller-file: 2.0.5
-      require-directory: 2.1.1
-      string-width: 4.2.3
-      y18n: 5.0.8
-      yargs-parser: 21.1.1
     dev: true
 
   /yocto-queue@0.1.0:

--- a/rollup.config.dts.mjs
+++ b/rollup.config.dts.mjs
@@ -13,6 +13,8 @@ const __dirname = path.dirname(__filename);
 
 export default {
   input: "./dist/dts/main.d.ts",
-  output: [{ file: "dist/bundle_.d.ts", format: "es" }],
-  plugins: [typescriptPaths(), dts()],
+  output: [{ file: "dist/bundle.d.ts", format: "es" }],
+  plugins: [typescriptPaths(), dts({
+    respectExternal: true,
+  })],
 };


### PR DESCRIPTION
## チケットへのリンク
 #99 

## やったこと
- `dts-bundle-generator` によって `NiconiComments.internal` 以下の変数名が変更されていたので `rollup-plugin-dts` 単体で処理するように変更

## できるようになること（ユーザ目線）

- 変数名が本来のものに戻る

## できなくなること（ユーザ目線）

- 直近のバージョンに合わせて修正を行っている場合はエラーになる(おそらくいない)

