### PR TITLE
fix: optimize input parser user ID assignment and XML dispatch

### DIFF
--- a/src/input/legacy.ts
+++ b/src/input/legacy.ts
@@ -8,6 +8,8 @@ import {
   ZRawApiResponse,
 } from "@/@types";
 
+import { assignUserId } from "./xmlDocument";
+
 export const LegacyParser: InputParser = {
   key: ["legacy"],
   parse: (input) => {
@@ -47,13 +49,7 @@ const fromLegacy = (data: RawApiResponse[]): FormattedComment[] => {
       if (value.content.startsWith("/") && !value.user_id) {
         tmpParam.mail.push("invisible");
       }
-      const existingUserId = userIdMap.get(value.user_id);
-      if (existingUserId === undefined) {
-        tmpParam.user_id = userIdMap.size;
-        userIdMap.set(value.user_id, tmpParam.user_id);
-      } else {
-        tmpParam.user_id = existingUserId;
-      }
+      tmpParam.user_id = assignUserId(userIdMap, value.user_id);
       data_.push(tmpParam);
     }
   }

--- a/src/input/legacy.ts
+++ b/src/input/legacy.ts
@@ -22,7 +22,7 @@ export const LegacyParser: InputParser = {
  */
 const fromLegacy = (data: RawApiResponse[]): FormattedComment[] => {
   const data_: FormattedComment[] = [];
-  const userList: string[] = [];
+  const userIdMap = new Map<string, number>();
   for (const _val of data) {
     const val = safeParse(ZApiChat, _val.chat);
     if (!val.success) continue;
@@ -47,12 +47,12 @@ const fromLegacy = (data: RawApiResponse[]): FormattedComment[] => {
       if (value.content.startsWith("/") && !value.user_id) {
         tmpParam.mail.push("invisible");
       }
-      const isUserExist = userList.indexOf(value.user_id);
-      if (isUserExist === -1) {
-        tmpParam.user_id = userList.length;
-        userList.push(value.user_id);
+      const existingUserId = userIdMap.get(value.user_id);
+      if (existingUserId === undefined) {
+        tmpParam.user_id = userIdMap.size;
+        userIdMap.set(value.user_id, tmpParam.user_id);
       } else {
-        tmpParam.user_id = isUserExist;
+        tmpParam.user_id = existingUserId;
       }
       data_.push(tmpParam);
     }

--- a/src/input/v1.ts
+++ b/src/input/v1.ts
@@ -3,6 +3,8 @@ import { array, parse } from "valibot";
 import type { InputParser } from "@/@types";
 import { type FormattedComment, type V1Thread, ZV1Thread } from "@/@types";
 
+import { assignUserId } from "./xmlDocument";
+
 export const V1Parser: InputParser = {
   key: ["v1"],
   parse: (input: unknown) => {
@@ -39,13 +41,7 @@ const fromV1 = (data: V1Thread[]): FormattedComment[] => {
       if (tmpParam.content.startsWith("/") && tmpParam.owner) {
         tmpParam.mail.push("invisible");
       }
-      const existingUserId = userIdMap.get(value.userId);
-      if (existingUserId === undefined) {
-        tmpParam.user_id = userIdMap.size;
-        userIdMap.set(value.userId, tmpParam.user_id);
-      } else {
-        tmpParam.user_id = existingUserId;
-      }
+      tmpParam.user_id = assignUserId(userIdMap, value.userId);
       data_.push(tmpParam);
     }
   }

--- a/src/input/v1.ts
+++ b/src/input/v1.ts
@@ -18,7 +18,7 @@ export const V1Parser: InputParser = {
  */
 const fromV1 = (data: V1Thread[]): FormattedComment[] => {
   const data_: FormattedComment[] = [];
-  const userList: string[] = [];
+  const userIdMap = new Map<string, number>();
   for (const item of data) {
     const val = item.comments;
     const forkName = item.fork;
@@ -39,12 +39,12 @@ const fromV1 = (data: V1Thread[]): FormattedComment[] => {
       if (tmpParam.content.startsWith("/") && tmpParam.owner) {
         tmpParam.mail.push("invisible");
       }
-      const isUserExist = userList.indexOf(value.userId);
-      if (isUserExist === -1) {
-        tmpParam.user_id = userList.length;
-        userList.push(value.userId);
+      const existingUserId = userIdMap.get(value.userId);
+      if (existingUserId === undefined) {
+        tmpParam.user_id = userIdMap.size;
+        userIdMap.set(value.userId, tmpParam.user_id);
       } else {
-        tmpParam.user_id = isUserExist;
+        tmpParam.user_id = existingUserId;
       }
       data_.push(tmpParam);
     }

--- a/src/input/xml2js.ts
+++ b/src/input/xml2js.ts
@@ -12,7 +12,7 @@ export const Xml2jsParser: InputParser = {
 
 const fromXml2js = (data: Xml2jsPacket): FormattedComment[] => {
   const data_: FormattedComment[] = [];
-  const userList: string[] = [];
+  const userIdMap = new Map<string, number>();
   let index = data.packet.chat.length;
   for (const item of data.packet.chat) {
     const tmpParam: FormattedComment = {
@@ -32,12 +32,12 @@ const fromXml2js = (data: Xml2jsPacket): FormattedComment[] => {
       tmpParam.mail.push("invisible");
     }
     const userId = item.$.user_id ?? "";
-    const isUserExist = userList.indexOf(userId);
-    if (isUserExist === -1) {
-      tmpParam.user_id = userList.length;
-      userList.push(userId);
+    const existingUserId = userIdMap.get(userId);
+    if (existingUserId === undefined) {
+      tmpParam.user_id = userIdMap.size;
+      userIdMap.set(userId, tmpParam.user_id);
     } else {
-      tmpParam.user_id = isUserExist;
+      tmpParam.user_id = existingUserId;
     }
     data_.push(tmpParam);
   }

--- a/src/input/xml2js.ts
+++ b/src/input/xml2js.ts
@@ -3,6 +3,8 @@ import { parse } from "valibot";
 import type { FormattedComment, InputParser, Xml2jsPacket } from "@/@types";
 import { ZXml2jsPacket } from "@/@types/";
 
+import { assignUserId } from "./xmlDocument";
+
 export const Xml2jsParser: InputParser = {
   key: ["xml2js"],
   parse: (input) => {
@@ -31,14 +33,7 @@ const fromXml2js = (data: Xml2jsPacket): FormattedComment[] => {
     if (tmpParam.content.startsWith("/") && tmpParam.owner) {
       tmpParam.mail.push("invisible");
     }
-    const userId = item.$.user_id ?? "";
-    const existingUserId = userIdMap.get(userId);
-    if (existingUserId === undefined) {
-      tmpParam.user_id = userIdMap.size;
-      userIdMap.set(userId, tmpParam.user_id);
-    } else {
-      tmpParam.user_id = existingUserId;
-    }
+    tmpParam.user_id = assignUserId(userIdMap, item.$.user_id ?? "");
     data_.push(tmpParam);
   }
   return data_;

--- a/src/input/xmlDocument.ts
+++ b/src/input/xmlDocument.ts
@@ -5,14 +5,18 @@ import typeGuard from "@/typeGuard";
 export const XmlDocumentParser: InputParser = {
   key: ["XMLDocument", "niconicome"],
   parse: (input: unknown): FormattedComment[] => {
-    if (
-      typeof input !== "object" ||
-      input === null ||
-      !typeGuard.xmlDocument(input)
-    ) {
+    let isXmlDocument = false;
+    if (typeof input === "object" && input !== null) {
+      try {
+        isXmlDocument = typeGuard.xmlDocument(input);
+      } catch {
+        isXmlDocument = false;
+      }
+    }
+    if (!isXmlDocument) {
       throw new InvalidFormatError();
     }
-    return parseXMLDocument(input);
+    return parseXMLDocument(input as XMLDocument);
   },
 };
 

--- a/src/input/xmlDocument.ts
+++ b/src/input/xmlDocument.ts
@@ -3,9 +3,15 @@ import { InvalidFormatError } from "@/errors";
 import typeGuard from "@/typeGuard";
 
 export const XmlDocumentParser: InputParser = {
-  key: ["formatted", "niconicome"],
+  key: ["XMLDocument", "niconicome"],
   parse: (input: unknown): FormattedComment[] => {
-    if (!typeGuard.xmlDocument(input)) throw new InvalidFormatError();
+    if (
+      typeof input !== "object" ||
+      input === null ||
+      !typeGuard.xmlDocument(input)
+    ) {
+      throw new InvalidFormatError();
+    }
     return parseXMLDocument(input);
   },
 };
@@ -17,7 +23,7 @@ export const XmlDocumentParser: InputParser = {
  */
 const parseXMLDocument = (data: XMLDocument): FormattedComment[] => {
   const data_: FormattedComment[] = [];
-  const userList: string[] = [];
+  const userIdMap = new Map<string, number>();
   let index = Array.from(data.documentElement.children).length;
   for (const item of Array.from(data.documentElement.children)) {
     if (item.nodeName !== "chat") continue;
@@ -41,12 +47,12 @@ const parseXMLDocument = (data: XMLDocument): FormattedComment[] => {
       tmpParam.mail.push("invisible");
     }
     const userId = item.getAttribute("user_id") ?? "";
-    const isUserExist = userList.indexOf(userId);
-    if (isUserExist === -1) {
-      tmpParam.user_id = userList.length;
-      userList.push(userId);
+    const existingUserId = userIdMap.get(userId);
+    if (existingUserId === undefined) {
+      tmpParam.user_id = userIdMap.size;
+      userIdMap.set(userId, tmpParam.user_id);
     } else {
-      tmpParam.user_id = isUserExist;
+      tmpParam.user_id = existingUserId;
     }
     data_.push(tmpParam);
   }

--- a/src/input/xmlDocument.ts
+++ b/src/input/xmlDocument.ts
@@ -2,17 +2,31 @@ import type { FormattedComment, InputParser } from "@/@types";
 import { InvalidFormatError } from "@/errors";
 import typeGuard from "@/typeGuard";
 
+export const assignUserId = (
+  userIdMap: Map<string, number>,
+  userId: string,
+): number => {
+  const existingUserId = userIdMap.get(userId);
+  if (existingUserId !== undefined) return existingUserId;
+
+  const nextUserId = userIdMap.size;
+  userIdMap.set(userId, nextUserId);
+  return nextUserId;
+};
+
 export const XmlDocumentParser: InputParser = {
   key: ["XMLDocument", "niconicome"],
   parse: (input: unknown): FormattedComment[] => {
+    let isXmlDocument = false;
     if (typeof input === "object" && input !== null) {
       try {
-        if (typeGuard.xmlDocument(input)) {
-          return parseXMLDocument(input);
-        }
+        isXmlDocument = typeGuard.xmlDocument(input);
       } catch (error) {
         if (!(error instanceof TypeError)) throw error;
       }
+    }
+    if (isXmlDocument) {
+      return parseXMLDocument(input as XMLDocument);
     }
     throw new InvalidFormatError();
   },
@@ -48,14 +62,10 @@ const parseXMLDocument = (data: XMLDocument): FormattedComment[] => {
     if (tmpParam.content.startsWith("/") && tmpParam.owner) {
       tmpParam.mail.push("invisible");
     }
-    const userId = item.getAttribute("user_id") ?? "";
-    const existingUserId = userIdMap.get(userId);
-    if (existingUserId === undefined) {
-      tmpParam.user_id = userIdMap.size;
-      userIdMap.set(userId, tmpParam.user_id);
-    } else {
-      tmpParam.user_id = existingUserId;
-    }
+    tmpParam.user_id = assignUserId(
+      userIdMap,
+      item.getAttribute("user_id") ?? "",
+    );
     data_.push(tmpParam);
   }
   return data_;

--- a/src/input/xmlDocument.ts
+++ b/src/input/xmlDocument.ts
@@ -5,18 +5,16 @@ import typeGuard from "@/typeGuard";
 export const XmlDocumentParser: InputParser = {
   key: ["XMLDocument", "niconicome"],
   parse: (input: unknown): FormattedComment[] => {
-    let isXmlDocument = false;
     if (typeof input === "object" && input !== null) {
       try {
-        isXmlDocument = typeGuard.xmlDocument(input);
-      } catch {
-        isXmlDocument = false;
+        if (typeGuard.xmlDocument(input)) {
+          return parseXMLDocument(input);
+        }
+      } catch (error) {
+        if (!(error instanceof TypeError)) throw error;
       }
     }
-    if (!isXmlDocument) {
-      throw new InvalidFormatError();
-    }
-    return parseXMLDocument(input as XMLDocument);
+    throw new InvalidFormatError();
   },
 };
 

--- a/src/inputParser.ts
+++ b/src/inputParser.ts
@@ -1,3 +1,5 @@
+import { ValiError } from "valibot";
+
 import type { FormattedComment, InputFormatType } from "@/@types/";
 import { InvalidFormatError } from "@/errors";
 import { parsers } from "@/input";
@@ -12,9 +14,24 @@ const convert2formattedComment = (
   data: unknown,
   type: InputFormatType,
 ): FormattedComment[] => {
-  const parser = parsers.find((parser) => parser.key.includes(type));
-  if (!parser) throw new InvalidFormatError();
-  return sort(parser.parse(data));
+  const targetParsers = parsers.filter((parser) => parser.key.includes(type));
+  if (targetParsers.length === 0) throw new InvalidFormatError();
+
+  let firstError: unknown;
+  for (const parser of targetParsers) {
+    try {
+      return sort(parser.parse(data));
+    } catch (error) {
+      if (
+        !(error instanceof InvalidFormatError || error instanceof ValiError)
+      ) {
+        throw error;
+      }
+      firstError ??= error;
+    }
+  }
+
+  throw firstError ?? new InvalidFormatError();
 };
 
 /**

--- a/tests/unit/inputParser.spec.ts
+++ b/tests/unit/inputParser.spec.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from "vitest";
+
+import { InvalidFormatError } from "@/errors";
+import convert2formattedComment from "@/inputParser";
+
+type TestElement = {
+  nodeName: string;
+  textContent: string;
+  getAttribute: (name: string) => string | null;
+};
+
+const createXmlElement = (
+  attributes: Record<string, string>,
+  content: string,
+): TestElement => ({
+  nodeName: "chat",
+  textContent: content,
+  getAttribute: (name) => attributes[name] ?? null,
+});
+
+const createXmlDocument = (children: TestElement[]): XMLDocument =>
+  ({
+    documentElement: {
+      nodeName: "packet",
+      children,
+    },
+  }) as XMLDocument;
+
+describe("convert2formattedComment", () => {
+  it.each([
+    {
+      type: "legacy" as const,
+      expectedUserIds: [0, 1, 0, 2, 2],
+      input: [
+        { chat: { no: 1, vpos: 0, date: 1, user_id: "alice", content: "a" } },
+        { chat: { no: 2, vpos: 1, date: 2, user_id: "bob", content: "b" } },
+        { chat: { no: 3, vpos: 2, date: 3, user_id: "alice", content: "c" } },
+        { chat: { no: 4, vpos: 3, date: 4, user_id: "", content: "d" } },
+        { chat: { no: 5, vpos: 4, date: 5, user_id: "", content: "e" } },
+      ],
+    },
+    {
+      type: "v1" as const,
+      expectedUserIds: [0, 1, 0],
+      input: [
+        {
+          id: "thread",
+          fork: "main",
+          comments: [
+            {
+              id: "1",
+              no: 1,
+              vposMs: 0,
+              body: "a",
+              commands: [],
+              userId: "alice",
+              isPremium: false,
+              score: 0,
+              postedAt: "2024-01-01T00:00:01.000Z",
+              nicoruCount: 0,
+              nicoruId: null,
+              source: "nicovideo",
+              isMyPost: false,
+            },
+            {
+              id: "2",
+              no: 2,
+              vposMs: 10,
+              body: "b",
+              commands: [],
+              userId: "bob",
+              isPremium: false,
+              score: 0,
+              postedAt: "2024-01-01T00:00:02.000Z",
+              nicoruCount: 0,
+              nicoruId: null,
+              source: "nicovideo",
+              isMyPost: false,
+            },
+            {
+              id: "3",
+              no: 3,
+              vposMs: 20,
+              body: "c",
+              commands: [],
+              userId: "alice",
+              isPremium: false,
+              score: 0,
+              postedAt: "2024-01-01T00:00:03.000Z",
+              nicoruCount: 0,
+              nicoruId: null,
+              source: "nicovideo",
+              isMyPost: false,
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: "xml2js" as const,
+      expectedUserIds: [0, 1, 0, 2, 2],
+      input: {
+        packet: {
+          chat: [
+            { _: "a", $: { no: "1", vpos: "0", date: "1", user_id: "alice" } },
+            { _: "b", $: { no: "2", vpos: "1", date: "2", user_id: "bob" } },
+            { _: "c", $: { no: "3", vpos: "2", date: "3", user_id: "alice" } },
+            { _: "d", $: { no: "4", vpos: "3", date: "4" } },
+            { _: "e", $: { no: "5", vpos: "4", date: "5" } },
+          ],
+        },
+      },
+    },
+    {
+      type: "XMLDocument" as const,
+      expectedUserIds: [0, 1, 0, 2, 2],
+      input: createXmlDocument([
+        createXmlElement(
+          { no: "1", vpos: "0", date: "1", user_id: "alice" },
+          "a",
+        ),
+        createXmlElement(
+          { no: "2", vpos: "1", date: "2", user_id: "bob" },
+          "b",
+        ),
+        createXmlElement(
+          { no: "3", vpos: "2", date: "3", user_id: "alice" },
+          "c",
+        ),
+        createXmlElement({ no: "4", vpos: "3", date: "4" }, "d"),
+        createXmlElement({ no: "5", vpos: "4", date: "5" }, "e"),
+      ]),
+    },
+  ])("assigns stable user_id values for $type input", ({
+    expectedUserIds,
+    input,
+    type,
+  }) => {
+    const output = convert2formattedComment(input, type);
+
+    expect(output.map((comment) => comment.user_id)).toEqual(expectedUserIds);
+  });
+
+  it("routes XMLDocument input through the XML parser for XMLDocument and niconicome", () => {
+    const xmlDocument = createXmlDocument([
+      createXmlElement(
+        { no: "1", vpos: "0", date: "1", user_id: "alice" },
+        "xml",
+      ),
+    ]);
+
+    expect(convert2formattedComment(xmlDocument, "XMLDocument")).toMatchObject([
+      { id: 1, content: "xml", user_id: 0, owner: false },
+    ]);
+    expect(convert2formattedComment(xmlDocument, "niconicome")).toMatchObject([
+      { id: 1, content: "xml", user_id: 0, owner: false },
+    ]);
+  });
+
+  it("keeps formatted and niconicome array input on the formatted parser path", () => {
+    const formattedArray = [
+      {
+        id: 1,
+        vpos: 0,
+        content: "array",
+        date: 1,
+        date_usec: 0,
+        owner: false,
+        premium: false,
+        mail: [],
+        user_id: 99,
+        layer: -1,
+        is_my_post: false,
+      },
+    ];
+
+    expect(convert2formattedComment(formattedArray, "formatted")).toMatchObject(
+      [{ id: 1, content: "array", user_id: 99 }],
+    );
+    expect(
+      convert2formattedComment(formattedArray, "niconicome"),
+    ).toMatchObject([{ id: 1, content: "array", user_id: 99 }]);
+  });
+
+  it("keeps first-seen user_id assignment stable after the final sort", () => {
+    const output = convert2formattedComment(
+      [
+        { chat: { no: 1, vpos: 20, date: 3, user_id: "bob", content: "late" } },
+        {
+          chat: {
+            no: 2,
+            vpos: 10,
+            date: 2,
+            user_id: "alice",
+            content: "middle",
+          },
+        },
+        { chat: { no: 3, vpos: 0, date: 1, user_id: "bob", content: "early" } },
+      ],
+      "legacy",
+    );
+
+    expect(output.map((comment) => comment.id)).toEqual([3, 2, 1]);
+    expect(output.map((comment) => comment.user_id)).toEqual([0, 1, 0]);
+  });
+
+  it("rejects XMLDocument input for the formatted array parser", () => {
+    const xmlDocument = createXmlDocument([
+      createXmlElement(
+        { no: "1", vpos: "0", date: "1", user_id: "alice" },
+        "xml",
+      ),
+    ]);
+
+    expect(() => convert2formattedComment(xmlDocument, "formatted")).toThrow();
+  });
+
+  it("throws InvalidFormatError for invalid XMLDocument-like input", () => {
+    expect(() => convert2formattedComment(null, "XMLDocument")).toThrow(
+      InvalidFormatError,
+    );
+  });
+});

--- a/tests/unit/inputParser.spec.ts
+++ b/tests/unit/inputParser.spec.ts
@@ -219,5 +219,16 @@ describe("convert2formattedComment", () => {
     expect(() => convert2formattedComment(null, "XMLDocument")).toThrow(
       InvalidFormatError,
     );
+    expect(() =>
+      convert2formattedComment(
+        {
+          documentElement: {
+            nodeName: "packet",
+            children: [{ nodeName: "chat" }],
+          },
+        } as XMLDocument,
+        "XMLDocument",
+      ),
+    ).toThrow(InvalidFormatError);
   });
 });


### PR DESCRIPTION
## Summary\n- replace quadratic user ID assignment in input parsers with Map-based stable numbering\n- route XMLDocument and niconicome XML input through the XML parser while preserving formatted array behavior\n- add focused unit coverage for stable numbering, sorting interaction, and XMLDocument dispatch/validation\n\n## Validation\n- rtk pnpm test:unit\n- rtk pnpm check-types\n- rtk pnpm lint

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the quadratic `indexOf`-based user ID numbering across all input parsers with a shared `assignUserId` helper backed by a `Map`, and reworks how `"XMLDocument"` and `"niconicome"` inputs are dispatched by switching `inputParser.ts` from a `find`-first to a `filter`-and-try-each approach.

- **`assignUserId` (xmlDocument.ts)**: Centralises the first-seen-wins ID assignment logic into a single O(1)-lookup helper, eliminating four near-identical O(n) implementations across `legacy.ts`, `v1.ts`, `xml2js.ts`, and `xmlDocument.ts`.
- **Parser key & dispatch change**: `XmlDocumentParser` loses the `"formatted"` key (it was already shadowed by `FormattedParser` under the old `find` strategy) and gains the explicit `"XMLDocument"` key; `inputParser.ts` now tries every matching parser in registration order, catching `InvalidFormatError`/`ValiError` to fall through to the next candidate.
- **Tests**: New unit suite in `tests/unit/inputParser.spec.ts` covers stable ID assignment, sort-interaction, XMLDocument dispatch, and rejection paths for all affected parsers.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — well-scoped refactor with no altered external contracts and full unit coverage of the new dispatch logic.

All four parsers now share a single, correctly implemented Map-based user ID helper. The multi-parser fallback in inputParser.ts is logically sound, registration order ensures FormattedParser is always tried before XmlDocumentParser for the shared niconicome key, and the new test suite covers all affected paths with no public API changes.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/input/xmlDocument.ts | Adds the exported assignUserId Map-based helper; refactors the parser key to ["XMLDocument","niconicome"] and wraps typeGuard.xmlDocument in a TypeError-aware try/catch. |
| src/inputParser.ts | Switches from find-first to filter+sequential-try, catching InvalidFormatError/ValiError to enable multi-parser fallback; re-throws unexpected errors immediately. |
| src/input/legacy.ts | Imports and delegates to assignUserId; removes the inlined indexOf-based quadratic lookup. Behaviour is preserved. |
| src/input/v1.ts | Same mechanical refactor as legacy.ts — inlined O(n) indexOf replaced by assignUserId. |
| src/input/xml2js.ts | Same mechanical refactor as legacy.ts — inlined O(n) indexOf replaced by assignUserId. |
| tests/unit/inputParser.spec.ts | New test file covering stable-ID assignment across all four parser types, sort-interaction, XMLDocument/niconicome routing, and error rejection paths. |

</details>

</details>

<sub>Reviews (3): Last reviewed commit: ["refactor: share stable input user ID ass..."](https://github.com/xpadev-net/niconicomments/commit/9ec492a1118583400dc7662b17aa232c464648eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35213761)</sub>

<!-- /greptile_comment -->