### PR TITLE
リリース用ciを更新

### DIFF
--- a/.github/workflows/release-publish-package.yml
+++ b/.github/workflows/release-publish-package.yml
@@ -1,7 +1,7 @@
 name: publish package
 
 permissions:
-  contents: read
+  contents: write
   id-token: write
 
 on:
@@ -28,7 +28,6 @@ jobs:
         with:
           node-version: '24'
           registry-url: https://registry.npmjs.org
-          always-auth: true
           scope: '@xpadev-net'
           cache: 'pnpm'
 
@@ -37,9 +36,7 @@ jobs:
           pnpm install
 
       - name: Publish package
-        run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the release CI workflow (`release-publish-package.yml`) with three changes: (1) elevates `contents` permission from `read` to `write` — necessary for the existing `softprops/action-gh-release@v2` step to create GitHub releases, (2) removes the `always-auth: true` option from the `setup-node` step (a minor cleanup), and (3) switches from plain `npm publish` with `NODE_AUTH_TOKEN` to `npm publish --provenance` without any explicit auth token — adding supply chain security via signed build provenance.

- The `contents: write` permission change is correct and required; the GitHub release step would have been silently failing without it.
- Adding `--provenance` is a good practice and leverages the pre-existing `id-token: write` permission for generating OIDC-based build attestations.
- **The removal of `NODE_AUTH_TOKEN` is a potential breaking change.** `npm publish` always requires authentication. `--provenance` uses the OIDC token for *signing* the provenance, not for registry authentication. Unless npm Trusted Publishing (OIDC) has been explicitly configured for this package on the npm registry, removing the token will cause the publish step to fail with an authentication error. This should be verified before merging.

<h3>Confidence Score: 3/5</h3>

Merging carries moderate risk of breaking npm publishing if npm Trusted Publishing (OIDC) has not been configured on the registry side.

The `contents: write` and `--provenance` changes are correct and beneficial. However, removing `NODE_AUTH_TOKEN` without confirmed npm Trusted Publishing setup means the publish step could silently fail on the next release — a runtime-only failure not caught in CI until an actual publish is attempted.

.github/workflows/release-publish-package.yml — specifically the Publish package step and whether npm Trusted Publishing is configured for this package.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-publish-package.yml | Updates release CI: upgrades to provenance publishing, elevates permissions to `contents: write` (needed for GitHub release creation), and removes `NODE_AUTH_TOKEN` — which may break npm authentication unless npm Trusted Publishing (OIDC) is configured on the registry side. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant NPM as npm Registry
    participant GHREL as GitHub Releases

    GH->>GH: checkout and install deps
    GH->>NPM: npm publish --provenance
    Note over GH,NPM: Auth via OIDC Trusted Publishing<br/>or classic token (removed in PR)
    NPM-->>GH: publish result
    GH->>GHREL: create GitHub release<br/>via softprops/action-gh-release@v2
    Note over GH,GHREL: Requires contents:write<br/>(upgraded in this PR)
    GHREL-->>GH: release created
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: .github/workflows/release-publish-package.yml
Line: 38-39

Comment:
**Missing npm authentication token**

`NODE_AUTH_TOKEN` was removed, but `npm publish` still needs authentication. When `actions/setup-node` is configured with a `registry-url`, it writes an `.npmrc` that references `${NODE_AUTH_TOKEN}` for authentication. Without this environment variable being set, the publish step will fail with a 401/403 authentication error.

The `--provenance` flag uses the OIDC token (covered by `id-token: write`) to generate a cryptographically signed attestation about how the package was built — but that is separate from registry authentication. You still need either:

1. **npm Trusted Publishing (OIDC)** — where the npm registry is explicitly configured to trust tokens from this specific GitHub Actions workflow context. If this has already been set up on the npm registry side for this package, the removal is correct and `NODE_AUTH_TOKEN` is no longer needed.
2. **A classic/automation token** passed via `NODE_AUTH_TOKEN` as before.

If Trusted Publishing is not configured on the npm side, the publish step will fail. Please confirm the npm package has OIDC Trusted Publishing enabled before merging.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #264 from xpadev-net/..."](https://github.com/xpadev-net/niconicomments/commit/3901dc6a6670fd08e737c104d9fe88b3078232f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27307074)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->