### PR TITLE
fix: set lineJoin to 'round' for smoother stroke rendering

### DIFF
--- a/src/renderer/canvas.ts
+++ b/src/renderer/canvas.ts
@@ -18,6 +18,7 @@ class CanvasRenderer implements IRenderer {
     this.context = context;
     this.context.textAlign = "start";
     this.context.textBaseline = "alphabetic";
+    this.context.lineJoin = "round";
     this.video = video;
   }
 


### PR DESCRIPTION
## 概要

このプルリクエストは Issue #132 「縁取りをラウンドにする」に対応します。

## 変更内容

-  のコンストラクタで  を  に設定
- これにより、コメントの縁取りが角ばったバリ状ではなく、滑らかなラウンド形状になります

## Issue への対応

- **問題**: ストロークの結合方法がCanvas標準の設定になっていて、フォントによってはバリのようなものが発生している
- **解決**:  を設定することで、ニコニコ動画の公式プレイヤーと同様のラウンド縁取りを実現

## テスト

- lefthook による lint および typecheck が通過
- 既存の機能に影響を与えない最小限の変更

Fixes #132