### PR TITLE
fix: bound comment durations and lazy expansion

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -34,7 +34,7 @@ import {
   processFixedComment,
   processMovableComment,
 } from "@/utils";
-import { MAX_LAZY_COMMENT_LOOKAHEAD } from "@/utils/comment";
+import { getLazyCommentLookahead } from "@/utils/comment";
 import { createCommentInstance } from "@/utils/plugins";
 import { RangeCacheContext } from "@/utils/rangeCache";
 
@@ -355,7 +355,8 @@ class NiconiComments {
   private resolveLazyCommentWindow(vpos: number) {
     if (!this.ctx.options.lazy) return false;
     const startIndex = this._advanceNextUnprocessedCommentIndex();
-    const resolveUntil = vpos + MAX_LAZY_COMMENT_LOOKAHEAD;
+    const resolveUntil =
+      vpos + getLazyCommentLookahead(this.ctx.config.canvasWidth);
     let endIndex = startIndex - 1;
     for (let i = startIndex; i < this.comments.length; i++) {
       const comment = this.comments[i];

--- a/src/main.ts
+++ b/src/main.ts
@@ -115,6 +115,7 @@ class NiconiComments {
     hasNaka: boolean;
   } | null = null;
   private lazyCommentOrderSortedByVpos: boolean;
+  private nextUnprocessedCommentIndex: number;
   private commentArrayIndexMap: WeakMap<IComment, number>;
   private processedCommentIndex: number;
   private comments: IComment[];
@@ -212,11 +213,13 @@ class NiconiComments {
     };
     this.lastVpos = -1;
     this.lazyCommentOrderSortedByVpos = true;
+    this.nextUnprocessedCommentIndex = 0;
     this.commentArrayIndexMap = new WeakMap();
     this.processedCommentIndex = -1;
 
     this.comments = this.preRendering(parsedData);
     this._rebuildCommentArrayIndex(this.comments);
+    this._advanceNextUnprocessedCommentIndex();
 
     this._log(
       `constructor complete: ${performance.now() - constructorStart}ms`,
@@ -234,6 +237,17 @@ class NiconiComments {
       if (!comment) continue;
       this.commentArrayIndexMap.set(comment, i);
     }
+  }
+
+  private _advanceNextUnprocessedCommentIndex(comments = this.comments) {
+    while (this.nextUnprocessedCommentIndex < comments.length) {
+      const comment = comments[this.nextUnprocessedCommentIndex];
+      if (comment && !comment.invisible && comment.posY < 0) {
+        break;
+      }
+      this.nextUnprocessedCommentIndex++;
+    }
+    return this.nextUnprocessedCommentIndex;
   }
 
   /**
@@ -322,6 +336,11 @@ class NiconiComments {
         );
       }
     }
+    this.nextUnprocessedCommentIndex = Math.max(
+      this.nextUnprocessedCommentIndex,
+      this.processedCommentIndex + 1,
+    );
+    this._advanceNextUnprocessedCommentIndex(data);
     this._log(
       `getCommentPos complete: ${performance.now() - getCommentPosStart}ms`,
     );
@@ -329,12 +348,15 @@ class NiconiComments {
 
   private resolveLazyCommentWindow(vpos: number) {
     if (!this.ctx.options.lazy) return false;
-    const startIndex = this.processedCommentIndex + 1;
+    const startIndex = this._advanceNextUnprocessedCommentIndex();
     const resolveUntil = vpos + MAX_LAZY_COMMENT_LOOKAHEAD;
     let endIndex = startIndex - 1;
-    for (let i = startIndex; i < this.comments.length; i++) {
+    const scanLimit = this.lazyCommentOrderSortedByVpos
+      ? this.comments.length
+      : Math.min(this.comments.length, startIndex + MAX_LAZY_COMMENT_LOOKAHEAD);
+    for (let i = startIndex; i < scanLimit; i++) {
       const comment = this.comments[i];
-      if (!comment || comment.posY > -1) {
+      if (!comment || comment.invisible || comment.posY > -1) {
         continue;
       }
       if (comment.vpos <= resolveUntil) {
@@ -410,6 +432,10 @@ class NiconiComments {
       }
     }
     this.comments.push(...comments);
+    this.nextUnprocessedCommentIndex = Math.min(
+      this.nextUnprocessedCommentIndex,
+      this.comments.length - comments.length,
+    );
     const baseOffset = this.comments.length - comments.length;
     for (let i = 0, n = comments.length; i < n; i++) {
       const comment = comments[i];
@@ -426,6 +452,7 @@ class NiconiComments {
         this.comments.length - 1,
       );
     }
+    this._advanceNextUnprocessedCommentIndex();
     this.sortTimelineComment();
     this._cachedSplit = null;
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -282,9 +282,8 @@ class NiconiComments {
    * 計算された描画サイズをもとに各コメントの配置位置を決定する
    * @param data コメントデータ
    * @param end 終了インデックス
-   * @param lazy 遅延処理を行うか
    */
-  private getCommentPos(data: IComment[], end: number, lazy = false) {
+  private getCommentPos(data: IComment[], end: number) {
     const getCommentPosStart = performance.now();
     const startIndex = this.processedCommentIndex + 1;
     if (startIndex >= end) return;
@@ -292,13 +291,13 @@ class NiconiComments {
       const comment = data[i];
       if (!comment) continue;
       this.processedCommentIndex = i;
-      if (comment.invisible || (comment.posY > -1 && !lazy)) continue;
+      if (comment.invisible || comment.posY > -1) continue;
       if (comment.loc === "naka") {
         processMovableComment(
           comment,
           this.collision,
           this.timeline,
-          lazy,
+          false,
           this.ctx.config,
         );
       } else {
@@ -306,13 +305,10 @@ class NiconiComments {
           comment,
           this.collision[comment.loc],
           this.timeline,
-          lazy,
+          false,
           this.ctx.config,
         );
       }
-    }
-    if (lazy) {
-      this.processedCommentIndex = -1;
     }
     this._log(
       `getCommentPos complete: ${performance.now() - getCommentPosStart}ms`,
@@ -323,29 +319,22 @@ class NiconiComments {
     if (!this.ctx.options.lazy) return false;
     const startIndex = this.processedCommentIndex + 1;
     const resolveUntil = vpos + MAX_LAZY_COMMENT_LOOKAHEAD;
-    let endIndex = startIndex;
-    while (endIndex < this.comments.length) {
-      const comment = this.comments[endIndex];
-      if (!comment) {
-        endIndex++;
+    let endIndex = startIndex - 1;
+    for (let i = startIndex; i < this.comments.length; i++) {
+      const comment = this.comments[i];
+      if (!comment || comment.posY > -1) {
         continue;
       }
-      if (comment.vpos > resolveUntil) {
-        break;
+      if (comment.vpos <= resolveUntil) {
+        endIndex = i;
       }
-      endIndex++;
     }
-    if (endIndex <= startIndex) {
+    if (endIndex < startIndex) {
       return false;
     }
-    this.getCommentPos(this.comments, endIndex);
+    this.getCommentPos(this.comments, endIndex + 1);
+    this.sortTimelineComment();
     return true;
-  }
-
-  private sortTimelineRange(vpos: number) {
-    const item = this.timeline[vpos];
-    item?.sort(TIMELINE_COMMENT_SORT);
-    return item ?? EMPTY_TIMELINE;
   }
 
   /**
@@ -467,15 +456,9 @@ class NiconiComments {
     const triggerHandlerStart = profile ? performance.now() : 0;
     this.eventHandler.trigger(vposInt, this.lastVposInt, this.ctx.nicoScripts);
     setProfile("triggerHandler", triggerHandlerStart);
-    const resolvedLazyWindow = this.resolveLazyCommentWindow(vposInt);
-    const timelineRange =
-      resolvedLazyWindow || this.ctx.options.lazy
-        ? this.sortTimelineRange(vposInt)
-        : (this.timeline[vposInt] ?? EMPTY_TIMELINE);
-    const lastTimelineRange =
-      resolvedLazyWindow || this.ctx.options.lazy
-        ? this.sortTimelineRange(this.lastVposInt)
-        : (this.timeline[this.lastVposInt] ?? EMPTY_TIMELINE);
+    this.resolveLazyCommentWindow(vposInt);
+    const timelineRange = this.timeline[vposInt] ?? EMPTY_TIMELINE;
+    const lastTimelineRange = this.timeline[this.lastVposInt] ?? EMPTY_TIMELINE;
     const currentHasNaka = hasNakaComment(timelineRange);
     const lastHasNaka =
       this._cachedSplit?.vpos === this.lastVposInt

--- a/src/main.ts
+++ b/src/main.ts
@@ -34,6 +34,7 @@ import {
   processFixedComment,
   processMovableComment,
 } from "@/utils";
+import { MAX_LAZY_COMMENT_LOOKAHEAD } from "@/utils/comment";
 import { createCommentInstance } from "@/utils/plugins";
 import { RangeCacheContext } from "@/utils/rangeCache";
 
@@ -41,6 +42,8 @@ import * as internal from "./internal";
 
 const EMPTY_TIMELINE = Object.freeze([]) as readonly IComment[];
 const BAN_FRAME_POSITION_RESOLUTION_BUDGET = 256;
+const TIMELINE_COMMENT_SORT = (a: IComment, b: IComment) =>
+  Number(a.owner) - Number(b.owner) || a.index - b.index;
 
 const toIntegerOrInfinity = (value: number) => {
   if (Number.isNaN(value) || value === 0) return 0;
@@ -246,8 +249,10 @@ class NiconiComments {
       pv.push(createCommentInstance(val, this.renderer, index, this.ctx));
       return pv;
     }, []);
-    this.getCommentPos(instances, instances.length, this.ctx.options.lazy);
-    this.sortTimelineComment();
+    if (!this.ctx.options.lazy) {
+      this.getCommentPos(instances, instances.length);
+      this.sortTimelineComment();
+    }
 
     const plugins: IPluginList = [];
     for (const plugin of this.ctx.config.plugins) {
@@ -314,6 +319,35 @@ class NiconiComments {
     );
   }
 
+  private resolveLazyCommentWindow(vpos: number) {
+    if (!this.ctx.options.lazy) return false;
+    const startIndex = this.processedCommentIndex + 1;
+    const resolveUntil = vpos + MAX_LAZY_COMMENT_LOOKAHEAD;
+    let endIndex = startIndex;
+    while (endIndex < this.comments.length) {
+      const comment = this.comments[endIndex];
+      if (!comment) {
+        endIndex++;
+        continue;
+      }
+      if (comment.vpos > resolveUntil) {
+        break;
+      }
+      endIndex++;
+    }
+    if (endIndex <= startIndex) {
+      return false;
+    }
+    this.getCommentPos(this.comments, endIndex);
+    return true;
+  }
+
+  private sortTimelineRange(vpos: number) {
+    const item = this.timeline[vpos];
+    item?.sort(TIMELINE_COMMENT_SORT);
+    return item ?? EMPTY_TIMELINE;
+  }
+
   /**
    * 投稿者コメントを前に移動
    */
@@ -322,9 +356,7 @@ class NiconiComments {
     for (const vpos of Object.keys(this.timeline)) {
       const item = this.timeline[Number(vpos)];
       if (!item) continue;
-      item.sort(
-        (a, b) => Number(a.owner) - Number(b.owner) || a.index - b.index,
-      );
+      item.sort(TIMELINE_COMMENT_SORT);
     }
     this._log(`parseData complete: ${performance.now() - sortCommentStart}ms`);
   }
@@ -435,8 +467,15 @@ class NiconiComments {
     const triggerHandlerStart = profile ? performance.now() : 0;
     this.eventHandler.trigger(vposInt, this.lastVposInt, this.ctx.nicoScripts);
     setProfile("triggerHandler", triggerHandlerStart);
-    const timelineRange = this.timeline[vposInt] ?? EMPTY_TIMELINE;
-    const lastTimelineRange = this.timeline[this.lastVposInt] ?? EMPTY_TIMELINE;
+    const resolvedLazyWindow = this.resolveLazyCommentWindow(vposInt);
+    const timelineRange =
+      resolvedLazyWindow || this.ctx.options.lazy
+        ? this.sortTimelineRange(vposInt)
+        : (this.timeline[vposInt] ?? EMPTY_TIMELINE);
+    const lastTimelineRange =
+      resolvedLazyWindow || this.ctx.options.lazy
+        ? this.sortTimelineRange(this.lastVposInt)
+        : (this.timeline[this.lastVposInt] ?? EMPTY_TIMELINE);
     const currentHasNaka = hasNakaComment(timelineRange);
     const lastHasNaka =
       this._cachedSplit?.vpos === this.lastVposInt

--- a/src/main.ts
+++ b/src/main.ts
@@ -298,6 +298,12 @@ class NiconiComments {
         );
       },
     );
+    if (this.ctx.options.lazy && !this.lazyCommentOrderSortedByVpos) {
+      // Lazy resolution assumes constructor input is vpos-ordered. Preserve
+      // correctness for unsorted input by resolving all comments eagerly once.
+      this.getCommentPos(instances, instances.length);
+      this.sortTimelineComment();
+    }
     this._log(
       `preRendering complete: ${performance.now() - preRenderingStart}ms`,
     );
@@ -351,10 +357,7 @@ class NiconiComments {
     const startIndex = this._advanceNextUnprocessedCommentIndex();
     const resolveUntil = vpos + MAX_LAZY_COMMENT_LOOKAHEAD;
     let endIndex = startIndex - 1;
-    const scanLimit = this.lazyCommentOrderSortedByVpos
-      ? this.comments.length
-      : Math.min(this.comments.length, startIndex + MAX_LAZY_COMMENT_LOOKAHEAD);
-    for (let i = startIndex; i < scanLimit; i++) {
+    for (let i = startIndex; i < this.comments.length; i++) {
       const comment = this.comments[i];
       if (!comment || comment.invisible || comment.posY > -1) {
         continue;

--- a/src/main.ts
+++ b/src/main.ts
@@ -114,6 +114,7 @@ class NiconiComments {
     vpos: number;
     hasNaka: boolean;
   } | null = null;
+  private lazyCommentOrderSortedByVpos: boolean;
   private commentArrayIndexMap: WeakMap<IComment, number>;
   private processedCommentIndex: number;
   private comments: IComment[];
@@ -210,6 +211,7 @@ class NiconiComments {
       right: {},
     };
     this.lastVpos = -1;
+    this.lazyCommentOrderSortedByVpos = true;
     this.commentArrayIndexMap = new WeakMap();
     this.processedCommentIndex = -1;
 
@@ -272,6 +274,16 @@ class NiconiComments {
     }
 
     this.plugins = plugins;
+    this.lazyCommentOrderSortedByVpos = instances.every(
+      (comment, index, comments) => {
+        const previousComment = comments[index - 1];
+        return (
+          index === 0 ||
+          previousComment === undefined ||
+          previousComment.vpos <= comment.vpos
+        );
+      },
+    );
     this._log(
       `preRendering complete: ${performance.now() - preRenderingStart}ms`,
     );
@@ -327,6 +339,8 @@ class NiconiComments {
       }
       if (comment.vpos <= resolveUntil) {
         endIndex = i;
+      } else if (this.lazyCommentOrderSortedByVpos) {
+        break;
       }
     }
     if (endIndex < startIndex) {

--- a/src/utils/comment.ts
+++ b/src/utils/comment.ts
@@ -45,8 +45,8 @@ const RE_WAKU = /^nico:waku:(.+)$/;
 const RE_FILL = /^nico:fill:(.+)$/;
 const RE_OPACITY = /^nico:opacity:(.+)$/;
 const RE_COLOR_CODE = /^#(?:[0-9a-z]{3}|[0-9a-z]{6})$/;
-const DEFAULT_COMMENT_LONG = 300;
-const DEFAULT_NICOSCRIPT_LONG = 30 * 100;
+export const DEFAULT_COMMENT_LONG = 300;
+export const DEFAULT_NICOSCRIPT_LONG = 30 * 100;
 export const MAX_COMMENT_LONG = 120 * 100;
 export const MAX_LAZY_COMMENT_LOOKAHEAD =
   Math.ceil((288 * (MAX_COMMENT_LONG + 125)) / 1632) + 100;

--- a/src/utils/comment.ts
+++ b/src/utils/comment.ts
@@ -45,6 +45,49 @@ const RE_WAKU = /^nico:waku:(.+)$/;
 const RE_FILL = /^nico:fill:(.+)$/;
 const RE_OPACITY = /^nico:opacity:(.+)$/;
 const RE_COLOR_CODE = /^#(?:[0-9a-z]{3}|[0-9a-z]{6})$/;
+const DEFAULT_COMMENT_LONG = 300;
+const DEFAULT_NICOSCRIPT_LONG = 30 * 100;
+export const MAX_COMMENT_LONG = 120 * 100;
+export const MAX_LAZY_COMMENT_LOOKAHEAD =
+  Math.ceil((288 * (MAX_COMMENT_LONG + 125)) / 1632) + 100;
+
+const normalizeLongCentiseconds = (value: number) => {
+  if (!Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+  return Math.min(Math.floor(value), MAX_COMMENT_LONG);
+};
+
+const normalizeCommentLong = (value: number | undefined) => {
+  if (value === undefined) {
+    return DEFAULT_COMMENT_LONG;
+  }
+  return normalizeLongCentiseconds(value * 100) || DEFAULT_COMMENT_LONG;
+};
+
+const normalizeParsedCommandLong = (value: number | undefined) => {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+  return Math.min(value, MAX_COMMENT_LONG / 100);
+};
+
+const normalizeOptionalLong = (value: number | undefined) => {
+  if (value === undefined) {
+    return undefined;
+  }
+  return normalizeLongCentiseconds(value * 100);
+};
+
+const normalizeNicoscriptLong = (value: number | undefined) => {
+  if (value === undefined) {
+    return DEFAULT_NICOSCRIPT_LONG;
+  }
+  return normalizeLongCentiseconds(value * 100);
+};
 
 /**
  * 改行リサイズが発生するか
@@ -177,6 +220,7 @@ const parseCommandAndNicoScript = (
   const { config, options, nicoScripts, rangeCache } = ctx;
   const isFlash = isFlashComment(comment, config, options);
   const commands = parseCommands(comment, config, options);
+  commands.long = normalizeParsedCommandLong(commands.long);
   processNicoscript(comment, commands, nicoScripts, rangeCache);
   const defaultCommand = getDefaultCommand(comment.vpos, nicoScripts);
   applyNicoScriptReplace(comment, commands, nicoScripts);
@@ -187,7 +231,7 @@ const parseCommandAndNicoScript = (
     color: commands.color ?? defaultCommand.color ?? "#FFFFFF",
     font: commands.font ?? defaultCommand.font ?? "defont",
     fontSize: getConfig(config.fontSize, isFlash)[size].default,
-    long: commands.long ? Math.floor(Number(commands.long) * 100) : 300,
+    long: normalizeCommentLong(commands.long),
     flash: isFlash,
     full: commands.full,
     ender: commands.ender,
@@ -265,8 +309,7 @@ const addNicoscriptReplace = (
     return;
   nicoScripts.replace.unshift({
     start: comment.vpos,
-    long:
-      commands.long === undefined ? undefined : Math.floor(commands.long * 100),
+    long: normalizeOptionalLong(commands.long),
     keyword: result[0],
     replace: result[1] ?? "",
     range: result[2] ?? "単", //単
@@ -361,8 +404,7 @@ const processDefaultScript = (
 ) => {
   nicoScripts.default.unshift({
     start: comment.vpos,
-    long:
-      commands.long === undefined ? undefined : Math.floor(commands.long * 100),
+    long: normalizeOptionalLong(commands.long),
     color: commands.color,
     size: commands.size,
     font: commands.font,
@@ -387,12 +429,10 @@ const processReverseScript = (
   const target = typeGuard.nicoScript.range.target(reverse?.[1])
     ? reverse?.[1]
     : "全";
-  if (commands.long === undefined) {
-    commands.long = 30;
-  }
+  const long = normalizeNicoscriptLong(commands.long);
   nicoScripts.reverse.unshift({
     start: comment.vpos,
-    end: comment.vpos + commands.long * 100,
+    end: comment.vpos + long,
     target,
   });
   rangeCache.reverseActiveOwner.clear();
@@ -412,12 +452,10 @@ const processBanScript = (
   nicoScripts: NicoScript,
   rangeCache: RangeCacheContext,
 ) => {
-  if (commands.long === undefined) {
-    commands.long = 30;
-  }
+  const long = normalizeNicoscriptLong(commands.long);
   nicoScripts.ban.unshift({
     start: comment.vpos,
-    end: comment.vpos + commands.long * 100,
+    end: comment.vpos + long,
   });
   rangeCache.banActive.clear();
 };
@@ -433,12 +471,10 @@ const processSeekDisableScript = (
   commands: ParsedCommand,
   nicoScripts: NicoScript,
 ) => {
-  if (commands.long === undefined) {
-    commands.long = 30;
-  }
+  const long = normalizeNicoscriptLong(commands.long);
   nicoScripts.seekDisable.unshift({
     start: comment.vpos,
-    end: comment.vpos + commands.long * 100,
+    end: comment.vpos + long,
   });
 };
 
@@ -457,10 +493,8 @@ const processJumpScript = (
 ) => {
   const jumpOptions = RE_JUMP.exec(input);
   if (!jumpOptions?.[1]) return;
-  const end =
-    commands.long === undefined
-      ? undefined
-      : commands.long * 100 + comment.vpos;
+  const long = normalizeOptionalLong(commands.long);
+  const end = long === undefined ? undefined : long + comment.vpos;
   nicoScripts.jump.unshift({
     start: comment.vpos,
     end,

--- a/src/utils/comment.ts
+++ b/src/utils/comment.ts
@@ -48,21 +48,28 @@ const RE_COLOR_CODE = /^#(?:[0-9a-z]{3}|[0-9a-z]{6})$/;
 export const DEFAULT_COMMENT_LONG = 300;
 export const DEFAULT_NICOSCRIPT_LONG = 30 * 100;
 export const MAX_COMMENT_LONG = 120 * 100;
+export const MAX_NICOSCRIPT_LONG = 60 * 60 * 100;
+// Derived from the maximum naka comment lead-in distance:
+// 288px off-screen travel, 1632px total travel width, plus 125cs motion margin
+// and a 100cs safety buffer to populate the lazy timeline before draw time.
 export const MAX_LAZY_COMMENT_LOOKAHEAD =
   Math.ceil((288 * (MAX_COMMENT_LONG + 125)) / 1632) + 100;
 
-const normalizeLongCentiseconds = (value: number) => {
+const normalizeLongCentiseconds = (value: number, max: number) => {
   if (!Number.isFinite(value) || value <= 0) {
     return 0;
   }
-  return Math.min(Math.floor(value), MAX_COMMENT_LONG);
+  return Math.min(Math.floor(value), max);
 };
 
 const normalizeCommentLong = (value: number | undefined) => {
   if (value === undefined) {
     return DEFAULT_COMMENT_LONG;
   }
-  return normalizeLongCentiseconds(value * 100) || DEFAULT_COMMENT_LONG;
+  return (
+    normalizeLongCentiseconds(value * 100, MAX_COMMENT_LONG) ||
+    DEFAULT_COMMENT_LONG
+  );
 };
 
 const normalizeParsedCommandLong = (value: number | undefined) => {
@@ -72,21 +79,24 @@ const normalizeParsedCommandLong = (value: number | undefined) => {
   if (!Number.isFinite(value) || value <= 0) {
     return undefined;
   }
-  return Math.min(value, MAX_COMMENT_LONG / 100);
+  return value;
 };
 
-const normalizeOptionalLong = (value: number | undefined) => {
+const normalizeOptionalNicoscriptLong = (value: number | undefined) => {
   if (value === undefined) {
     return undefined;
   }
-  return normalizeLongCentiseconds(value * 100);
+  return normalizeLongCentiseconds(value * 100, MAX_NICOSCRIPT_LONG);
 };
 
 const normalizeNicoscriptLong = (value: number | undefined) => {
   if (value === undefined) {
     return DEFAULT_NICOSCRIPT_LONG;
   }
-  return normalizeLongCentiseconds(value * 100);
+  return (
+    normalizeLongCentiseconds(value * 100, MAX_NICOSCRIPT_LONG) ||
+    DEFAULT_NICOSCRIPT_LONG
+  );
 };
 
 /**
@@ -309,7 +319,7 @@ const addNicoscriptReplace = (
     return;
   nicoScripts.replace.unshift({
     start: comment.vpos,
-    long: normalizeOptionalLong(commands.long),
+    long: normalizeOptionalNicoscriptLong(commands.long),
     keyword: result[0],
     replace: result[1] ?? "",
     range: result[2] ?? "単", //単
@@ -404,7 +414,7 @@ const processDefaultScript = (
 ) => {
   nicoScripts.default.unshift({
     start: comment.vpos,
-    long: normalizeOptionalLong(commands.long),
+    long: normalizeOptionalNicoscriptLong(commands.long),
     color: commands.color,
     size: commands.size,
     font: commands.font,
@@ -493,7 +503,7 @@ const processJumpScript = (
 ) => {
   const jumpOptions = RE_JUMP.exec(input);
   if (!jumpOptions?.[1]) return;
-  const long = normalizeOptionalLong(commands.long);
+  const long = normalizeOptionalNicoscriptLong(commands.long);
   const end = long === undefined ? undefined : long + comment.vpos;
   nicoScripts.jump.unshift({
     start: comment.vpos,

--- a/src/utils/comment.ts
+++ b/src/utils/comment.ts
@@ -70,7 +70,7 @@ const normalizeParsedCommandLong = (value: number | undefined) => {
     return undefined;
   }
   if (!Number.isFinite(value) || value <= 0) {
-    return 0;
+    return undefined;
   }
   return Math.min(value, MAX_COMMENT_LONG / 100);
 };

--- a/src/utils/comment.ts
+++ b/src/utils/comment.ts
@@ -49,11 +49,34 @@ export const DEFAULT_COMMENT_LONG = 300;
 export const DEFAULT_NICOSCRIPT_LONG = 30 * 100;
 export const MAX_COMMENT_LONG = 120 * 100;
 export const MAX_NICOSCRIPT_LONG = 60 * 60 * 100;
+const LAZY_LOOKAHEAD_LEAD_IN = 288;
+const LAZY_LOOKAHEAD_MOTION_MARGIN = 125;
+const LAZY_LOOKAHEAD_SAFETY_BUFFER = 100;
+const STANDARD_LAZY_LOOKAHEAD_CANVAS_WIDTH = 1920;
+const STANDARD_LAZY_LOOKAHEAD_TRAVEL_WIDTH = 1632;
 // Derived from the maximum naka comment lead-in distance:
 // 288px off-screen travel, 1632px total travel width, plus 125cs motion margin
 // and a 100cs safety buffer to populate the lazy timeline before draw time.
 export const MAX_LAZY_COMMENT_LOOKAHEAD =
-  Math.ceil((288 * (MAX_COMMENT_LONG + 125)) / 1632) + 100;
+  Math.ceil(
+    (LAZY_LOOKAHEAD_LEAD_IN *
+      (MAX_COMMENT_LONG + LAZY_LOOKAHEAD_MOTION_MARGIN)) /
+      STANDARD_LAZY_LOOKAHEAD_TRAVEL_WIDTH,
+  ) + LAZY_LOOKAHEAD_SAFETY_BUFFER;
+
+export const getLazyCommentLookahead = (canvasWidth: number) => {
+  if (!Number.isFinite(canvasWidth) || canvasWidth <= 0) {
+    return MAX_LAZY_COMMENT_LOOKAHEAD;
+  }
+  return (
+    Math.ceil(
+      (LAZY_LOOKAHEAD_LEAD_IN *
+        (MAX_COMMENT_LONG + LAZY_LOOKAHEAD_MOTION_MARGIN) *
+        (STANDARD_LAZY_LOOKAHEAD_CANVAS_WIDTH / canvasWidth)) /
+        STANDARD_LAZY_LOOKAHEAD_TRAVEL_WIDTH,
+    ) + LAZY_LOOKAHEAD_SAFETY_BUFFER
+  );
+};
 
 const normalizeLongCentiseconds = (value: number, max: number) => {
   if (!Number.isFinite(value) || value <= 0) {
@@ -86,7 +109,9 @@ const normalizeOptionalNicoscriptLong = (value: number | undefined) => {
   if (value === undefined) {
     return undefined;
   }
-  return normalizeLongCentiseconds(value * 100, MAX_NICOSCRIPT_LONG);
+  return (
+    normalizeLongCentiseconds(value * 100, MAX_NICOSCRIPT_LONG) || undefined
+  );
 };
 
 const normalizeNicoscriptLong = (value: number | undefined) => {

--- a/tests/unit/duration-lazy.spec.ts
+++ b/tests/unit/duration-lazy.spec.ts
@@ -1,0 +1,267 @@
+import { beforeAll, beforeEach, describe, expect, test } from "vitest";
+
+import type { FormattedComment, IRenderer } from "@/@types/";
+import type { CommentInstanceContext } from "@/contexts";
+import { createNicoScripts, ImageCacheContext } from "@/contexts";
+import { defaultConfig, defaultOptions } from "@/definition/config";
+import { initConfig } from "@/definition/initConfig";
+import NiconiComments from "@/main";
+import {
+  MAX_COMMENT_LONG,
+  MAX_LAZY_COMMENT_LOOKAHEAD,
+  parseCommandAndNicoScript,
+} from "@/utils/comment";
+import { RangeCacheContext } from "@/utils/rangeCache";
+
+class HTMLCanvasElementMock {}
+
+const HUGE_DURATION = "@9999";
+const OVERFLOW_DURATION = `@${"9".repeat(400)}`;
+
+const emptyTextMetrics = (width: number): TextMetrics =>
+  ({
+    width,
+    actualBoundingBoxLeft: 0,
+    actualBoundingBoxRight: width,
+    actualBoundingBoxAscent: 0,
+    actualBoundingBoxDescent: 0,
+    alphabeticBaseline: 0,
+    hangingBaseline: 0,
+    emHeightAscent: 0,
+    emHeightDescent: 0,
+    fontBoundingBoxAscent: 0,
+    fontBoundingBoxDescent: 0,
+    ideographicBaseline: 0,
+  }) as TextMetrics;
+
+class FakeRenderer implements IRenderer {
+  public readonly rendererName = "FakeRenderer";
+  public readonly canvas = {} as HTMLCanvasElement;
+  private font = "";
+  private size = { width: 1920, height: 1080 };
+
+  destroy() {}
+  drawVideo() {}
+  getFont() {
+    return this.font;
+  }
+  getFillStyle() {
+    return "#000000";
+  }
+  setScale() {}
+  fillRect() {}
+  strokeRect() {}
+  fillText() {}
+  strokeText() {}
+  quadraticCurveTo() {}
+  clearRect() {}
+  setFont(font: string) {
+    this.font = font;
+  }
+  setFillStyle() {}
+  setStrokeStyle() {}
+  setLineWidth() {}
+  setGlobalAlpha() {}
+  setSize(width: number, height: number) {
+    this.size = { width, height };
+  }
+  getSize() {
+    return this.size;
+  }
+  measureText(_text: string) {
+    return emptyTextMetrics(300);
+  }
+  beginPath() {}
+  closePath() {}
+  moveTo() {}
+  lineTo() {}
+  stroke() {}
+  save() {}
+  restore() {}
+  getCanvas() {
+    return this;
+  }
+  drawImage() {}
+  flush() {}
+  invalidateImage() {}
+}
+
+const createComment = (
+  overrides: Partial<FormattedComment> = {},
+): FormattedComment => ({
+  id: overrides.id ?? 1,
+  vpos: overrides.vpos ?? 0,
+  content: overrides.content ?? "test comment",
+  date: overrides.date ?? 1,
+  date_usec: overrides.date_usec ?? 0,
+  owner: overrides.owner ?? false,
+  premium: overrides.premium ?? false,
+  mail: overrides.mail ?? [],
+  user_id: overrides.user_id ?? 1,
+  layer: overrides.layer ?? -1,
+  is_my_post: overrides.is_my_post ?? false,
+});
+
+const createContext = (): CommentInstanceContext => {
+  initConfig();
+  return {
+    config: { ...defaultConfig },
+    options: { ...defaultOptions, mode: "html5" },
+    nicoScripts: createNicoScripts(),
+    imageCache: new ImageCacheContext(),
+    rangeCache: new RangeCacheContext(),
+  };
+};
+
+describe("duration bounds and lazy timeline expansion", () => {
+  beforeAll(() => {
+    if (typeof HTMLCanvasElement === "undefined") {
+      Object.defineProperty(globalThis, "HTMLCanvasElement", {
+        value: HTMLCanvasElementMock,
+        configurable: true,
+      });
+    }
+    if (typeof window === "undefined") {
+      Object.defineProperty(globalThis, "window", {
+        value: globalThis,
+        configurable: true,
+      });
+    }
+  });
+
+  beforeEach(() => {
+    initConfig();
+  });
+
+  test("caps huge fixed comment durations without creating enormous timeline keys", () => {
+    const startVpos = 100;
+    const instance = new NiconiComments(
+      new FakeRenderer(),
+      [createComment({ vpos: startVpos, mail: ["ue", HUGE_DURATION] })],
+      { format: "formatted", mode: "html5" },
+    );
+    const state = instance as unknown as {
+      comments: { long: number }[];
+      timeline: Record<number, unknown[]>;
+    };
+    const keys = Object.keys(state.timeline)
+      .map(Number)
+      .sort((a, b) => a - b);
+
+    expect(state.comments[0]?.long).toBe(MAX_COMMENT_LONG);
+    expect(keys).toHaveLength(MAX_COMMENT_LONG);
+    expect(keys[0]).toBe(startVpos);
+    expect(keys.at(-1)).toBe(startVpos + MAX_COMMENT_LONG - 1);
+  });
+
+  test("caps huge moving durations and neutralizes overflow-like values", () => {
+    const defaultMoving = parseCommandAndNicoScript(
+      createComment(),
+      createContext(),
+    );
+    const moving = parseCommandAndNicoScript(
+      createComment({ mail: [HUGE_DURATION] }),
+      createContext(),
+    );
+    expect(moving.long).toBe(MAX_COMMENT_LONG);
+
+    const infinityLike = parseCommandAndNicoScript(
+      createComment({ mail: [OVERFLOW_DURATION] }),
+      createContext(),
+    );
+    expect(infinityLike.long).toBe(defaultMoving.long);
+    expect(infinityLike.long).toBeLessThanOrEqual(MAX_COMMENT_LONG);
+  });
+
+  test("bounds NicoScript ban/reverse ranges and neutralizes explicit bad durations", () => {
+    const banContext = createContext();
+    parseCommandAndNicoScript(
+      createComment({
+        owner: true,
+        content: "@コメント禁止",
+        mail: [HUGE_DURATION],
+      }),
+      banContext,
+    );
+    expect(
+      banContext.nicoScripts.ban[0]?.end - banContext.nicoScripts.ban[0]?.start,
+    ).toBe(MAX_COMMENT_LONG);
+
+    const reverseContext = createContext();
+    parseCommandAndNicoScript(
+      createComment({
+        owner: true,
+        content: "@逆 全",
+        mail: [HUGE_DURATION],
+      }),
+      reverseContext,
+    );
+    expect(
+      reverseContext.nicoScripts.reverse[0]?.end -
+        reverseContext.nicoScripts.reverse[0]?.start,
+    ).toBe(MAX_COMMENT_LONG);
+
+    const neutralizedBanContext = createContext();
+    parseCommandAndNicoScript(
+      createComment({
+        owner: true,
+        content: "@コメント禁止",
+        mail: ["@0"],
+      }),
+      neutralizedBanContext,
+    );
+    expect(neutralizedBanContext.nicoScripts.ban[0]?.end).toBe(
+      neutralizedBanContext.nicoScripts.ban[0]?.start,
+    );
+
+    const neutralizedReverseContext = createContext();
+    parseCommandAndNicoScript(
+      createComment({
+        owner: true,
+        content: "@逆 全",
+        mail: ["@0"],
+      }),
+      neutralizedReverseContext,
+    );
+    expect(neutralizedReverseContext.nicoScripts.reverse[0]?.end).toBe(
+      neutralizedReverseContext.nicoScripts.reverse[0]?.start,
+    );
+  });
+
+  test("lazy constructor defers timeline expansion until the visible window", () => {
+    const farVpos = MAX_LAZY_COMMENT_LOOKAHEAD + MAX_COMMENT_LONG + 500;
+    const instance = new NiconiComments(
+      new FakeRenderer(),
+      [
+        createComment({ id: 1, vpos: 0, mail: ["ue"] }),
+        createComment({
+          id: 2,
+          vpos: MAX_LAZY_COMMENT_LOOKAHEAD,
+          mail: ["ue"],
+        }),
+        createComment({ id: 3, vpos: farVpos, mail: ["ue"] }),
+      ],
+      { format: "formatted", lazy: true, mode: "html5" },
+    );
+    const state = instance as unknown as {
+      comments: { posY: number }[];
+      processedCommentIndex: number;
+      timeline: Record<number, unknown[]>;
+    };
+
+    expect(Object.keys(state.timeline)).toHaveLength(0);
+    expect(state.processedCommentIndex).toBe(-1);
+
+    instance.drawCanvas(0, true);
+    const keys = Object.keys(state.timeline)
+      .map(Number)
+      .sort((a, b) => a - b);
+
+    expect(state.processedCommentIndex).toBe(1);
+    expect(state.comments[0]?.posY).not.toBe(-1);
+    expect(state.comments[1]?.posY).not.toBe(-1);
+    expect(state.comments[2]?.posY).toBe(-1);
+    expect(keys).not.toContain(farVpos);
+    expect(keys.at(-1)).toBeLessThan(farVpos);
+  });
+});

--- a/tests/unit/duration-lazy.spec.ts
+++ b/tests/unit/duration-lazy.spec.ts
@@ -264,4 +264,31 @@ describe("duration bounds and lazy timeline expansion", () => {
     expect(keys).not.toContain(farVpos);
     expect(keys.at(-1)).toBeLessThan(farVpos);
   });
+
+  test("addComments keeps hostile durations bounded on the production path", () => {
+    const instance = new NiconiComments(new FakeRenderer(), [], {
+      format: "formatted",
+      lazy: true,
+      mode: "html5",
+    });
+    const state = instance as unknown as {
+      comments: { long: number }[];
+      timeline: Record<number, unknown[]>;
+    };
+
+    expect(() =>
+      instance.addComments(
+        createComment({ id: 1, vpos: 100, mail: ["ue", HUGE_DURATION] }),
+        createComment({ id: 2, vpos: 500, mail: [HUGE_DURATION] }),
+        createComment({ id: 3, vpos: 1000, mail: [OVERFLOW_DURATION] }),
+      ),
+    ).not.toThrow();
+
+    expect(state.comments[0]?.long).toBe(MAX_COMMENT_LONG);
+    expect(state.comments[1]?.long).toBe(MAX_COMMENT_LONG);
+    expect(state.comments[2]?.long).toBe(300);
+    expect(Object.keys(state.timeline).length).toBeLessThan(
+      MAX_COMMENT_LONG * 3,
+    );
+  });
 });

--- a/tests/unit/duration-lazy.spec.ts
+++ b/tests/unit/duration-lazy.spec.ts
@@ -11,6 +11,7 @@ import {
   DEFAULT_NICOSCRIPT_LONG,
   MAX_COMMENT_LONG,
   MAX_LAZY_COMMENT_LOOKAHEAD,
+  MAX_NICOSCRIPT_LONG,
   parseCommandAndNicoScript,
 } from "@/utils/comment";
 import { RangeCacheContext } from "@/utils/rangeCache";
@@ -176,6 +177,21 @@ describe("duration bounds and lazy timeline expansion", () => {
   });
 
   test("bounds NicoScript ban/reverse ranges and falls back to defaults for invalid durations", () => {
+    const preservedNicoscriptDuration = "@300";
+    const preservedBanContext = createContext();
+    parseCommandAndNicoScript(
+      createComment({
+        owner: true,
+        content: "@コメント禁止",
+        mail: [preservedNicoscriptDuration],
+      }),
+      preservedBanContext,
+    );
+    expect(
+      preservedBanContext.nicoScripts.ban[0]?.end -
+        preservedBanContext.nicoScripts.ban[0]?.start,
+    ).toBe(300 * 100);
+
     const banContext = createContext();
     parseCommandAndNicoScript(
       createComment({
@@ -187,7 +203,7 @@ describe("duration bounds and lazy timeline expansion", () => {
     );
     expect(
       banContext.nicoScripts.ban[0]?.end - banContext.nicoScripts.ban[0]?.start,
-    ).toBe(MAX_COMMENT_LONG);
+    ).toBe(MAX_NICOSCRIPT_LONG);
 
     const reverseContext = createContext();
     parseCommandAndNicoScript(
@@ -201,7 +217,7 @@ describe("duration bounds and lazy timeline expansion", () => {
     expect(
       reverseContext.nicoScripts.reverse[0]?.end -
         reverseContext.nicoScripts.reverse[0]?.start,
-    ).toBe(MAX_COMMENT_LONG);
+    ).toBe(MAX_NICOSCRIPT_LONG);
 
     const zeroBanContext = createContext();
     parseCommandAndNicoScript(

--- a/tests/unit/duration-lazy.spec.ts
+++ b/tests/unit/duration-lazy.spec.ts
@@ -1,6 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, test } from "vitest";
 
-import type { FormattedComment, IRenderer } from "@/@types/";
+import type { FormattedComment, IComment, IRenderer } from "@/@types/";
 import type { CommentInstanceContext } from "@/contexts";
 import { createNicoScripts, ImageCacheContext } from "@/contexts";
 import { defaultConfig, defaultOptions } from "@/definition/config";
@@ -87,6 +87,20 @@ class FakeRenderer implements IRenderer {
   drawImage() {}
   flush() {}
   invalidateImage() {}
+}
+
+class ReverseCommentsPlugin {
+  static readonly id = "reverse-comments-plugin";
+
+  constructor(_canvas: IRenderer, _comments: IComment[]) {}
+
+  draw() {
+    return false;
+  }
+
+  transformComments(comments: IComment[]) {
+    return [...comments].reverse();
+  }
 }
 
 const createComment = (
@@ -311,6 +325,32 @@ describe("duration bounds and lazy timeline expansion", () => {
     expect(state.comments[2]?.posY).toBe(-1);
     expect(keys).not.toContain(farVpos);
     expect(keys.at(-1)).toBeLessThan(farVpos);
+  });
+
+  test("lazy constructor falls back to eager resolution for plugin-reordered input", () => {
+    const instance = new NiconiComments(
+      new FakeRenderer(),
+      [
+        createComment({ id: 1, vpos: 100000, mail: ["ue"] }),
+        createComment({ id: 2, vpos: 0, mail: ["ue"] }),
+      ],
+      {
+        format: "formatted",
+        lazy: true,
+        mode: "html5",
+        config: { plugins: [ReverseCommentsPlugin] },
+      },
+    );
+    const state = instance as unknown as {
+      comments: { posY: number }[];
+      processedCommentIndex: number;
+      timeline: Record<number, unknown[]>;
+    };
+
+    expect(state.processedCommentIndex).toBe(state.comments.length - 1);
+    expect(state.comments[0]?.posY).not.toBe(-1);
+    expect(state.comments[1]?.posY).not.toBe(-1);
+    expect(state.timeline[0]).toBeDefined();
   });
 
   test("addComments keeps hostile durations bounded on the production path", () => {

--- a/tests/unit/duration-lazy.spec.ts
+++ b/tests/unit/duration-lazy.spec.ts
@@ -7,6 +7,8 @@ import { defaultConfig, defaultOptions } from "@/definition/config";
 import { initConfig } from "@/definition/initConfig";
 import NiconiComments from "@/main";
 import {
+  DEFAULT_COMMENT_LONG,
+  DEFAULT_NICOSCRIPT_LONG,
   MAX_COMMENT_LONG,
   MAX_LAZY_COMMENT_LOOKAHEAD,
   parseCommandAndNicoScript,
@@ -201,8 +203,6 @@ describe("duration bounds and lazy timeline expansion", () => {
         reverseContext.nicoScripts.reverse[0]?.start,
     ).toBe(MAX_COMMENT_LONG);
 
-    const defaultBanRange = 30 * 100;
-
     const zeroBanContext = createContext();
     parseCommandAndNicoScript(
       createComment({
@@ -215,7 +215,7 @@ describe("duration bounds and lazy timeline expansion", () => {
     expect(
       zeroBanContext.nicoScripts.ban[0]?.end -
         zeroBanContext.nicoScripts.ban[0]?.start,
-    ).toBe(defaultBanRange);
+    ).toBe(DEFAULT_NICOSCRIPT_LONG);
 
     const overflowBanContext = createContext();
     parseCommandAndNicoScript(
@@ -229,7 +229,7 @@ describe("duration bounds and lazy timeline expansion", () => {
     expect(
       overflowBanContext.nicoScripts.ban[0]?.end -
         overflowBanContext.nicoScripts.ban[0]?.start,
-    ).toBe(defaultBanRange);
+    ).toBe(DEFAULT_NICOSCRIPT_LONG);
 
     const zeroReverseContext = createContext();
     parseCommandAndNicoScript(
@@ -243,7 +243,7 @@ describe("duration bounds and lazy timeline expansion", () => {
     expect(
       zeroReverseContext.nicoScripts.reverse[0]?.end -
         zeroReverseContext.nicoScripts.reverse[0]?.start,
-    ).toBe(defaultBanRange);
+    ).toBe(DEFAULT_NICOSCRIPT_LONG);
 
     const overflowReverseContext = createContext();
     parseCommandAndNicoScript(
@@ -257,7 +257,7 @@ describe("duration bounds and lazy timeline expansion", () => {
     expect(
       overflowReverseContext.nicoScripts.reverse[0]?.end -
         overflowReverseContext.nicoScripts.reverse[0]?.start,
-    ).toBe(defaultBanRange);
+    ).toBe(DEFAULT_NICOSCRIPT_LONG);
   });
 
   test("lazy constructor defers timeline expansion until the visible window", () => {
@@ -318,7 +318,7 @@ describe("duration bounds and lazy timeline expansion", () => {
 
     expect(state.comments[0]?.long).toBe(MAX_COMMENT_LONG);
     expect(state.comments[1]?.long).toBe(MAX_COMMENT_LONG);
-    expect(state.comments[2]?.long).toBe(300);
+    expect(state.comments[2]?.long).toBe(DEFAULT_COMMENT_LONG);
     expect(Object.keys(state.timeline).length).toBeLessThan(
       MAX_COMMENT_LONG * 3,
     );

--- a/tests/unit/duration-lazy.spec.ts
+++ b/tests/unit/duration-lazy.spec.ts
@@ -331,8 +331,8 @@ describe("duration bounds and lazy timeline expansion", () => {
     const instance = new NiconiComments(
       new FakeRenderer(),
       [
-        createComment({ id: 1, vpos: 100000, mail: ["ue"] }),
-        createComment({ id: 2, vpos: 0, mail: ["ue"] }),
+        createComment({ id: 1, vpos: 0, mail: ["ue"] }),
+        createComment({ id: 2, vpos: 100000, mail: ["ue"] }),
       ],
       {
         format: "formatted",

--- a/tests/unit/duration-lazy.spec.ts
+++ b/tests/unit/duration-lazy.spec.ts
@@ -173,7 +173,7 @@ describe("duration bounds and lazy timeline expansion", () => {
     expect(infinityLike.long).toBeLessThanOrEqual(MAX_COMMENT_LONG);
   });
 
-  test("bounds NicoScript ban/reverse ranges and neutralizes explicit bad durations", () => {
+  test("bounds NicoScript ban/reverse ranges and falls back to defaults for invalid durations", () => {
     const banContext = createContext();
     parseCommandAndNicoScript(
       createComment({
@@ -201,31 +201,63 @@ describe("duration bounds and lazy timeline expansion", () => {
         reverseContext.nicoScripts.reverse[0]?.start,
     ).toBe(MAX_COMMENT_LONG);
 
-    const neutralizedBanContext = createContext();
+    const defaultBanRange = 30 * 100;
+
+    const zeroBanContext = createContext();
     parseCommandAndNicoScript(
       createComment({
         owner: true,
         content: "@コメント禁止",
         mail: ["@0"],
       }),
-      neutralizedBanContext,
+      zeroBanContext,
     );
-    expect(neutralizedBanContext.nicoScripts.ban[0]?.end).toBe(
-      neutralizedBanContext.nicoScripts.ban[0]?.start,
-    );
+    expect(
+      zeroBanContext.nicoScripts.ban[0]?.end -
+        zeroBanContext.nicoScripts.ban[0]?.start,
+    ).toBe(defaultBanRange);
 
-    const neutralizedReverseContext = createContext();
+    const overflowBanContext = createContext();
+    parseCommandAndNicoScript(
+      createComment({
+        owner: true,
+        content: "@コメント禁止",
+        mail: [OVERFLOW_DURATION],
+      }),
+      overflowBanContext,
+    );
+    expect(
+      overflowBanContext.nicoScripts.ban[0]?.end -
+        overflowBanContext.nicoScripts.ban[0]?.start,
+    ).toBe(defaultBanRange);
+
+    const zeroReverseContext = createContext();
     parseCommandAndNicoScript(
       createComment({
         owner: true,
         content: "@逆 全",
         mail: ["@0"],
       }),
-      neutralizedReverseContext,
+      zeroReverseContext,
     );
-    expect(neutralizedReverseContext.nicoScripts.reverse[0]?.end).toBe(
-      neutralizedReverseContext.nicoScripts.reverse[0]?.start,
+    expect(
+      zeroReverseContext.nicoScripts.reverse[0]?.end -
+        zeroReverseContext.nicoScripts.reverse[0]?.start,
+    ).toBe(defaultBanRange);
+
+    const overflowReverseContext = createContext();
+    parseCommandAndNicoScript(
+      createComment({
+        owner: true,
+        content: "@逆 全",
+        mail: [OVERFLOW_DURATION],
+      }),
+      overflowReverseContext,
     );
+    expect(
+      overflowReverseContext.nicoScripts.reverse[0]?.end -
+        overflowReverseContext.nicoScripts.reverse[0]?.start,
+    ).toBe(defaultBanRange);
   });
 
   test("lazy constructor defers timeline expansion until the visible window", () => {

--- a/tests/unit/duration-lazy.spec.ts
+++ b/tests/unit/duration-lazy.spec.ts
@@ -9,6 +9,7 @@ import NiconiComments from "@/main";
 import {
   DEFAULT_COMMENT_LONG,
   DEFAULT_NICOSCRIPT_LONG,
+  getLazyCommentLookahead,
   MAX_COMMENT_LONG,
   MAX_LAZY_COMMENT_LOOKAHEAD,
   MAX_NICOSCRIPT_LONG,
@@ -288,6 +289,26 @@ describe("duration bounds and lazy timeline expansion", () => {
       overflowReverseContext.nicoScripts.reverse[0]?.end -
         overflowReverseContext.nicoScripts.reverse[0]?.start,
     ).toBe(DEFAULT_NICOSCRIPT_LONG);
+
+    const subCentisecondJumpContext = createContext();
+    parseCommandAndNicoScript(
+      createComment({
+        owner: true,
+        content: "@ジャンプ sm9",
+        mail: ["@0.005"],
+      }),
+      subCentisecondJumpContext,
+    );
+    expect(subCentisecondJumpContext.nicoScripts.jump[0]?.end).toBeUndefined();
+  });
+
+  test("widens lazy lookahead for narrower canvas widths", () => {
+    expect(getLazyCommentLookahead(defaultConfig.canvasWidth)).toBe(
+      MAX_LAZY_COMMENT_LOOKAHEAD,
+    );
+    expect(
+      getLazyCommentLookahead(defaultConfig.canvasWidth / 2),
+    ).toBeGreaterThan(MAX_LAZY_COMMENT_LOOKAHEAD);
   });
 
   test("lazy constructor defers timeline expansion until the visible window", () => {


### PR DESCRIPTION
## Summary
- centralize duration normalization before NicoScript processing and cap or neutralize malformed values
- keep lazy mode from pre-expanding the full timeline during construction by resolving only a bounded lookahead window on draw
- add focused unit regressions for finite caps, overflow-like inputs, NicoScript ranges, and lazy constructor behavior

## Validation
- pnpm check-types
- pnpm test:unit
- pnpm lint

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR centralizes comment duration normalization before NicoScript processing — capping oversized values to `MAX_COMMENT_LONG` / `MAX_NICOSCRIPT_LONG` and neutralizing non-finite or non-positive inputs — and replaces the old eager lazy-mode pre-expansion with a per-draw bounded lookahead window driven by canvas geometry.

- **Duration normalization** (`src/utils/comment.ts`): a small pipeline of helpers (`normalizeParsedCommandLong` → `normalizeCommentLong` / `normalizeNicoscriptLong` / `normalizeOptionalNicoscriptLong`) replaces scattered inline math; constants are exported for test assertions and the `getLazyCommentLookahead` formula is derived from naka comment off-screen lead-in geometry.
- **Lazy window resolution** (`src/main.ts`): `resolveLazyCommentWindow` is called each frame and positions only comments within `[nextUnprocessedCommentIndex, resolveUntil]`, where `resolveUntil = vpos + getLazyCommentLookahead(canvasWidth)`; unsorted plugin-reordered input falls back to eager resolution at construction time by detecting ordering via `lazyCommentOrderSortedByVpos`.
- **Unit tests** (`tests/unit/duration-lazy.spec.ts`): new spec covers finite caps, overflow-like strings, NicoScript ban/reverse/jump range bounds, lazy constructor deferral, plugin-reordered eager fallback, and `addComments` bound enforcement via a `FakeRenderer` stub.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge; the lazy resolution path is mechanically correct, and duration bounds are consistently applied with well-targeted test coverage.

The duration normalization pipeline is straightforward and easy to audit: invalid inputs become undefined before entering NicoScript processing, and are then clamped by context-specific normalizers. The lazy window logic correctly threads nextUnprocessedCommentIndex and processedCommentIndex through construction, addComments, and per-frame resolution without re-positioning already-placed comments. The unsorted-input fallback (eager resolution when lazyCommentOrderSortedByVpos = false) prevents the out-of-order miss described in the previous review thread. No cross-repo impact detected; the plugin adapter only consumes the public IComment type.

No files require special attention; all three changed files are internally consistent and the new unit tests exercise the key edge cases.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/utils/comment.ts | Adds centralized duration normalization functions and lazy-lookahead geometry constants; replaces scattered inline math; exports new constants for tests. |
| src/main.ts | Refactors lazy mode to defer timeline population via a bounded lookahead window; detects unsorted plugin-reordered input and falls back to eager resolution; removes dead lazy parameter from getCommentPos. |
| tests/unit/duration-lazy.spec.ts | New unit spec covering finite caps, overflow-like strings, NicoScript range bounds, lazy constructor deferral, plugin-reordered eager fallback, and addComments bound enforcement. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[constructor / preRendering] --> B{lazy mode?}
    B -- no --> C[getCommentPos all + sortTimeline]
    B -- yes --> D{lazyCommentOrderSortedByVpos?}
    D -- sorted --> E[skip eager resolution]
    D -- unsorted --> F[getCommentPos all eagerly]
    E --> G[drawCanvas]
    F --> G
    C --> G
    G --> H[resolveLazyCommentWindow]
    H --> I{lazy mode?}
    I -- no --> J[no-op]
    I -- yes --> K[advance nextUnprocessedCommentIndex]
    K --> L[scan window up to resolveUntil]
    L --> M{new comments found?}
    M -- no --> N[return false]
    M -- yes --> O[getCommentPos + sortTimeline]
    O --> P[render frame]
    N --> P
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/main.ts`, line 287-319 ([link](https://github.com/xpadev-net/niconicomments/blob/02aada68290115a006ba2846d7cecbe22bbd4283/src/main.ts#L287-L319)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Dead `lazy` parameter on `getCommentPos`**

   The `lazy` parameter (defaulting to `false`) is never passed as `true` by any call site after this PR. The `if (lazy) { this.processedCommentIndex = -1; }` reset and the `comment.posY > -1 && !lazy` bypass are unreachable. The parameter's presence implies the function still supports a "lazy position" mode, but all lazy-window resolution now goes through `resolveLazyCommentWindow`, which calls `getCommentPos` with `lazy = false`. Leaving the dead path makes it easy for a future contributor to accidentally pass `lazy = true` and trigger an incorrect `processedCommentIndex` reset mid-stream.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/main.ts
   Line: 287-319

   Comment:
   **Dead `lazy` parameter on `getCommentPos`**

   The `lazy` parameter (defaulting to `false`) is never passed as `true` by any call site after this PR. The `if (lazy) { this.processedCommentIndex = -1; }` reset and the `comment.posY > -1 && !lazy` bypass are unreachable. The parameter's presence implies the function still supports a "lazy position" mode, but all lazy-window resolution now goes through `resolveLazyCommentWindow`, which calls `getCommentPos` with `lazy = false`. Leaving the dead path makes it easy for a future contributor to accidentally pass `lazy = true` and trigger an incorrect `processedCommentIndex` reset mid-stream.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fmain.ts%0ALine%3A%20287-319%0A%0AComment%3A%0A**Dead%20%60lazy%60%20parameter%20on%20%60getCommentPos%60**%0A%0AThe%20%60lazy%60%20parameter%20%28defaulting%20to%20%60false%60%29%20is%20never%20passed%20as%20%60true%60%20by%20any%20call%20site%20after%20this%20PR.%20The%20%60if%20%28lazy%29%20%7B%20this.processedCommentIndex%20%3D%20-1%3B%20%7D%60%20reset%20and%20the%20%60comment.posY%20%3E%20-1%20%26%26%20!lazy%60%20bypass%20are%20unreachable.%20The%20parameter's%20presence%20implies%20the%20function%20still%20supports%20a%20%22lazy%20position%22%20mode%2C%20but%20all%20lazy-window%20resolution%20now%20goes%20through%20%60resolveLazyCommentWindow%60%2C%20which%20calls%20%60getCommentPos%60%20with%20%60lazy%20%3D%20false%60.%20Leaving%20the%20dead%20path%20makes%20it%20easy%20for%20a%20future%20contributor%20to%20accidentally%20pass%20%60lazy%20%3D%20true%60%20and%20trigger%20an%20incorrect%20%60processedCommentIndex%60%20reset%20mid-stream.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=xpadev-net%2Fniconicomments&pr=290&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (9): Last reviewed commit: ["fix: tighten lazy lookahead handling"](https://github.com/xpadev-net/niconicomments/commit/e65a83ea541e3918b2e6d07c772bc561e53cd604) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35214098)</sub>

<!-- /greptile_comment -->