### PR TITLE
fix: harden sample CDN version loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm： https://www.npmjs.com/package/@xpadev-net/niconicomments
 ## Installation
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@xpadev-net/niconicomments@latest/dist/bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@xpadev-net/niconicomments@0.2.78/dist/bundle.min.js"></script>
 ```
 
 or
@@ -48,4 +48,4 @@ setInterval(
 ### このライブラリを使用される方へ
 
 このライブラリを使用するかどうかに関わらず、リアルタイムでコメントを取得、画面を描画、コメントの投稿という一連の流れを実装した場合、ニコニコの特許を侵害する可能性があります  
-詳しくはこちら[ニコニコが保有する特許について](https://github.com/xpadev-net/niconicomments/blob/develop/ABOUT_PATENT.md)を参照してください  
+詳しくはこちら[ニコニコが保有する特許について](https://github.com/xpadev-net/niconicomments/blob/develop/ABOUT_PATENT.md)を参照してください

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@
         <p>NodeJS:</p>
         <pre><code>npm i @xpadev-net/niconicomments</code></pre>
         <p>Web:</p>
-        <pre><code><span class="blue">&lt;script <span class="yellow">src=</span><span class="green">&quot;https://cdn.jsdelivr.net/npm/@xpadev-net/niconicomments@latest/dist/bundle.min.js&quot;</span>&gt;&lt;/script&gt;</span></code></pre>
+        <pre><code><span class="blue">&lt;script <span class="yellow">src=</span><span class="green">&quot;https://cdn.jsdelivr.net/npm/@xpadev-net/niconicomments@0.2.78/dist/bundle.min.js&quot;</span>&gt;&lt;/script&gt;</span></code></pre>
       </section>
       <section id="example">
         <h2>Example</h2>

--- a/docs/sample/sample.js
+++ b/docs/sample/sample.js
@@ -20,11 +20,10 @@ const VERSION_PARAM_CONFIG = {
     defaultValue: DEFAULT_NIWANGO_VERSION,
   },
 };
-const SIMPLE_SEMVER_RANGE_RE =
-  /^(?:[~^]|>=|<=|>|<|=)?v?(?:0|[1-9]\d*|[xX*])(?:\.(?:0|[1-9]\d*|[xX*])){0,2}(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
-const SAFE_VERSION_CHARS_RE = /^[0-9A-Za-z.*^~<>=-]+$/;
+const EXACT_SEMVER_RE =
+  /^v?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const SAFE_VERSION_CHARS_RE = /^[0-9A-Za-z.-]+$/;
 const RAW_BLOCKED_VERSION_CHARS_RE = /[%/?#\\]/;
-const BLOCKED_VERSION_CHARS_RE = /[@:/?#\\]/;
 const getControlsBarHeight = () =>
   parseFloat(
     getComputedStyle(document.documentElement).getPropertyValue(
@@ -63,8 +62,7 @@ const isSafeVersionValue = (value, aliases) => {
   if (aliases.has(value)) return true;
   if (!value || value.length > MAX_VERSION_LENGTH) return false;
   if (!SAFE_VERSION_CHARS_RE.test(value)) return false;
-  if (BLOCKED_VERSION_CHARS_RE.test(value)) return false;
-  return SIMPLE_SEMVER_RANGE_RE.test(value);
+  return EXACT_SEMVER_RE.test(value);
 };
 
 const readVersionParam = (paramName) => {
@@ -510,7 +508,13 @@ const showScriptError = (message) => {
 
 let versionWarningShown = false;
 const showVersionWarning = () => {
-  if (versionWarningShown || invalidVersionParams.length === 0) return;
+  if (
+    versionWarningShown ||
+    invalidVersionParams.length === 0 ||
+    !document.body
+  ) {
+    return;
+  }
   versionWarningShown = true;
   const el = document.createElement("div");
   el.style.cssText =
@@ -524,7 +528,13 @@ const showVersionWarning = () => {
     `${invalidParamNames.join(", ")}. Using safe defaults instead.`;
   document.body.appendChild(el);
 };
-showVersionWarning();
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", showVersionWarning, {
+    once: true,
+  });
+} else {
+  showVersionWarning();
+}
 
 const formatTime = (sec) => {
   const h = Math.floor(sec / 3600);

--- a/docs/sample/sample.js
+++ b/docs/sample/sample.js
@@ -2,6 +2,29 @@ const NC_DEV_URL =
   "https://cdn.jsdelivr.net/gh/xpadev-net/niconicomments@dev-build/dist/bundle.js";
 const NIWANGO_DEV_URL =
   "https://cdn.jsdelivr.net/gh/xpadev-net/niwango.js@dev-build/dist/bundle.js";
+const DEFAULT_NC_VERSION = "dev";
+const DEFAULT_PLUGIN_VERSION = "latest";
+const DEFAULT_NIWANGO_VERSION = "dev-build";
+const MAX_VERSION_LENGTH = 64;
+const VERSION_PARAM_CONFIG = {
+  ncVersion: {
+    aliases: new Set([DEFAULT_NC_VERSION]),
+    defaultValue: DEFAULT_NC_VERSION,
+  },
+  pluginVersion: {
+    aliases: new Set([DEFAULT_PLUGIN_VERSION]),
+    defaultValue: DEFAULT_PLUGIN_VERSION,
+  },
+  niwangoVersion: {
+    aliases: new Set([DEFAULT_NIWANGO_VERSION]),
+    defaultValue: DEFAULT_NIWANGO_VERSION,
+  },
+};
+const SIMPLE_SEMVER_RANGE_RE =
+  /^(?:[~^]|>=|<=|>|<|=)?v?(?:0|[1-9]\d*|[xX*])(?:\.(?:0|[1-9]\d*|[xX*])){0,2}(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
+const SAFE_VERSION_CHARS_RE = /^[0-9A-Za-z.*^~<>=-]+$/;
+const RAW_BLOCKED_VERSION_CHARS_RE = /[%/?#\\]/;
+const BLOCKED_VERSION_CHARS_RE = /[@:/?#\\]/;
 const getControlsBarHeight = () =>
   parseFloat(
     getComputedStyle(document.documentElement).getPropertyValue(
@@ -10,12 +33,79 @@ const getControlsBarHeight = () =>
   ) || 0;
 
 const urlParams = new URLSearchParams(window.location.search);
+const rawQueryString = window.location.search.startsWith("?")
+  ? window.location.search.slice(1)
+  : "";
+
+const getRawQueryParamValue = (name) => {
+  const encodedName = encodeURIComponent(name);
+  for (const pair of rawQueryString.split("&")) {
+    if (!pair) continue;
+    const separatorIndex = pair.indexOf("=");
+    const rawName =
+      separatorIndex === -1 ? pair : pair.slice(0, separatorIndex);
+    if (rawName !== encodedName) continue;
+    return separatorIndex === -1 ? "" : pair.slice(separatorIndex + 1);
+  }
+  return null;
+};
+
+const invalidVersionParams = [];
+const markInvalidVersionParam = (paramName, reason) => {
+  invalidVersionParams.push({
+    paramName,
+    reason,
+  });
+  return VERSION_PARAM_CONFIG[paramName].defaultValue;
+};
+
+const isSafeVersionValue = (value, aliases) => {
+  if (aliases.has(value)) return true;
+  if (!value || value.length > MAX_VERSION_LENGTH) return false;
+  if (!SAFE_VERSION_CHARS_RE.test(value)) return false;
+  if (BLOCKED_VERSION_CHARS_RE.test(value)) return false;
+  return SIMPLE_SEMVER_RANGE_RE.test(value);
+};
+
+const readVersionParam = (paramName) => {
+  const rawValue = getRawQueryParamValue(paramName);
+  if (rawValue == null) {
+    return VERSION_PARAM_CONFIG[paramName].defaultValue;
+  }
+  if (
+    rawValue.length === 0 ||
+    rawValue.length > MAX_VERSION_LENGTH ||
+    RAW_BLOCKED_VERSION_CHARS_RE.test(rawValue)
+  ) {
+    return markInvalidVersionParam(paramName, "unsafe raw value");
+  }
+  const decodedValue = urlParams.get(paramName);
+  if (
+    decodedValue == null ||
+    !isSafeVersionValue(decodedValue, VERSION_PARAM_CONFIG[paramName].aliases)
+  ) {
+    return markInvalidVersionParam(paramName, "unsafe decoded value");
+  }
+  return decodedValue;
+};
+
 let video = Number(urlParams.get("video") || 0),
   noVideo = !!urlParams.get("novideo"),
   time = Number(urlParams.get("time") || -1);
-const ncVersion = urlParams.get("ncVersion") || "dev";
-const pluginVersion = urlParams.get("pluginVersion") || "latest";
-const niwangoVersion = urlParams.get("niwangoVersion") || "dev-build";
+const ncVersion = readVersionParam("ncVersion");
+const pluginVersion = readVersionParam("pluginVersion");
+const niwangoVersion = readVersionParam("niwangoVersion");
+
+for (const { paramName } of invalidVersionParams) {
+  urlParams.set(paramName, VERSION_PARAM_CONFIG[paramName].defaultValue);
+}
+if (invalidVersionParams.length > 0) {
+  const sanitizedSearch = urlParams.toString();
+  const nextUrl = `${window.location.pathname}${
+    sanitizedSearch ? `?${sanitizedSearch}` : ""
+  }${window.location.hash}`;
+  window.history.replaceState(null, "", nextUrl);
+}
 
 // --- Dynamic script loading ---
 const loadScript = (src) =>
@@ -27,16 +117,17 @@ const loadScript = (src) =>
     document.head.appendChild(s);
   });
 
+const encodeVersionForUrl = (value) => encodeURIComponent(value);
 const getNCUrl = (v) =>
   v === "dev"
     ? NC_DEV_URL
-    : `https://cdn.jsdelivr.net/npm/@xpadev-net/niconicomments@${v}/dist/bundle.min.js`;
+    : `https://cdn.jsdelivr.net/npm/@xpadev-net/niconicomments@${encodeVersionForUrl(v)}/dist/bundle.min.js`;
 const getPluginUrl = (v) =>
-  `https://cdn.jsdelivr.net/npm/@xpadev-net/niconicomments-plugin-niwango@${v}/dist/bundle.min.js`;
+  `https://cdn.jsdelivr.net/npm/@xpadev-net/niconicomments-plugin-niwango@${encodeVersionForUrl(v)}/dist/bundle.min.js`;
 const getNiwangoUrl = (v) =>
   v === "dev-build"
     ? NIWANGO_DEV_URL
-    : `https://cdn.jsdelivr.net/npm/@xpadev-net/niwango@${v}/dist/bundle.js`;
+    : `https://cdn.jsdelivr.net/npm/@xpadev-net/niwango@${encodeVersionForUrl(v)}/dist/bundle.js`;
 
 let resolveScripts;
 let scriptsLoadError = null;
@@ -416,6 +507,24 @@ const showScriptError = (message) => {
     `Script load failed (ncVersion=${ncVersion}, pluginVersion=${pluginVersion}, niwangoVersion=${niwangoVersion}). Check version selectors.`;
   document.body.appendChild(el);
 };
+
+let versionWarningShown = false;
+const showVersionWarning = () => {
+  if (versionWarningShown || invalidVersionParams.length === 0) return;
+  versionWarningShown = true;
+  const el = document.createElement("div");
+  el.style.cssText =
+    "position:fixed;top:0;left:0;right:0;z-index:99;background:#8a4b00;" +
+    "color:#fff;padding:12px 16px;font-family:monospace;font-size:13px;";
+  const invalidParamNames = invalidVersionParams.map(
+    ({ paramName }) => paramName,
+  );
+  el.textContent =
+    `Ignored unsafe version query parameter${invalidParamNames.length > 1 ? "s" : ""}: ` +
+    `${invalidParamNames.join(", ")}. Using safe defaults instead.`;
+  document.body.appendChild(el);
+};
+showVersionWarning();
 
 const formatTime = (sec) => {
   const h = Math.floor(sec / 3600);


### PR DESCRIPTION
## Summary
- sanitize sample version query params before constructing CDN URLs
- fall back to safe defaults and surface a warning for rejected values
- pin docs install examples instead of recommending mutable @latest

## Validation
- pnpm exec biome check docs/sample/sample.js
- pnpm check-types
- pnpm build
- local VM sanity check for malicious and valid version query strings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens the sample demo page against URL-parameter injection by replacing direct `URLSearchParams.get()` usage with a two-layer validation pipeline: raw-query inspection (blocking `%`, `/`, `?`, `#`, `\`) followed by a decoded-value check against a character whitelist and a strict exact-semver regex. Rejected values fall back to safe defaults, the address bar is sanitised via `history.replaceState`, a visible warning banner is shown, and CDN URL construction is wrapped with `encodeURIComponent`. Documentation install examples are pinned from `@latest` to `@0.2.78`.

- **`docs/sample/sample.js`** — adds `getRawQueryParamValue`, `isSafeVersionValue`, and `readVersionParam`; replaces plain `urlParams.get()` calls; adds history sanitisation and the `showVersionWarning` banner.
- **`README.md` / `docs/index.html`** — pins the CDN `<script>` install snippet from the mutable `@latest` tag to the concrete `@0.2.78` release.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the validation logic is layered and correct, with no reachable bypass identified.

All three changed files contain straightforward, low-risk edits. The version-param validation in sample.js uses two independent checks (raw-char blocklist, then decoded-value whitelist + strict semver regex) with no gap between them. Range operators are now excluded by the whitelist, CDN URLs are constructed with encodeURIComponent, and the fallback-and-warn path is exercised for any rejected value.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/sample/sample.js | Major rework of version-param handling: manual raw-query parsing with RAW_BLOCKED_VERSION_CHARS_RE + SAFE_VERSION_CHARS_RE + EXACT_SEMVER_RE layered validation, fallback-to-default on rejection, history.replaceState sanitisation, and encodeURIComponent on CDN URL construction. |
| README.md | Pins install example from @latest to @0.2.78 and adds trailing newline. |
| docs/index.html | Pins CDN script tag from @latest to @0.2.78. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["URL query string"] --> B["getRawQueryParamValue(paramName)"]
    B -->|"null (param absent)"| C["Return defaultValue"]
    B -->|"raw string"| D{"rawValue empty or > 64 chars or RAW_BLOCKED_VERSION_CHARS_RE"}
    D -->|yes| E["markInvalidVersionParam"]
    D -->|no| F["URLSearchParams.get -> decodedValue"]
    F -->|"null"| E
    F -->|"string"| G{"isSafeVersionValue"}
    G -->|"alias match"| H["Return decodedValue"]
    G -->|"SAFE_VERSION_CHARS_RE pass"| I{"EXACT_SEMVER_RE"}
    I -->|pass| H
    I -->|fail| E
    G -->|"fails char whitelist"| E
    E --> J["Push to invalidVersionParams / Return defaultValue"]
    H --> K["encodeVersionForUrl -> CDN URL"]
    J --> L["history.replaceState with sanitised params"]
    J --> M["showVersionWarning banner"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/dev..."](https://github.com/xpadev-net/niconicomments/commit/8434eb6c0fc7a2ef88c5d01926e0bae9481db815) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35212929)</sub>

<!-- /greptile_comment -->