### PR TITLE
Harden workflow token handling

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -47,6 +47,7 @@ jobs:
           name: dev-build-artifacts
           path: dev-build-artifacts.tgz
           if-no-files-found: error
+          retention-days: 1
 
   push-dev-build:
     needs: build

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -16,18 +16,18 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a
         name: Install pnpm
         with:
           version: 11
           run_install: false
 
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 24
           cache: 'pnpm'
@@ -42,7 +42,7 @@ jobs:
         run: tar -czf dev-build-artifacts.tgz dist/bundle.js
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: dev-build-artifacts
           path: dev-build-artifacts.tgz

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -1,8 +1,5 @@
 name: Dev Build
 
-permissions:
-  contents: write
-
 on:
   push:
     branches: [develop]
@@ -14,10 +11,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  dev-build:
+  build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@v6
         name: Install pnpm
@@ -37,14 +38,43 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Package build artifact
+        run: tar -czf dev-build-artifacts.tgz dist/bundle.js
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dev-build-artifacts
+          path: dev-build-artifacts.tgz
+          if-no-files-found: error
+
+  push-dev-build:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          token: ''
+          persist-credentials: false
+
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dev-build-artifacts
+          path: ${{ runner.temp }}/dev-build-artifacts
+
       - name: Push to dev-build branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.email "github-actions@xpadev.net"
           git config user.name "github-actions"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git checkout --orphan dev-build
           git rm -rf . --quiet || true
+          tar -xzf "${RUNNER_TEMP}/dev-build-artifacts/dev-build-artifacts.tgz"
           git add dist/bundle.js -f
           git commit -m "dev build"
           git push -f origin dev-build

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -51,6 +51,7 @@ jobs:
   push-dev-build:
     needs: build
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/develop'
     permissions:
       contents: write
     steps:

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -42,7 +42,7 @@ jobs:
         run: tar -czf dev-build-artifacts.tgz dist/bundle.js
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: dev-build-artifacts
           path: dev-build-artifacts.tgz

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -54,13 +54,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          token: ''
           persist-credentials: false
 
       - name: Download build artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: dev-build-artifacts
           path: ${{ runner.temp }}/dev-build-artifacts

--- a/.github/workflows/release-publish-package.yml
+++ b/.github/workflows/release-publish-package.yml
@@ -1,9 +1,5 @@
 name: publish package
 
-permissions:
-  contents: write
-  id-token: write
-
 on:
   push:
     branches:
@@ -11,11 +7,16 @@ on:
   workflow_dispatch:
 
 jobs:
-  release:
+  publish:
     name: Publish npm package
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@v6
         name: Install pnpm
@@ -38,8 +39,15 @@ jobs:
       - name: Publish package
         run: npm publish --provenance
 
+  release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    needs: publish
+    permissions:
+      contents: write
+    steps:
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:
           tag_name: ${{ github.ref_name }}
           name: Release ${{ github.ref_name }}

--- a/.github/workflows/release-publish-package.yml
+++ b/.github/workflows/release-publish-package.yml
@@ -46,10 +46,6 @@ jobs:
     permissions:
       contents: write # Create the GitHub release for the published ref.
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          persist-credentials: false
-
       - name: Create GitHub release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:

--- a/.github/workflows/release-publish-package.yml
+++ b/.github/workflows/release-publish-package.yml
@@ -11,8 +11,8 @@ jobs:
     name: Publish npm package
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      id-token: write
+      contents: read # Checkout repository contents for the publish build.
+      id-token: write # Request an OIDC token for npm provenance.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: publish
     permissions:
-      contents: write
+      contents: write # Create the GitHub release for the published ref.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:

--- a/.github/workflows/release-publish-package.yml
+++ b/.github/workflows/release-publish-package.yml
@@ -14,18 +14,18 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a
         name: Install pnpm
         with:
           version: 11
           run_install: false
 
       - name: Install Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: '24'
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/release-publish-package.yml
+++ b/.github/workflows/release-publish-package.yml
@@ -46,6 +46,10 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:

--- a/.github/workflows/release-typedoc.yml
+++ b/.github/workflows/release-typedoc.yml
@@ -2,6 +2,10 @@
 
 name: TypeDoc
 
+concurrency:
+  group: ${{ github.repository }}-typedoc
+  cancel-in-progress: true
+
 # Controls when the workflow will run
 on:
   # Triggers the workflow on push or pull request events but only for the master branch

--- a/.github/workflows/release-typedoc.yml
+++ b/.github/workflows/release-typedoc.yml
@@ -23,19 +23,19 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           persist-credentials: false
 
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a
         name: Install pnpm
         with:
           version: 11
           run_install: false
 
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: 24
           cache: 'pnpm'
@@ -57,7 +57,7 @@ jobs:
         run: tar -czf typedoc-artifacts.tgz .gitignore docs/type dist/bundle.js
 
       - name: Upload generated artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: typedoc-artifacts
           path: typedoc-artifacts.tgz

--- a/.github/workflows/release-typedoc.yml
+++ b/.github/workflows/release-typedoc.yml
@@ -66,6 +66,7 @@ jobs:
   push-typedoc:
     needs: typedoc
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release-typedoc.yml
+++ b/.github/workflows/release-typedoc.yml
@@ -57,7 +57,7 @@ jobs:
         run: tar -czf typedoc-artifacts.tgz .gitignore docs/type dist/bundle.js
 
       - name: Upload generated artifacts
-        uses: actions/upload-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: typedoc-artifacts
           path: typedoc-artifacts.tgz

--- a/.github/workflows/release-typedoc.yml
+++ b/.github/workflows/release-typedoc.yml
@@ -69,13 +69,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
-          token: ''
           persist-credentials: false
 
       - name: Download generated artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: typedoc-artifacts
           path: ${{ runner.temp }}/typedoc-artifacts

--- a/.github/workflows/release-typedoc.yml
+++ b/.github/workflows/release-typedoc.yml
@@ -62,6 +62,7 @@ jobs:
           name: typedoc-artifacts
           path: typedoc-artifacts.tgz
           if-no-files-found: error
+          retention-days: 1
 
   push-typedoc:
     needs: typedoc

--- a/.github/workflows/release-typedoc.yml
+++ b/.github/workflows/release-typedoc.yml
@@ -1,8 +1,6 @@
 # This is a basic workflow to help you get started with Actions
 
 name: TypeDoc
-permissions:
-  contents: write
 
 # Controls when the workflow will run
 on:
@@ -19,11 +17,15 @@ jobs:
   typedoc:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
 
       - uses: pnpm/action-setup@v6
@@ -51,13 +53,43 @@ jobs:
       - name: generate dev build
         run: pnpm build
 
+      - name: Package generated artifacts
+        run: tar -czf typedoc-artifacts.tgz .gitignore docs/type dist/bundle.js
+
+      - name: Upload generated artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: typedoc-artifacts
+          path: typedoc-artifacts.tgz
+          if-no-files-found: error
+
+  push-typedoc:
+    needs: typedoc
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          token: ''
+          persist-credentials: false
+
+      - name: Download generated artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: typedoc-artifacts
+          path: ${{ runner.temp }}/typedoc-artifacts
+
       - name: Create new Branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.email "github-actions@xpadev.net"
           git config user.name "github-actions"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git checkout -b typedoc
+          git rm -rf . --quiet || true
+          tar -xzf "${RUNNER_TEMP}/typedoc-artifacts/typedoc-artifacts.tgz"
           cp -f ./dist/bundle.js ./docs/
           git add .
           git commit -m "auto generate" -n


### PR DESCRIPTION
## Summary
- split release publish from GitHub release creation so write contents access is only granted to the release job
- split dev-build and typedoc workflows into read-only build jobs plus write-only push jobs with artifact handoff
- disable persisted checkout credentials and pin the write-capable release action to an immutable revision

## Validation
- pnpm lint
- pnpm check-types
- YAML parse sanity check
- git diff --check
- deep-review self-review plus independent workflow-security review

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens the GitHub Actions workflows by splitting broad-permission jobs into lean read-only build jobs plus minimal write-only push/release jobs, pinning every action to an immutable SHA, disabling persisted checkout credentials, and introducing a tarball artifact handoff between the split jobs.

- **dev-build.yml**: Splits the old `dev-build` job into `build` (`contents: read`, SHA-pinned) and `push-dev-build` (`contents: write`, SHA-pinned), using `actions/upload-artifact` / `actions/download-artifact` to transfer the built `dist/bundle.js`.
- **release-publish-package.yml**: Separates `publish` (`contents: read`, `id-token: write`, SHA-pinned) from `release` (`contents: write`, using SHA-pinned `softprops/action-gh-release`) so OIDC token scope is never co-present with write-to-contents scope.
- **release-typedoc.yml**: Same split pattern as dev-build, plus adds a workflow-level `concurrency` group; all actions SHA-pinned throughout.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — the hardening goals are fully achieved and all previously flagged issues have been addressed in the current HEAD.

Every action across all three workflows is now pinned to an immutable SHA. Write-capable jobs carry only the narrowest permission required and use only SHA-pinned actions. The build/push split is implemented consistently across all three workflows, and the credential isolation pattern (persist-credentials: false + explicit remote-URL token injection) is applied uniformly.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/dev-build.yml | Cleanly split into read-only build job and write-only push job; all actions SHA-pinned; credential isolation achieved via persist-credentials: false plus explicit remote-URL token injection in the push step. |
| .github/workflows/release-publish-package.yml | publish job narrowed to contents: read + id-token: write with all three actions SHA-pinned; release job is minimal (contents: write, single SHA-pinned action, no checkout needed since all release params are explicit API calls). |
| .github/workflows/release-typedoc.yml | Same split pattern as dev-build; workflow-level concurrency group added; all actions SHA-pinned; push-typedoc correctly uses persist-credentials: false and manually injects the token via git remote set-url. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph dev-build.yml
        A[push to develop / workflow_dispatch] --> B[build
contents: read
SHA-pinned actions]
        B -->|upload artifact| C[push-dev-build
contents: write
SHA-pinned actions]
        C --> D[git push -f origin dev-build]
    end

    subgraph release-publish-package.yml
        E[push to master / workflow_dispatch] --> F[publish
contents: read
id-token: write
SHA-pinned actions]
        F -->|npm publish --provenance| G[release
contents: write
SHA-pinned softprops action]
        G --> H[GitHub Release created]
    end

    subgraph release-typedoc.yml
        I[push to master / workflow_dispatch] --> J[typedoc
contents: read
SHA-pinned actions]
        J -->|upload artifact| K[push-typedoc
contents: write
SHA-pinned actions]
        K --> L[git push -f origin typedoc]
    end
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/release-publish-package.yml`, line 17-29 ([link](https://github.com/xpadev-net/niconicomments/blob/be016057daaf1580c99eb78f45ea293c97c45555/.github/workflows/release-publish-package.yml#L17-L29)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **Floating action tags in job with `id-token: write`**

   The `publish` job uses `actions/checkout@v6`, `pnpm/action-setup@v6`, and `actions/setup-node@v6` — all mutable floating tags — while holding `id-token: write`. A hijacked or compromised tag can request an OIDC token during step execution and use it to forge npm provenance attestations or exfiltrate the credential to an external service. The `release` job in the same file correctly pins `softprops/action-gh-release` to an immutable SHA, and all three other jobs introduced by this PR (`build`, `push-dev-build`, `push-typedoc`) are SHA-pinned throughout; applying the same treatment here would make the hardening consistent.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/release-publish-package.yml
   Line: 17-29

   Comment:
   **Floating action tags in job with `id-token: write`**

   The `publish` job uses `actions/checkout@v6`, `pnpm/action-setup@v6`, and `actions/setup-node@v6` — all mutable floating tags — while holding `id-token: write`. A hijacked or compromised tag can request an OIDC token during step execution and use it to forge npm provenance attestations or exfiltrate the credential to an external service. The `release` job in the same file correctly pins `softprops/action-gh-release` to an immutable SHA, and all three other jobs introduced by this PR (`build`, `push-dev-build`, `push-typedoc`) are SHA-pinned throughout; applying the same treatment here would make the hardening consistent.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Frelease-publish-package.yml%0ALine%3A%2017-29%0A%0AComment%3A%0A**Floating%20action%20tags%20in%20job%20with%20%60id-token%3A%20write%60**%0A%0AThe%20%60publish%60%20job%20uses%20%60actions%2Fcheckout%40v6%60%2C%20%60pnpm%2Faction-setup%40v6%60%2C%20and%20%60actions%2Fsetup-node%40v6%60%20%E2%80%94%20all%20mutable%20floating%20tags%20%E2%80%94%20while%20holding%20%60id-token%3A%20write%60.%20A%20hijacked%20or%20compromised%20tag%20can%20request%20an%20OIDC%20token%20during%20step%20execution%20and%20use%20it%20to%20forge%20npm%20provenance%20attestations%20or%20exfiltrate%20the%20credential%20to%20an%20external%20service.%20The%20%60release%60%20job%20in%20the%20same%20file%20correctly%20pins%20%60softprops%2Faction-gh-release%60%20to%20an%20immutable%20SHA%2C%20and%20all%20three%20other%20jobs%20introduced%20by%20this%20PR%20%28%60build%60%2C%20%60push-dev-build%60%2C%20%60push-typedoc%60%29%20are%20SHA-pinned%20throughout%3B%20applying%20the%20same%20treatment%20here%20would%20make%20the%20hardening%20consistent.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=xpadev-net%2Fniconicomments&pr=287&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (9): Last reviewed commit: ["Serialize typedoc workflow runs"](https://github.com/xpadev-net/niconicomments/commit/f28e7cbdc655b571db94e1d34ed7d9c19c8ce067) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35213360)</sub>

<!-- /greptile_comment -->