### PR TITLE
[実装] 不透明度の変更を行える nico:opacity コマンドを追加

### DIFF
--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -31,6 +31,7 @@ export type FormattedCommentWithFont = {
   strokeColor?: string;
   wakuColor?: string;
   fillColor?: string;
+  opacity?: number;
   full: boolean;
   ender: boolean;
   _live: boolean;
@@ -71,6 +72,7 @@ export type ParseCommandAndNicoScriptResult = {
   strokeColor?: string;
   wakuColor?: string;
   fillColor?: string;
+  opacity?: number;
   font: CommentFont;
   full: boolean;
   ender: boolean;
@@ -277,6 +279,7 @@ export type ParsedCommand = {
   strokeColor?: string;
   wakuColor?: string;
   fillColor?: string;
+  opacity?: number;
   font: CommentFont | undefined;
   full: boolean;
   ender: boolean;

--- a/src/comments/BaseComment.ts
+++ b/src/comments/BaseComment.ts
@@ -181,7 +181,12 @@ class BaseComment implements IComment {
     }
     if (this.image) {
       this.renderer.save();
-      if (this.comment._live) {
+      if (
+        typeof this.comment.opacity === "number" &&
+        this.comment.opacity >= 0
+      ) {
+        this.renderer.setGlobalAlpha(this.comment.opacity);
+      } else if (this.comment._live) {
         this.renderer.setGlobalAlpha(config.contextFillLiveOpacity);
       } else {
         this.renderer.setGlobalAlpha(1);

--- a/src/utils/comment.ts
+++ b/src/utils/comment.ts
@@ -152,6 +152,7 @@ const parseCommandAndNicoScript = (
     strokeColor: commands.strokeColor,
     wakuColor: commands.wakuColor,
     fillColor: commands.fillColor,
+    opacity: commands.opacity,
     button: commands.button,
   };
 };
@@ -497,6 +498,11 @@ const parseCommand = (
     result.fillColor ??= fillColor;
     return;
   }
+  const opacity = getOpacity(RegExp(/^nico:opacity:(.+)$/).exec(command));
+  if (typeof opacity === "number") {
+    result.opacity ??= opacity;
+    return;
+  }
   if (is(ZCommentLoc, command)) {
     result.loc ??= command;
     return;
@@ -536,6 +542,20 @@ const getColor = (match: RegExpMatchArray | null) => {
     return colors[value];
   }
   if (typeGuard.comment.colorCodeAllowAlpha(value)) {
+    return value;
+  }
+  return;
+};
+
+/**
+ * 正規表現の結果から透明度を取得する
+ * @param match 正規表現の結果
+ * @returns 透明度
+ */
+const getOpacity = (match: RegExpMatchArray | null) => {
+  if (!match) return;
+  const value = Number(match[1]);
+  if (!Number.isNaN(value)) {
     return value;
   }
   return;


### PR DESCRIPTION
## チケットへのリンク
なし

## やったこと
コメントの不透明度を個別に操作する`nico:opacity:<透明度>`コマンドを実装した。

内部的にはコマンドのパース結果にそれぞれoptionalの`opacity`キーを追加し、number型の値が入っている場合にその透明度でオーバーライドするようにしています。

コマンドのパース段階で、値がNaNになる場合は無視しています。
描画段階で、opacityの値がNumber型ではないか0未満の場合にも、無視して1として扱います。

オーバーライド用のコマンドのため、`_live`より適用優先度が高いです。

## やらないこと
なし

## できるようになること（ユーザ目線）
ライブラリを使用する開発者が透明度をコメントごとに変更したい場合に、
コマンドを予め付与して渡すことで、自由に透明度の違うコメントを表示できるようになる。
`_live`コマンドを付与したり、CSSでcanvasの透明度を変更するよりも自由度が高い。

## できなくなること（ユーザ目線）
なし

## 動作確認
サンプルの`-1.json`内に想定される値を入れて検証し、期待通りに動作することを確認しています。
Chrome 136.0.7103.114 / Windows 11 24H2 26100.4061
(「透明度」で書いてますがこれ「不透明度」ですね…)
![image](https://github.com/user-attachments/assets/f9615a02-2fb7-4608-bb64-0922bd3bdbe7)

## その他
playwrightのE2Eテストは自分の環境では動作しなかったため行っていません。