### PR TITLE
fix: add node types to tsconfig for typedoc compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,9 @@
       "esnext",
       "dom"
     ] /* Specify library files to be included in the compilation. */,
+    "types": [
+      "node"
+    ] /* Type declaration files to be included in compilation. */,
     "allowJs": true /* Allow javascript files to be compiled. */,
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */


### PR DESCRIPTION
## Summary
- `tsconfig.json` に `"types": ["node"]` を追加
- TypeDoc CI が `process` の型解決に失敗していた問題を修正 ([actions/runs/23958922032](https://github.com/xpadev-net/niconicomments/actions/runs/23958922032))
- `check-types` は CLI で `--types node` を渡していたが、TypeDoc は `tsconfig.json` を直接読むため `types` フィールドが必要だった

## Test plan
- [x] `npm run typedoc` がローカルで成功することを確認
- [x] `npm run check-types` が引き続き成功することを確認

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes TypeDoc CI failures by adding `"types": ["node"]` to `tsconfig.json`, aligning it with the `--types node` flag already used in the `check-types` npm script. Since TypeDoc reads `tsconfig.json` directly (rather than accepting CLI overrides), it was failing to resolve the `process` global type. The fix is minimal, targeted, and consistent with the project's existing approach — `@types/node` is already a devDependency.

- Added `"types": ["node"]` to `compilerOptions` in `tsconfig.json`
- No functional changes to the build output or type declarations
- Consistent with the existing `check-types` script that already passes `--types node` via CLI

<h3>Confidence Score: 5/5</h3>

Safe to merge — single config-only change that corrects a CI failure with no functional impact.

The change is a one-field addition to `tsconfig.json` that mirrors an already-working CLI flag, `@types/node` is confirmed in devDependencies, and there is no impact on emitted output or public API types.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tsconfig.json | Adds `"types": ["node"]` to align TypeDoc's type resolution with the existing `--types node` flag already passed to `tsc` in the `check-types` script. `@types/node` is present as a devDependency. One minor nit: the now-redundant commented-out `types` template on line 55 could be removed. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[npm run check-types] -->|passes --types node via CLI| B[tsc resolves @types/node ✅]
    C[npm run typedoc] -->|reads tsconfig.json directly| D{types field present?}
    D -- Before PR: No --> E[process type unresolved ❌]
    D -- After PR: Yes, node --> F[process type resolved ✅]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tsconfig.json`, line 55 ([link](https://github.com/xpadev-net/niconicomments/blob/22411277cffb9a55349bcfad7570771d8675ee61/tsconfig.json#L55)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Stale commented-out `types` template**

   Now that `"types"` is actively configured above (line 10–12), this commented-out placeholder is redundant and slightly misleading — a reader could mistake it for an alternate / disabled configuration. Consider removing it.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: tsconfig.json
   Line: 55

   Comment:
   **Stale commented-out `types` template**

   Now that `"types"` is actively configured above (line 10–12), this commented-out placeholder is redundant and slightly misleading — a reader could mistake it for an alternate / disabled configuration. Consider removing it.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <sub>Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!</sub>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: tsconfig.json
Line: 55

Comment:
**Stale commented-out `types` template**

Now that `"types"` is actively configured above (line 10–12), this commented-out placeholder is redundant and slightly misleading — a reader could mistake it for an alternate / disabled configuration. Consider removing it.

```suggestion
    //"typeRoots": [],                       /* List of folders to include type definitions from. */
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: add node types to tsconfig for type..."](https://github.com/xpadev-net/niconicomments/commit/22411277cffb9a55349bcfad7570771d8675ee61) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27308203)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript configuration to include Node.js type declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->