### PR TITLE
リリースworkflowをOIDC trusted publishingに移行

### DIFF
--- a/.github/workflows/release-publish-package.yml
+++ b/.github/workflows/release-publish-package.yml
@@ -1,7 +1,7 @@
 name: publish package
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 on:
@@ -28,7 +28,6 @@ jobs:
         with:
           node-version: '24'
           registry-url: https://registry.npmjs.org
-          always-auth: true
           scope: '@xpadev-net'
           cache: 'pnpm'
 
@@ -37,9 +36,7 @@ jobs:
           pnpm install
 
       - name: Publish package
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates the npm publish workflow from static token-based authentication (`NPM_TOKEN` secret) to OIDC Trusted Publishing, which is the modern, more secure approach for publishing to npm. The changes are minimal and correct for this migration:

- `contents: read` → `contents: write` to allow the existing `softprops/action-gh-release@v2` step to create GitHub releases (this was a pre-existing oversight — the release step always needed `write` permission).
- Removes `always-auth: true` and `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`, which are not needed with OIDC.
- Adds `--provenance` to `npm publish`, enabling provenance attestation via the already-present `id-token: write` permission.

The changes are well-scoped and follow npm's OIDC Trusted Publishing best practices. No logic or application code is affected.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the changes are a straightforward OIDC migration with no impact on application code.

The changes are minimal, well-understood, and follow npm's recommended OIDC Trusted Publishing pattern. The only prerequisite is that the OIDC trusted publisher must be configured on npmjs.com for this repository before the workflow runs; if it isn't, the publish step will fail at runtime (operational concern, not a code defect). The contents: write permission change is a legitimate correction needed for the pre-existing GitHub release step.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-publish-package.yml | Migrates npm publish to OIDC Trusted Publishing by removing the static NPM_TOKEN secret and adding --provenance; also corrects the contents permission from read to write for GitHub release creation. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions
    participant OIDC as GitHub OIDC Provider
    participant NPM as npm Registry
    participant GH as GitHub Releases

    GHA->>OIDC: Request OIDC token (id-token: write)
    OIDC-->>GHA: Short-lived OIDC token
    GHA->>NPM: npm publish --provenance (with OIDC token)
    NPM-->>GHA: Publish success + provenance attestation
    GHA->>GH: Create GitHub release (contents: write)
    GH-->>GHA: Release created
```

<sub>Reviews (1): Last reviewed commit: ["ci: migrate npm publish to OIDC trusted ..."](https://github.com/xpadev-net/niconicomments/commit/e6f0d56f41fb2aed79896872cc66401f858fe14c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27306993)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD publishing configuration for enhanced security and reliability.

---

**Note:** This release contains no user-visible changes. The updates are internal infrastructure improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->