### PR TITLE
[修正] typecheckをpre-commit hookに追加

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,6 +1,10 @@
 pre-commit:
   commands:
-    check:
+    lint:
       glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
       run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+      stage_fixed: true
+    typecheck:
+      glob: "*.{ts,tsx}"
+      run: npx tsc --noEmit --skipLibCheck --pretty --noErrorTruncation --skipDefaultLibCheck --project tsconfig.json
       stage_fixed: true


### PR DESCRIPTION
型エラーがbiomeを貫通してtypedocのビルドにコケたため