### PR TITLE
Harden Playwright artifact comment workflow

### DIFF
--- a/.github/workflows/pr-test-playwright-comment.yml
+++ b/.github/workflows/pr-test-playwright-comment.yml
@@ -46,103 +46,108 @@ jobs:
               return result(false, 'invalid-pr-number');
             }
 
-            const { data: pr } = await github.rest.pulls.get({
-              owner,
-              repo,
-              pull_number: prNumber,
-            });
-
-            const baseRepo = pr.base.repo?.full_name ?? '';
-            const prHeadRepo = pr.head.repo?.full_name ?? '';
-            const runHeadRepo = run.head_repository?.full_name ?? '';
-            const runHeadSha = run.head_sha ?? '';
-            const isCurrentHead = pr.head.sha === runHeadSha;
-
-            if (pr.state !== 'open') {
-              core.info(`Skipping PR #${prNumber} because it is ${pr.state}`);
-              return result(false, 'pr-not-open', { prNumber });
-            }
-
-            if (baseRepo !== `${owner}/${repo}`) {
-              core.warning(`Unexpected base repo for PR #${prNumber}: ${baseRepo}`);
-              return result(false, 'unexpected-base-repo', { prNumber });
-            }
-
-            if (!runHeadRepo || runHeadRepo !== prHeadRepo) {
-              core.warning(`Head repository mismatch for PR #${prNumber}: workflow_run=${runHeadRepo} pr=${prHeadRepo}`);
-              return result(false, 'head-repo-mismatch', { prNumber });
-            }
-
-            if (!runHeadSha) {
-              core.warning('workflow_run.head_sha is missing');
-              return result(false, 'missing-head-sha', { prNumber });
-            }
-
-            if (!isCurrentHead) {
-              core.info(`Skipping stale run ${run.id}; PR #${prNumber} head is ${pr.head.sha}, run head is ${runHeadSha}`);
-              return result(false, 'stale-run', { prNumber, runHeadSha });
-            }
-
-            const artifacts = await github.paginate(
-              github.rest.actions.listWorkflowRunArtifacts,
-              {
+            try {
+              const { data: pr } = await github.rest.pulls.get({
                 owner,
                 repo,
-                run_id: run.id,
-                per_page: 100,
+                pull_number: prNumber,
+              });
+
+              const baseRepo = pr.base.repo?.full_name ?? '';
+              const prHeadRepo = pr.head.repo?.full_name ?? '';
+              const runHeadRepo = run.head_repository?.full_name ?? '';
+              const runHeadSha = run.head_sha ?? '';
+              const isCurrentHead = pr.head.sha === runHeadSha;
+
+              if (pr.state !== 'open') {
+                core.info(`Skipping PR #${prNumber} because it is ${pr.state}`);
+                return result(false, 'pr-not-open', { prNumber });
               }
-            );
-            const candidateArtifacts = artifacts.filter(artifact => artifactDownloadPattern.test(artifact.name));
-            const invalidArtifacts = candidateArtifacts.filter(artifact => !allowedArtifactPattern.test(artifact.name));
-            const artifactBytes = candidateArtifacts.reduce((sum, artifact) => sum + (artifact.size_in_bytes ?? 0), 0);
-            const expectedArtifactNames = candidateArtifacts
-              .map(artifact => artifact.name)
-              .sort();
 
-            if (invalidArtifacts.length > 0) {
+              if (baseRepo !== `${owner}/${repo}`) {
+                core.warning(`Unexpected base repo for PR #${prNumber}: ${baseRepo}`);
+                return result(false, 'unexpected-base-repo', { prNumber });
+              }
+
+              if (!runHeadRepo || runHeadRepo !== prHeadRepo) {
+                core.warning(`Head repository mismatch for PR #${prNumber}: workflow_run=${runHeadRepo} pr=${prHeadRepo}`);
+                return result(false, 'head-repo-mismatch', { prNumber });
+              }
+
+              if (!runHeadSha) {
+                core.warning('workflow_run.head_sha is missing');
+                return result(false, 'missing-head-sha', { prNumber });
+              }
+
+              if (!isCurrentHead) {
+                core.info(`Skipping stale run ${run.id}; PR #${prNumber} head is ${pr.head.sha}, run head is ${runHeadSha}`);
+                return result(false, 'stale-run', { prNumber, runHeadSha });
+              }
+
+              const artifacts = await github.paginate(
+                github.rest.actions.listWorkflowRunArtifacts,
+                {
+                  owner,
+                  repo,
+                  run_id: run.id,
+                  per_page: 100,
+                }
+              );
+              const candidateArtifacts = artifacts.filter(artifact => artifactDownloadPattern.test(artifact.name));
+              const invalidArtifacts = candidateArtifacts.filter(artifact => !allowedArtifactPattern.test(artifact.name));
+              const artifactBytes = candidateArtifacts.reduce((sum, artifact) => sum + (artifact.size_in_bytes ?? 0), 0);
+              const expectedArtifactNames = candidateArtifacts
+                .map(artifact => artifact.name)
+                .sort();
+
+              if (invalidArtifacts.length > 0) {
+                return result(true, 'trusted', {
+                  prNumber,
+                  runHeadSha,
+                  branchName: '_playwright-artifacts',
+                  testResultsArtifactCount: candidateArtifacts.length,
+                  expectedArtifactNames,
+                  artifactDisposition: 'rejected',
+                  artifactError: `Unexpected artifact names: ${invalidArtifacts.map(artifact => artifact.name).join(', ')}`,
+                });
+              }
+
+              if (candidateArtifacts.length > maxArtifactDirectories) {
+                return result(true, 'trusted', {
+                  prNumber,
+                  runHeadSha,
+                  branchName: '_playwright-artifacts',
+                  testResultsArtifactCount: candidateArtifacts.length,
+                  expectedArtifactNames,
+                  artifactDisposition: 'rejected',
+                  artifactError: `Unexpected test result artifact count: ${candidateArtifacts.length}`,
+                });
+              }
+
+              if (artifactBytes > maxArtifactBytes) {
+                return result(true, 'trusted', {
+                  prNumber,
+                  runHeadSha,
+                  branchName: '_playwright-artifacts',
+                  testResultsArtifactCount: candidateArtifacts.length,
+                  expectedArtifactNames,
+                  artifactDisposition: 'rejected',
+                  artifactError: `Test result artifacts exceed byte limit: ${artifactBytes}`,
+                });
+              }
+
               return result(true, 'trusted', {
                 prNumber,
                 runHeadSha,
                 branchName: '_playwright-artifacts',
                 testResultsArtifactCount: candidateArtifacts.length,
                 expectedArtifactNames,
-                artifactDisposition: 'rejected',
-                artifactError: `Unexpected artifact names: ${invalidArtifacts.map(artifact => artifact.name).join(', ')}`,
+                artifactDisposition: candidateArtifacts.length === 0 ? 'none' : 'download',
               });
+            } catch (error) {
+              core.warning(`Failed to resolve trusted PR context: ${error.message}`);
+              return result(false, 'api-error', { prNumber });
             }
-
-            if (candidateArtifacts.length > maxArtifactDirectories) {
-              return result(true, 'trusted', {
-                prNumber,
-                runHeadSha,
-                branchName: '_playwright-artifacts',
-                testResultsArtifactCount: candidateArtifacts.length,
-                expectedArtifactNames,
-                artifactDisposition: 'rejected',
-                artifactError: `Unexpected test result artifact count: ${candidateArtifacts.length}`,
-              });
-            }
-
-            if (artifactBytes > maxArtifactBytes) {
-              return result(true, 'trusted', {
-                prNumber,
-                runHeadSha,
-                branchName: '_playwright-artifacts',
-                testResultsArtifactCount: candidateArtifacts.length,
-                expectedArtifactNames,
-                artifactDisposition: 'rejected',
-                artifactError: `Test result artifacts exceed byte limit: ${artifactBytes}`,
-              });
-            }
-
-            return result(true, 'trusted', {
-              prNumber,
-              runHeadSha,
-              branchName: '_playwright-artifacts',
-              testResultsArtifactCount: candidateArtifacts.length,
-              expectedArtifactNames,
-              artifactDisposition: candidateArtifacts.length === 0 ? 'none' : 'download',
-            });
 
       - name: Download test results
         id: test-results

--- a/.github/workflows/pr-test-playwright-comment.yml
+++ b/.github/workflows/pr-test-playwright-comment.yml
@@ -25,7 +25,8 @@ jobs:
             const repo = context.repo.repo;
             const run = context.payload.workflow_run;
             const prs = Array.isArray(run.pull_requests) ? run.pull_requests : [];
-            const allowedArtifactPattern = /^test-results-node-(22|24|26)$/;
+            const artifactDownloadPattern = /^test-results-node-.+$/;
+            const allowedArtifactPattern = /^test-results-node-(\d+)$/;
             const maxArtifactDirectories = 3;
             const maxArtifactBytes = 50 * 1024 * 1024;
 
@@ -90,17 +91,34 @@ jobs:
                 per_page: 100,
               }
             );
-            const testResultArtifacts = artifacts.filter(artifact => allowedArtifactPattern.test(artifact.name));
-            const artifactBytes = testResultArtifacts.reduce((sum, artifact) => sum + (artifact.size_in_bytes ?? 0), 0);
+            const candidateArtifacts = artifacts.filter(artifact => artifactDownloadPattern.test(artifact.name));
+            const invalidArtifacts = candidateArtifacts.filter(artifact => !allowedArtifactPattern.test(artifact.name));
+            const artifactBytes = candidateArtifacts.reduce((sum, artifact) => sum + (artifact.size_in_bytes ?? 0), 0);
+            const expectedArtifactNames = candidateArtifacts
+              .map(artifact => artifact.name)
+              .sort();
 
-            if (testResultArtifacts.length > maxArtifactDirectories) {
+            if (invalidArtifacts.length > 0) {
               return result(true, 'trusted', {
                 prNumber,
                 runHeadSha,
                 branchName: '_playwright-artifacts',
-                testResultsArtifactCount: testResultArtifacts.length,
+                testResultsArtifactCount: candidateArtifacts.length,
+                expectedArtifactNames,
                 artifactDisposition: 'rejected',
-                artifactError: `Unexpected test result artifact count: ${testResultArtifacts.length}`,
+                artifactError: `Unexpected artifact names: ${invalidArtifacts.map(artifact => artifact.name).join(', ')}`,
+              });
+            }
+
+            if (candidateArtifacts.length > maxArtifactDirectories) {
+              return result(true, 'trusted', {
+                prNumber,
+                runHeadSha,
+                branchName: '_playwright-artifacts',
+                testResultsArtifactCount: candidateArtifacts.length,
+                expectedArtifactNames,
+                artifactDisposition: 'rejected',
+                artifactError: `Unexpected test result artifact count: ${candidateArtifacts.length}`,
               });
             }
 
@@ -109,7 +127,8 @@ jobs:
                 prNumber,
                 runHeadSha,
                 branchName: '_playwright-artifacts',
-                testResultsArtifactCount: testResultArtifacts.length,
+                testResultsArtifactCount: candidateArtifacts.length,
+                expectedArtifactNames,
                 artifactDisposition: 'rejected',
                 artifactError: `Test result artifacts exceed byte limit: ${artifactBytes}`,
               });
@@ -119,8 +138,9 @@ jobs:
               prNumber,
               runHeadSha,
               branchName: '_playwright-artifacts',
-              testResultsArtifactCount: testResultArtifacts.length,
-              artifactDisposition: testResultArtifacts.length === 0 ? 'none' : 'download',
+              testResultsArtifactCount: candidateArtifacts.length,
+              expectedArtifactNames,
+              artifactDisposition: candidateArtifacts.length === 0 ? 'none' : 'download',
             });
 
       - name: Download test results
@@ -135,8 +155,8 @@ jobs:
           merge-multiple: false
         continue-on-error: true
 
-      - name: Post failure screenshots to PR
-        if: ${{ github.event.workflow_run.conclusion == 'failure' && fromJSON(steps.pr-context.outputs.result).trusted }}
+      - name: Sync failure screenshots comment
+        if: ${{ fromJSON(steps.pr-context.outputs.result).trusted }}
         uses: actions/github-script@v9
         env:
           DOWNLOAD_OUTCOME: ${{ steps.test-results.outcome }}
@@ -149,16 +169,23 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
             const runId = context.payload.workflow_run.id;
+            const conclusion = context.payload.workflow_run.conclusion;
             const marker = '<!-- playwright-failure-screenshots -->';
             const prContext = JSON.parse(process.env.PR_CONTEXT);
             const prNumber = prContext.prNumber;
             const branchName = prContext.branchName;
-            const artifactDisposition = prContext.artifactDisposition ?? 'download';
+            const artifactDisposition = prContext.artifactDisposition ?? 'rejected';
             const artifactError = prContext.artifactError ?? '';
             const downloadOutcome = process.env.DOWNLOAD_OUTCOME;
             const artifactsDir = path.join(process.cwd(), 'all-test-results');
-            const allowedNodeVersions = new Set(['22', '24', '26']);
-            const maxArtifactDirectories = allowedNodeVersions.size;
+            const expectedArtifactNames = Array.isArray(prContext.expectedArtifactNames) ? prContext.expectedArtifactNames : [];
+            const expectedArtifactNamesSet = new Set(expectedArtifactNames);
+            const expectedNodeVersions = new Set(
+              expectedArtifactNames
+                .map(name => name.match(/^test-results-node-(\d+)$/)?.[1])
+                .filter(Boolean)
+            );
+            const maxArtifactDirectories = expectedArtifactNames.length;
             const maxTestDirectoriesPerArtifact = 200;
             const maxFailures = 20;
             const maxFileBytes = 5 * 1024 * 1024;
@@ -247,10 +274,25 @@ jobs:
             const failures = [];
             const treePathOwners = new Map();
 
+            if (conclusion === 'success') {
+              await removeStaleComment();
+              return;
+            }
+
+            if (conclusion !== 'failure') {
+              console.log(`Skipping comment sync for workflow conclusion ${conclusion}`);
+              return;
+            }
+
             if (artifactDisposition === 'none') {
               console.log('No matching screenshot artifacts were uploaded for this run');
               await removeStaleComment();
               return;
+            }
+
+            if (!['download', 'none', 'rejected'].includes(artifactDisposition)) {
+              await removeStaleComment();
+              throw new Error(`Unknown artifact disposition: ${artifactDisposition}`);
             }
 
             if (artifactDisposition === 'rejected') {
@@ -269,19 +311,19 @@ jobs:
             ensureDirectory(artifactsDir, 'Artifact root');
             const artifactDirs = fs.readdirSync(artifactsDir);
 
-            if (artifactDirs.length > maxArtifactDirectories) {
+            if (artifactDirs.length !== maxArtifactDirectories) {
               throw new Error(`Unexpected artifact directory count: ${artifactDirs.length}`);
             }
 
             for (const artifactDir of artifactDirs) {
-              const match = artifactDir.match(/^test-results-node-(\d+)$/);
-              if (!match) {
+              if (!expectedArtifactNamesSet.has(artifactDir)) {
                 throw new Error(`Unexpected artifact directory name: ${artifactDir}`);
               }
 
-              const nodeVersion = match[1];
-              if (!allowedNodeVersions.has(nodeVersion)) {
-                throw new Error(`Unexpected node version artifact: ${nodeVersion}`);
+              const match = artifactDir.match(/^test-results-node-(\d+)$/);
+              const nodeVersion = match?.[1];
+              if (!nodeVersion || !expectedNodeVersions.has(nodeVersion)) {
+                throw new Error(`Unexpected node version artifact: ${artifactDir}`);
               }
 
               const artifactPath = path.join(artifactsDir, artifactDir);
@@ -523,37 +565,4 @@ jobs:
                 owner, repo, issue_number: prNumber, body,
               });
               console.log('Created new comment');
-            }
-
-      - name: Remove stale failure comment
-        if: ${{ github.event.workflow_run.conclusion == 'success' && fromJSON(steps.pr-context.outputs.result).trusted }}
-        uses: actions/github-script@v9
-        env:
-          PR_CONTEXT: ${{ steps.pr-context.outputs.result }}
-        with:
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const prContext = JSON.parse(process.env.PR_CONTEXT);
-            const prNumber = prContext.prNumber;
-            const marker = '<!-- playwright-failure-screenshots -->';
-
-            const comments = await github.paginate(
-              github.rest.issues.listComments,
-              { owner, repo, issue_number: prNumber, per_page: 100 },
-            );
-            const existing = comments.find(comment =>
-              Boolean(
-                comment.body &&
-                comment.body.includes(marker) &&
-                comment.user?.type === 'Bot' &&
-                comment.user?.login === 'github-actions[bot]'
-              )
-            );
-
-            if (existing) {
-              await github.rest.issues.deleteComment({
-                owner, repo, comment_id: existing.id,
-              });
-              console.log(`Deleted stale comment ${existing.id}`);
             }

--- a/.github/workflows/pr-test-playwright-comment.yml
+++ b/.github/workflows/pr-test-playwright-comment.yml
@@ -510,9 +510,7 @@ jobs:
               }
             }
 
-            await pushWithRetry(blobResults);
-
-            // Phase 3: Build and post PR comment
+            // Phase 3: Build PR comment body before pushing blobs
             const baseUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${branchName}`;
 
             let body = `${marker}\n## Playwright Visual Regression Test Failures\n\n`;
@@ -547,6 +545,8 @@ jobs:
             if (body.length > maxCommentLength) {
               throw new Error(`Generated comment body exceeded ${maxCommentLength} characters`);
             }
+
+            await pushWithRetry(blobResults);
 
             // Find existing comment (paginated)
             const comments = await github.paginate(

--- a/.github/workflows/pr-test-playwright-comment.yml
+++ b/.github/workflows/pr-test-playwright-comment.yml
@@ -234,7 +234,7 @@ jobs:
                 .replace(/^_+|_+$/g, '')
                 .slice(0, 120);
 
-              if (!sanitized) {
+              if (!sanitized || /^\.+$/.test(sanitized)) {
                 throw new Error(`Unable to sanitize path segment: ${s}`);
               }
 

--- a/.github/workflows/pr-test-playwright-comment.yml
+++ b/.github/workflows/pr-test-playwright-comment.yml
@@ -2,7 +2,7 @@ name: Playwright Screenshots Comment
 permissions:
   actions: read
   contents: write
-  pull-requests: write
+  issues: write
 on:
   workflow_run:
     workflows: ["Playwright Tests"]
@@ -15,29 +15,132 @@ jobs:
     if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion != 'cancelled' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Download PR info
-        id: pr-info
-        uses: actions/download-artifact@v8
+      - name: Resolve trusted PR context
+        id: pr-context
+        uses: actions/github-script@v9
         with:
-          name: pr-info
-          path: pr-info/
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: true
+          result-encoding: string
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const run = context.payload.workflow_run;
+            const prs = Array.isArray(run.pull_requests) ? run.pull_requests : [];
+            const allowedArtifactPattern = /^test-results-node-(22|24|26)$/;
+            const maxArtifactDirectories = 3;
+            const maxArtifactBytes = 50 * 1024 * 1024;
+
+            function result(trusted, reason, extra = {}) {
+              return JSON.stringify({ trusted, reason, ...extra });
+            }
+
+            if (prs.length !== 1) {
+              core.warning(`Expected exactly one pull request on workflow_run, found ${prs.length}`);
+              return result(false, 'unexpected-pr-count');
+            }
+
+            const prNumber = prs[0]?.number;
+            if (!Number.isInteger(prNumber) || prNumber <= 0) {
+              core.warning(`Invalid pull request number: ${prNumber}`);
+              return result(false, 'invalid-pr-number');
+            }
+
+            const { data: pr } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: prNumber,
+            });
+
+            const baseRepo = pr.base.repo?.full_name ?? '';
+            const prHeadRepo = pr.head.repo?.full_name ?? '';
+            const runHeadRepo = run.head_repository?.full_name ?? '';
+            const runHeadSha = run.head_sha ?? '';
+            const isCurrentHead = pr.head.sha === runHeadSha;
+
+            if (pr.state !== 'open') {
+              core.info(`Skipping PR #${prNumber} because it is ${pr.state}`);
+              return result(false, 'pr-not-open', { prNumber });
+            }
+
+            if (baseRepo !== `${owner}/${repo}`) {
+              core.warning(`Unexpected base repo for PR #${prNumber}: ${baseRepo}`);
+              return result(false, 'unexpected-base-repo', { prNumber });
+            }
+
+            if (!runHeadRepo || runHeadRepo !== prHeadRepo) {
+              core.warning(`Head repository mismatch for PR #${prNumber}: workflow_run=${runHeadRepo} pr=${prHeadRepo}`);
+              return result(false, 'head-repo-mismatch', { prNumber });
+            }
+
+            if (!runHeadSha) {
+              core.warning('workflow_run.head_sha is missing');
+              return result(false, 'missing-head-sha', { prNumber });
+            }
+
+            if (!isCurrentHead) {
+              core.info(`Skipping stale run ${run.id}; PR #${prNumber} head is ${pr.head.sha}, run head is ${runHeadSha}`);
+              return result(false, 'stale-run', { prNumber, runHeadSha });
+            }
+
+            const artifacts = await github.paginate(
+              github.rest.actions.listWorkflowRunArtifacts,
+              {
+                owner,
+                repo,
+                run_id: run.id,
+                per_page: 100,
+              }
+            );
+            const testResultArtifacts = artifacts.filter(artifact => allowedArtifactPattern.test(artifact.name));
+            const artifactBytes = testResultArtifacts.reduce((sum, artifact) => sum + (artifact.size_in_bytes ?? 0), 0);
+
+            if (testResultArtifacts.length > maxArtifactDirectories) {
+              return result(true, 'trusted', {
+                prNumber,
+                runHeadSha,
+                branchName: '_playwright-artifacts',
+                testResultsArtifactCount: testResultArtifacts.length,
+                artifactDisposition: 'rejected',
+                artifactError: `Unexpected test result artifact count: ${testResultArtifacts.length}`,
+              });
+            }
+
+            if (artifactBytes > maxArtifactBytes) {
+              return result(true, 'trusted', {
+                prNumber,
+                runHeadSha,
+                branchName: '_playwright-artifacts',
+                testResultsArtifactCount: testResultArtifacts.length,
+                artifactDisposition: 'rejected',
+                artifactError: `Test result artifacts exceed byte limit: ${artifactBytes}`,
+              });
+            }
+
+            return result(true, 'trusted', {
+              prNumber,
+              runHeadSha,
+              branchName: '_playwright-artifacts',
+              testResultsArtifactCount: testResultArtifacts.length,
+              artifactDisposition: testResultArtifacts.length === 0 ? 'none' : 'download',
+            });
 
       - name: Download test results
-        if: ${{ github.event.workflow_run.conclusion == 'failure' && steps.pr-info.outcome == 'success' }}
+        id: test-results
+        if: ${{ github.event.workflow_run.conclusion == 'failure' && fromJSON(steps.pr-context.outputs.result).trusted && fromJSON(steps.pr-context.outputs.result).artifactDisposition == 'download' && fromJSON(steps.pr-context.outputs.result).testResultsArtifactCount > 0 }}
         uses: actions/download-artifact@v8
         with:
           pattern: test-results-node-*
           path: all-test-results/
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          merge-multiple: false
         continue-on-error: true
 
       - name: Post failure screenshots to PR
-        if: ${{ github.event.workflow_run.conclusion == 'failure' && steps.pr-info.outcome == 'success' }}
+        if: ${{ github.event.workflow_run.conclusion == 'failure' && fromJSON(steps.pr-context.outputs.result).trusted }}
         uses: actions/github-script@v9
+        env:
+          DOWNLOAD_OUTCOME: ${{ steps.test-results.outcome }}
+          PR_CONTEXT: ${{ steps.pr-context.outputs.result }}
         with:
           script: |
             const fs = require('fs');
@@ -45,10 +148,24 @@ jobs:
 
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const prNumber = parseInt(fs.readFileSync('pr-info/number', 'utf8').trim(), 10);
             const runId = context.payload.workflow_run.id;
-            const branchName = '_playwright-artifacts';
             const marker = '<!-- playwright-failure-screenshots -->';
+            const prContext = JSON.parse(process.env.PR_CONTEXT);
+            const prNumber = prContext.prNumber;
+            const branchName = prContext.branchName;
+            const artifactDisposition = prContext.artifactDisposition ?? 'download';
+            const artifactError = prContext.artifactError ?? '';
+            const downloadOutcome = process.env.DOWNLOAD_OUTCOME;
+            const artifactsDir = path.join(process.cwd(), 'all-test-results');
+            const allowedNodeVersions = new Set(['22', '24', '26']);
+            const maxArtifactDirectories = allowedNodeVersions.size;
+            const maxTestDirectoriesPerArtifact = 200;
+            const maxFailures = 20;
+            const maxFileBytes = 5 * 1024 * 1024;
+            const maxTotalBytes = 45 * 1024 * 1024;
+            const maxCommentLength = 60000;
+            const pngSignature = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+            let totalBytes = 0;
 
             // Helper: remove stale marker comment if it exists
             async function removeStaleComment() {
@@ -56,7 +173,7 @@ jobs:
                 github.rest.issues.listComments,
                 { owner, repo, issue_number: prNumber, per_page: 100 },
               );
-              const existing = comments.find(c => c.body && c.body.includes(marker));
+              const existing = comments.find(isManagedComment);
               if (existing) {
                 await github.rest.issues.deleteComment({
                   owner, repo, comment_id: existing.id,
@@ -65,27 +182,129 @@ jobs:
               }
             }
 
-            // Phase 1: Discover failure screenshots
-            const artifactsDir = 'all-test-results';
-            const failures = [];
+            function escapeHtml(s) {
+              return s
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;');
+            }
 
-            if (!fs.existsSync(artifactsDir)) {
-              console.log('No test results directory found');
+            function isManagedComment(comment) {
+              return Boolean(
+                comment.body &&
+                comment.body.includes(marker) &&
+                comment.user?.type === 'Bot' &&
+                comment.user?.login === 'github-actions[bot]'
+              );
+            }
+
+            function sanitizePathSegment(s) {
+              const sanitized = s
+                .normalize('NFKC')
+                .replace(/[^a-zA-Z0-9._-]/g, '_')
+                .replace(/_+/g, '_')
+                .replace(/^_+|_+$/g, '')
+                .slice(0, 120);
+
+              if (!sanitized) {
+                throw new Error(`Unable to sanitize path segment: ${s}`);
+              }
+
+              return sanitized;
+            }
+
+            function ensureDirectory(dirPath, label) {
+              const stats = fs.lstatSync(dirPath);
+              if (stats.isSymbolicLink() || !stats.isDirectory()) {
+                throw new Error(`${label} must be a real directory: ${dirPath}`);
+              }
+            }
+
+            function readValidatedPng(filePath) {
+              const stats = fs.lstatSync(filePath);
+              if (stats.isSymbolicLink() || !stats.isFile()) {
+                throw new Error(`Expected a regular file: ${filePath}`);
+              }
+
+              if (stats.size <= 0 || stats.size > maxFileBytes) {
+                throw new Error(`Unexpected PNG size for ${filePath}: ${stats.size}`);
+              }
+
+              totalBytes += stats.size;
+              if (totalBytes > maxTotalBytes) {
+                throw new Error(`Total PNG bytes exceeded limit of ${maxTotalBytes}`);
+              }
+
+              const buffer = fs.readFileSync(filePath);
+              if (buffer.length < pngSignature.length || !buffer.subarray(0, pngSignature.length).equals(pngSignature)) {
+                throw new Error(`Invalid PNG signature for ${filePath}`);
+              }
+
+              return buffer;
+            }
+
+            const failures = [];
+            const treePathOwners = new Map();
+
+            if (artifactDisposition === 'none') {
+              console.log('No matching screenshot artifacts were uploaded for this run');
               await removeStaleComment();
               return;
             }
 
-            for (const artifactDir of fs.readdirSync(artifactsDir)) {
+            if (artifactDisposition === 'rejected') {
+              await removeStaleComment();
+              throw new Error(artifactError || 'Screenshot artifacts were rejected by policy');
+            }
+
+            if (downloadOutcome !== 'success') {
+              throw new Error(`Screenshot artifact download failed with outcome ${downloadOutcome}`);
+            }
+
+            if (!fs.existsSync(artifactsDir)) {
+              throw new Error('Expected screenshot artifacts were reported but no download directory was created');
+            }
+
+            ensureDirectory(artifactsDir, 'Artifact root');
+            const artifactDirs = fs.readdirSync(artifactsDir);
+
+            if (artifactDirs.length > maxArtifactDirectories) {
+              throw new Error(`Unexpected artifact directory count: ${artifactDirs.length}`);
+            }
+
+            for (const artifactDir of artifactDirs) {
               const match = artifactDir.match(/^test-results-node-(\d+)$/);
-              if (!match) continue;
+              if (!match) {
+                throw new Error(`Unexpected artifact directory name: ${artifactDir}`);
+              }
+
               const nodeVersion = match[1];
+              if (!allowedNodeVersions.has(nodeVersion)) {
+                throw new Error(`Unexpected node version artifact: ${nodeVersion}`);
+              }
+
               const artifactPath = path.join(artifactsDir, artifactDir);
+              ensureDirectory(artifactPath, `Artifact directory ${artifactDir}`);
+              const testEntries = fs.readdirSync(artifactPath, { withFileTypes: true });
 
-              if (!fs.statSync(artifactPath).isDirectory()) continue;
+              for (const entry of testEntries) {
+                if (entry.isSymbolicLink()) {
+                  throw new Error(`Symbolic links are not allowed in ${artifactDir}: ${entry.name}`);
+                }
+              }
 
-              for (const testDir of fs.readdirSync(artifactPath)) {
+              const testDirs = testEntries
+                .filter(entry => entry.isDirectory())
+                .map(entry => entry.name);
+
+              if (testDirs.length > maxTestDirectoriesPerArtifact) {
+                throw new Error(`Too many test result directories in ${artifactDir}: ${testDirs.length}`);
+              }
+
+              for (const testDir of testDirs) {
                 const testPath = path.join(artifactPath, testDir);
-                if (!fs.statSync(testPath).isDirectory()) continue;
+                ensureDirectory(testPath, `Test directory ${testDir}`);
 
                 const files = fs.readdirSync(testPath);
                 const diffFiles = files.filter(f => f.endsWith('-diff.png'));
@@ -96,14 +315,44 @@ jobs:
                   const expectedFile = `${baseName}-expected.png`;
 
                   if (files.includes(actualFile) && files.includes(expectedFile)) {
+                    const safeNodeVersion = sanitizePathSegment(nodeVersion);
+                    const safeTestName = sanitizePathSegment(testDir);
+                    const safeScreenshotName = sanitizePathSegment(baseName);
+                    const actualPath = path.join(testPath, actualFile);
+                    const expectedPath = path.join(testPath, expectedFile);
+                    const diffPath = path.join(testPath, diffFile);
+                    const baseTreePath = `pr-${prNumber}/${runId}/node-${safeNodeVersion}/${safeTestName}/${safeScreenshotName}`;
+                    const buffers = {
+                      actual: readValidatedPng(actualPath),
+                      expected: readValidatedPng(expectedPath),
+                      diff: readValidatedPng(diffPath),
+                    };
+
+                    for (const suffix of Object.keys(buffers)) {
+                      const treePath = `${baseTreePath}-${suffix}.png`;
+                      const previousOwner = treePathOwners.get(treePath);
+                      const ownerLabel = `${nodeVersion}/${testDir}/${baseName}`;
+
+                      if (previousOwner && previousOwner !== ownerLabel) {
+                        throw new Error(`Sanitized path collision for ${treePath}: ${previousOwner} vs ${ownerLabel}`);
+                      }
+
+                      treePathOwners.set(treePath, ownerLabel);
+                    }
+
                     failures.push({
                       nodeVersion,
                       testName: testDir,
                       screenshotName: baseName,
-                      actualPath: path.join(testPath, actualFile),
-                      expectedPath: path.join(testPath, expectedFile),
-                      diffPath: path.join(testPath, diffFile),
+                      safeNodeVersion,
+                      safeTestName,
+                      safeScreenshotName,
+                      buffers,
                     });
+
+                    if (failures.length > maxFailures) {
+                      throw new Error(`Too many failure screenshot groups: ${failures.length}`);
+                    }
                   }
                 }
               }
@@ -117,40 +366,21 @@ jobs:
 
             console.log(`Found ${failures.length} failure(s)`);
 
-            // Sanitization helpers
-            function escapeHtml(s) {
-              return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
-            }
-            function sanitizePathSegment(s) {
-              return s.replace(/[^a-zA-Z0-9._-]/g, '_');
-            }
-
             // Phase 2: Upload images to _playwright-artifacts branch via Git Data API
-            async function createBlob(filePath) {
-              const content = fs.readFileSync(filePath).toString('base64');
+            async function createBlob(buffer) {
+              const content = buffer.toString('base64');
               const { data } = await github.rest.git.createBlob({
                 owner, repo, content, encoding: 'base64',
               });
               return data.sha;
             }
 
-            // Sanitize path segments for git tree and URLs
-            for (const failure of failures) {
-              failure.safeNodeVersion = sanitizePathSegment(failure.nodeVersion);
-              failure.safeTestName = sanitizePathSegment(failure.testName);
-              failure.safeScreenshotName = sanitizePathSegment(failure.screenshotName);
-            }
-
             // Create all blobs in parallel
             const blobEntries = [];
             for (const failure of failures) {
-              for (const [suffix, filePath] of [
-                ['actual', failure.actualPath],
-                ['expected', failure.expectedPath],
-                ['diff', failure.diffPath],
-              ]) {
+              for (const [suffix, buffer] of Object.entries(failure.buffers)) {
                 blobEntries.push({
-                  filePath,
+                  buffer,
                   treePath: `pr-${prNumber}/${runId}/node-${failure.safeNodeVersion}/${failure.safeTestName}/${failure.safeScreenshotName}-${suffix}.png`,
                 });
               }
@@ -161,7 +391,7 @@ jobs:
                 path: entry.treePath,
                 mode: '100644',
                 type: 'blob',
-                sha: await createBlob(entry.filePath),
+                sha: await createBlob(entry.buffer),
               }))
             );
 
@@ -272,12 +502,16 @@ jobs:
 
             body += `---\n*Auto-generated by Playwright CI*\n`;
 
+            if (body.length > maxCommentLength) {
+              throw new Error(`Generated comment body exceeded ${maxCommentLength} characters`);
+            }
+
             // Find existing comment (paginated)
             const comments = await github.paginate(
               github.rest.issues.listComments,
               { owner, repo, issue_number: prNumber, per_page: 100 },
             );
-            const existing = comments.find(c => c.body && c.body.includes(marker));
+            const existing = comments.find(isManagedComment);
 
             if (existing) {
               await github.rest.issues.updateComment({
@@ -292,21 +526,30 @@ jobs:
             }
 
       - name: Remove stale failure comment
-        if: ${{ github.event.workflow_run.conclusion == 'success' && steps.pr-info.outcome == 'success' }}
+        if: ${{ github.event.workflow_run.conclusion == 'success' && fromJSON(steps.pr-context.outputs.result).trusted }}
         uses: actions/github-script@v9
+        env:
+          PR_CONTEXT: ${{ steps.pr-context.outputs.result }}
         with:
           script: |
-            const fs = require('fs');
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const prNumber = parseInt(fs.readFileSync('pr-info/number', 'utf8').trim(), 10);
+            const prContext = JSON.parse(process.env.PR_CONTEXT);
+            const prNumber = prContext.prNumber;
             const marker = '<!-- playwright-failure-screenshots -->';
 
             const comments = await github.paginate(
               github.rest.issues.listComments,
               { owner, repo, issue_number: prNumber, per_page: 100 },
             );
-            const existing = comments.find(c => c.body && c.body.includes(marker));
+            const existing = comments.find(comment =>
+              Boolean(
+                comment.body &&
+                comment.body.includes(marker) &&
+                comment.user?.type === 'Bot' &&
+                comment.user?.login === 'github-actions[bot]'
+              )
+            );
 
             if (existing) {
               await github.rest.issues.deleteComment({

--- a/.github/workflows/pr-test-playwright-comment.yml
+++ b/.github/workflows/pr-test-playwright-comment.yml
@@ -3,6 +3,7 @@ permissions:
   actions: read
   contents: write
   issues: write
+  pull-requests: read
 on:
   workflow_run:
     workflows: ["Playwright Tests"]
@@ -17,7 +18,7 @@ jobs:
     steps:
       - name: Resolve trusted PR context
         id: pr-context
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           result-encoding: string
           script: |
@@ -146,7 +147,7 @@ jobs:
       - name: Download test results
         id: test-results
         if: ${{ github.event.workflow_run.conclusion == 'failure' && fromJSON(steps.pr-context.outputs.result).trusted && fromJSON(steps.pr-context.outputs.result).artifactDisposition == 'download' && fromJSON(steps.pr-context.outputs.result).testResultsArtifactCount > 0 }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@974686ed5098c7f9c9289ec946b9058e496a2561
         with:
           pattern: test-results-node-*
           path: all-test-results/
@@ -157,7 +158,7 @@ jobs:
 
       - name: Sync failure screenshots comment
         if: ${{ fromJSON(steps.pr-context.outputs.result).trusted }}
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         env:
           DOWNLOAD_OUTCOME: ${{ steps.test-results.outcome }}
           PR_CONTEXT: ${{ steps.pr-context.outputs.result }}
@@ -301,6 +302,7 @@ jobs:
             }
 
             if (downloadOutcome !== 'success') {
+              await removeStaleComment();
               throw new Error(`Screenshot artifact download failed with outcome ${downloadOutcome}`);
             }
 

--- a/.github/workflows/pr-test-playwright-comment.yml
+++ b/.github/workflows/pr-test-playwright-comment.yml
@@ -25,7 +25,7 @@ jobs:
             const repo = context.repo.repo;
             const run = context.payload.workflow_run;
             const prs = Array.isArray(run.pull_requests) ? run.pull_requests : [];
-            const artifactDownloadPattern = /^test-results-node-.+$/;
+            const artifactDownloadPattern = /^test-results-node-.*$/;
             const allowedArtifactPattern = /^test-results-node-(\d+)$/;
             const maxArtifactDirectories = 3;
             const maxArtifactBytes = 50 * 1024 * 1024;

--- a/.github/workflows/pr-test-playwright.yml
+++ b/.github/workflows/pr-test-playwright.yml
@@ -47,17 +47,3 @@ jobs:
           name: test-results-node-${{ matrix.node-version }}
           path: test-results/
           retention-days: 30
-
-  save-pr-info:
-    if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Save PR info
-        run: |
-          mkdir -p pr-info
-          echo '${{ github.event.pull_request.number }}' > pr-info/number
-      - uses: actions/upload-artifact@v7
-        with:
-          name: pr-info
-          path: pr-info/
-          overwrite: true


### PR DESCRIPTION
## チケットへのリンク

- T8

## やったこと

- `workflow_run` 側で PR 番号を untrusted artifact から読まず、trusted な `workflow_run` / PR API 情報から解決するように変更
- Playwright スクリーンショット artifact の件数・サイズ・PNG 署名・ディレクトリ形状・パス衝突を検証し、許可された PNG のみを `_playwright-artifacts` ブランチへ書き込むように変更
- bot 所有コメントだけを更新・削除するようにして、stale comment cleanup と artifact rejection/download failure の失敗系を整理
- `pr-info` artifact の生成ジョブを削除

## やらないこと

- 無し

## できるようになること（ユーザ目線）

- fork 由来の Playwright 失敗 artifact でも、権限昇格したコメント workflow が任意 PR を選んだり任意コメントを書き換えたりせずに、必要な失敗スクリーンショットだけを安全にコメントできる

## できなくなること（ユーザ目線）

- ポリシー外の artifact 件数/サイズ/形状のデータはコメントに反映されず、workflow が失敗として可視化される

## 動作確認

- `ruby` による YAML parse: `yaml-ok`
- `git diff --check` 通過
- scoped self-review 実施
- subagent independent review で承認取得

## その他

- `actionlint` はローカル未導入のため未実施
- workflow-only 変更のため `pnpm lint` / `check-types` はスキップ（CI/アプリコードには未影響）

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens the `workflow_run`-triggered Playwright screenshot comment workflow by resolving PR context from trusted GitHub API sources instead of an untrusted artifact, and adds layered validation (artifact name pattern, count, total byte size, PNG signature, symlink detection, path-collision detection) before writing to `_playwright-artifacts`. The `save-pr-info` job and its artifact are removed entirely.

- **Trusted PR resolution**: PR number now comes from `workflow_run.pull_requests[]` cross-validated via `github.rest.pulls.get()`, with checks for open state, correct base repo, and matching head SHA.
- **Defense-in-depth artifact validation**: Each downloaded PNG is checked for symlinks, size bounds, PNG magic bytes, and sanitized tree path uniqueness before any blob is pushed or comment is written.
- **Unified comment management**: Success and failure paths are merged into one `actions/github-script` step with `isManagedComment` ensuring only the bot's own comment is updated or deleted.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — the workflow-only change closes the untrusted-artifact PR-number path and adds thorough validation before any privileged write occurs.

Every attack surface introduced by `workflow_run` privilege escalation is now gated: PR number comes from the trusted API, artifact names/sizes/PNG headers are validated before processing, and only the bot's own comment is ever modified. The permission block is correctly scoped (`pull-requests: read`, `issues: write`, `contents: write`, `actions: read`), and the removed `save-pr-info` job eliminates the original injection vector entirely.

No files require special attention. Both changed files are workflow definitions with no impact on application code.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/pr-test-playwright-comment.yml | Core security hardening: replaces untrusted artifact-based PR resolution with GitHub API validation, adds multi-layer artifact inspection (name, count, size, PNG signature, symlinks, path collisions), and consolidates comment lifecycle into one step. All prior permission and duplication issues are addressed. |
| .github/workflows/pr-test-playwright.yml | Removes the `save-pr-info` job that wrote the untrusted PR number artifact; no other logic changed. Clean removal with no side effects. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Fork as Fork PR / push
    participant PW as Playwright Tests (pr-test-playwright.yml)
    participant WR as workflow_run trigger
    participant GH as GitHub API
    participant SC as Sync comment step
    participant Branch as _playwright-artifacts branch
    participant PR as PR comment

    Fork->>PW: push / pull_request event
    PW->>PW: Run tests (matrix node 22/24/26)
    PW->>GH: "Upload artifact test-results-node-{N}"
    PW-->>WR: workflow_run completed event

    WR->>WR: Resolve trusted PR context
    WR->>GH: pulls.get(prNumber) [pull-requests: read]
    GH-->>WR: PR state, head SHA, repos
    WR->>GH: listWorkflowRunArtifacts [actions: read]
    GH-->>WR: artifact list (validate name/count/size)
    WR-->>SC: prContext JSON (trusted, disposition, expectedNames)

    alt "disposition == download && conclusion == failure"
        WR->>GH: "download-artifact (pattern: test-results-node-*)"
        GH-->>WR: all-test-results/
    end

    SC->>SC: "conclusion == success?"
    alt success
        SC->>PR: delete bot comment (removeStaleComment)
    else failure
        SC->>SC: Validate dirs, symlinks, PNG headers
        SC->>SC: Sanitize paths, check collisions
        SC->>SC: Build comment body
        SC->>Branch: pushWithRetry (Git Data API) [contents: write]
        SC->>PR: create/update bot comment [issues: write]
    end
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/pr-test-playwright-comment.yml`, line 1-5 ([link](https://github.com/xpadev-net/niconicomments/blob/ba258249dcd68e1ef1d2ec65e5d20e71f54a78b2/.github/workflows/pr-test-playwright-comment.yml#L1-L5)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Missing `pull-requests: read` permission breaks the security validation step**

   The "Resolve trusted PR context" step calls `github.rest.pulls.get()` at line 48 to verify the PR's state, base repo, and head SHA — the core of the new security hardening. However, the `permissions` block only declares `actions: read`, `contents: write`, and `issues: write`. In GitHub Actions, explicitly setting `permissions` causes all unmentioned scopes to default to `none`, so `pull-requests` is `none`. The `pulls.get()` API call will return HTTP 403, the step will fail, `steps.pr-context.outputs.result` will be empty, and all subsequent `fromJSON(...)` expressions in the next steps' `if:` conditions will fail to evaluate — meaning neither download nor comment posting will occur. The entire workflow becomes a no-op.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/pr-test-playwright-comment.yml
   Line: 1-5

   Comment:
   **Missing `pull-requests: read` permission breaks the security validation step**

   The "Resolve trusted PR context" step calls `github.rest.pulls.get()` at line 48 to verify the PR's state, base repo, and head SHA — the core of the new security hardening. However, the `permissions` block only declares `actions: read`, `contents: write`, and `issues: write`. In GitHub Actions, explicitly setting `permissions` causes all unmentioned scopes to default to `none`, so `pull-requests` is `none`. The `pulls.get()` API call will return HTTP 403, the step will fail, `steps.pr-context.outputs.result` will be empty, and all subsequent `fromJSON(...)` expressions in the next steps' `if:` conditions will fail to evaluate — meaning neither download nor comment posting will occur. The entire workflow becomes a no-op.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fpr-test-playwright-comment.yml%0ALine%3A%201-5%0A%0AComment%3A%0A**Missing%20%60pull-requests%3A%20read%60%20permission%20breaks%20the%20security%20validation%20step**%0A%0AThe%20%22Resolve%20trusted%20PR%20context%22%20step%20calls%20%60github.rest.pulls.get%28%29%60%20at%20line%2048%20to%20verify%20the%20PR's%20state%2C%20base%20repo%2C%20and%20head%20SHA%20%E2%80%94%20the%20core%20of%20the%20new%20security%20hardening.%20However%2C%20the%20%60permissions%60%20block%20only%20declares%20%60actions%3A%20read%60%2C%20%60contents%3A%20write%60%2C%20and%20%60issues%3A%20write%60.%20In%20GitHub%20Actions%2C%20explicitly%20setting%20%60permissions%60%20causes%20all%20unmentioned%20scopes%20to%20default%20to%20%60none%60%2C%20so%20%60pull-requests%60%20is%20%60none%60.%20The%20%60pulls.get%28%29%60%20API%20call%20will%20return%20HTTP%20403%2C%20the%20step%20will%20fail%2C%20%60steps.pr-context.outputs.result%60%20will%20be%20empty%2C%20and%20all%20subsequent%20%60fromJSON%28...%29%60%20expressions%20in%20the%20next%20steps'%20%60if%3A%60%20conditions%20will%20fail%20to%20evaluate%20%E2%80%94%20meaning%20neither%20download%20nor%20comment%20posting%20will%20occur.%20The%20entire%20workflow%20becomes%20a%20no-op.%0A%0A%60%60%60suggestion%0Apermissions%3A%0A%20%20actions%3A%20read%0A%20%20contents%3A%20write%0A%20%20issues%3A%20write%0A%20%20pull-requests%3A%20read%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=xpadev-net%2Fniconicomments&pr=288&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (6): Last reviewed commit: ["Fail closed on PR context API errors"](https://github.com/xpadev-net/niconicomments/commit/6f3b9f94a39eff6150123fd6c1c76d98ba22dd28) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35213413)</sub>

<!-- /greptile_comment -->