### PR TITLE
[修正] @逆 の対象設定を省略可能にする

### DIFF
--- a/src/utils/comment.ts
+++ b/src/utils/comment.ts
@@ -328,14 +328,16 @@ const processReverseScript = (
   const reverse = RegExp(
     /^[@\uff20]\u9006(?:\s+)?(\u5168|\u30b3\u30e1|\u6295\u30b3\u30e1)?/,
   ).exec(comment.content);
-  if (!reverse?.[1] || !typeGuard.nicoScript.range.target(reverse[1])) return;
+  const target = typeGuard.nicoScript.range.target(reverse?.[1])
+    ? reverse?.[1]
+    : "全";
   if (commands.long === undefined) {
     commands.long = 30;
   }
   nicoScripts.reverse.unshift({
     start: comment.vpos,
     end: comment.vpos + commands.long * 100,
-    target: reverse[1],
+    target,
   });
 };
 


### PR DESCRIPTION
## チケットへのリンク
なし

## やったこと
`@逆` ニコスクリプトの対象設定(`全|投コメ|コメ`)が省略されたか無効な値だった場合、
無視する代わりに公式レンダラーに沿って全コメ対象で適用するようにした。

## やらないこと
なし

## できるようになること（ユーザ目線）
一部の逆コメ動画に対する描画が、公式レンダラーと同じように機能するようになる。
対象設定が書かれている場合は引き続き対象設定が適用される。

## できなくなること（ユーザ目線）
なし

## 動作確認
#121 と同様に、サンプルの`-1.json`内にニコスクリプトと投稿者コメント/通常コメントを入れ、期待通りに対象設定が動作することを確認しています。
Chrome 136.0.7103.114 / Windows 11 24H2 26100.4061

## その他
#121 と同じ理由でplaywrightのE2Eテストは行っていません。