### PR TITLE
パッケージのリリース時に OCID を用いた trusted publishing を用いるように変更

### DIFF
--- a/.github/workflows/release-publish-package.yml
+++ b/.github/workflows/release-publish-package.yml
@@ -2,8 +2,7 @@ name: publish package
 
 permissions:
   contents: read
-  packages: write
-  actions: write
+  id-token: write
 
 on:
   push:
@@ -39,8 +38,6 @@ jobs:
 
       - name: Publish package
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
- パッケージのリリース時に OCID を用いた trusted publishing を用いるように変更
https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/