### PR TITLE
fix: invalidate WebGL texture cache when canvas is returned to pool

### DIFF
--- a/src/renderer/canvas.ts
+++ b/src/renderer/canvas.ts
@@ -29,13 +29,16 @@ class CanvasRenderer implements IRenderer {
 
   /** プールから取得した canvas かどうか (destroy 時にプールに返却するため) */
   private readonly pooled: boolean;
+  private readonly _onDestroy?: () => void;
 
   constructor(
     canvas?: HTMLCanvasElement,
     video?: HTMLVideoElement,
     padding = 0,
+    onDestroy?: () => void,
   ) {
     this.pooled = !canvas;
+    this._onDestroy = onDestroy;
     this.canvas = canvas ?? canvasPool.acquire();
     const context = this.canvas.getContext("2d");
     if (!context) throw new CanvasRenderingContext2DError();
@@ -200,6 +203,7 @@ class CanvasRenderer implements IRenderer {
   }
 
   destroy() {
+    this._onDestroy?.();
     if (this.pooled) {
       canvasPool.release(this.canvas);
     }

--- a/src/renderer/webgl2.ts
+++ b/src/renderer/webgl2.ts
@@ -654,12 +654,9 @@ class WebGL2Renderer implements IRenderer {
   }
 
   getCanvas(padding = 0): IRenderer {
-    const inner = new CanvasRenderer(undefined, undefined, padding);
-    const origDestroy = inner.destroy.bind(inner);
-    inner.destroy = () => {
+    const inner = new CanvasRenderer(undefined, undefined, padding, () => {
       this.invalidateImage(inner);
-      origDestroy();
-    };
+    });
     return inner;
   }
 

--- a/src/renderer/webgl2.ts
+++ b/src/renderer/webgl2.ts
@@ -654,7 +654,13 @@ class WebGL2Renderer implements IRenderer {
   }
 
   getCanvas(padding = 0): IRenderer {
-    return new CanvasRenderer(undefined, undefined, padding);
+    const inner = new CanvasRenderer(undefined, undefined, padding);
+    const origDestroy = inner.destroy.bind(inner);
+    inner.destroy = () => {
+      this.invalidateImage(inner);
+      origDestroy();
+    };
+    return inner;
   }
 
   /* ═══ IRenderer: Drawing ═══ */


### PR DESCRIPTION
## Summary

- WebGLレンダラーで再生後に巻き戻して再度再生すると、コメントが歪んで重複表示される不具合を修正
- `canvasPool`に返却されたキャンバスの古いGPUテクスチャが`texMap`に残り、再利用時に誤ったテクスチャ・サイズ情報で描画されることが原因
- `WebGL2Renderer.getCanvas()`で返す`CanvasRenderer`の`destroy()`をラップし、プール返却前に`invalidateImage()`でテクスチャキャッシュを無効化するよう修正

## Test plan

- [ ] WebGLレンダラーでコメント付き動画を再生
- [ ] 途中で巻き戻し、再度再生してコメントが正常に表示されることを確認
- [ ] 複数回のシーク操作でもコメント表示が崩れないことを確認
- [ ] Canvas2Dレンダラーへのフォールバック時に影響がないことを確認

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a visual corruption bug in the WebGL renderer where rewinding and replaying a video caused comments to render distorted or duplicated. The root cause was stale GPU texture entries in `texMap` persisting after a `CanvasRenderer`'s underlying canvas was returned to `canvasPool` for reuse.

The fix introduces an `onDestroy` callback parameter to `CanvasRenderer`'s constructor (replacing the previously reviewed monkey-patching approach), and `WebGL2Renderer.getCanvas()` passes a hook that calls `invalidateImage(inner)` before pool release — ensuring the texture cache is always cleared at the right moment.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is correct, well-scoped, and addresses the previously flagged monkey-patching concern.

Both changed files have no P0/P1 issues. The `onDestroy` callback is invoked before `canvasPool.release()`, ensuring `inner.canvas` is still keyed in `texMap` when `invalidateImage` runs. Edge cases (double-destroy, WebGL2Renderer destroyed first) are handled gracefully. All remaining observations are at most P2.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/renderer/canvas.ts | Adds optional `onDestroy` callback to `CanvasRenderer` constructor, invoked at the start of `destroy()` before the canvas is returned to the pool — clean, minimal change with correct ordering. |
| src/renderer/webgl2.ts | Replaces the previous instance monkey-patching pattern in `getCanvas()` with the constructor callback approach; passes an `onDestroy` hook that calls `invalidateImage(inner)` before pool release, correctly eliminating stale GPU texture cache entries. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant WebGL2Renderer
    participant CanvasRenderer
    participant canvasPool
    participant texMap

    Caller->>WebGL2Renderer: getCanvas(padding)
    WebGL2Renderer->>canvasPool: acquire()
    canvasPool-->>WebGL2Renderer: canvas
    WebGL2Renderer->>CanvasRenderer: new CanvasRenderer(undefined, undefined, padding, onDestroy)
    WebGL2Renderer-->>Caller: inner (IRenderer)

    note over Caller,texMap: rendering happens - texMap is populated

    Caller->>CanvasRenderer: destroy()
    CanvasRenderer->>WebGL2Renderer: onDestroy() invalidateImage(inner)
    WebGL2Renderer->>texMap: delete(inner.canvas) + _deleteTiles()
    CanvasRenderer->>canvasPool: release(canvas)
    note over canvasPool,texMap: Canvas safely reusable with no stale GPU texture
```

<sub>Reviews (2): Last reviewed commit: ["refactor: use onDestroy callback instead..."](https://github.com/xpadev-net/niconicomments/commit/44275108f61e99fa406d0a90c7765b704ba60fd1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27309777)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced renderer cleanup and image invalidation mechanisms to improve internal consistency during canvas lifecycle management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->