### PR TITLE
Fix timeline insertion complexity

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -378,8 +378,9 @@ class NiconiComments {
     if (endIndex < startIndex) {
       return false;
     }
-    this.getCommentPos(this.comments, endIndex + 1);
-    this.sortTimelineComment();
+    const touchedTimeline = new Set<number>();
+    this.getCommentPos(this.comments, endIndex + 1, touchedTimeline);
+    this.sortTimelineComment(touchedTimeline);
     return true;
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -279,7 +279,12 @@ class NiconiComments {
    * @param end 終了インデックス
    * @param lazy 遅延処理を行うか
    */
-  private getCommentPos(data: IComment[], end: number, lazy = false) {
+  private getCommentPos(
+    data: IComment[],
+    end: number,
+    lazy = false,
+    touchedTimeline?: Set<number>,
+  ) {
     const getCommentPosStart = performance.now();
     const startIndex = this.processedCommentIndex + 1;
     if (startIndex >= end) return;
@@ -295,6 +300,7 @@ class NiconiComments {
           this.timeline,
           lazy,
           this.ctx.config,
+          touchedTimeline,
         );
       } else {
         processFixedComment(
@@ -303,6 +309,7 @@ class NiconiComments {
           this.timeline,
           lazy,
           this.ctx.config,
+          touchedTimeline,
         );
       }
     }
@@ -317,9 +324,10 @@ class NiconiComments {
   /**
    * 投稿者コメントを前に移動
    */
-  private sortTimelineComment() {
+  private sortTimelineComment(vposes?: Iterable<number | string>) {
     const sortCommentStart = performance.now();
-    for (const vpos of Object.keys(this.timeline)) {
+    const targetVposes = vposes ?? Object.keys(this.timeline);
+    for (const vpos of targetVposes) {
       const item = this.timeline[Number(vpos)];
       if (!item) continue;
       item.sort(
@@ -336,6 +344,7 @@ class NiconiComments {
    */
   public addComments(...rawComments: FormattedComment[]) {
     this.ctx.rangeCache.reset();
+    const touchedTimeline = new Set<number>();
     const comments = rawComments.reduce<IComment[]>((pv, val, index) => {
       pv.push(
         createCommentInstance(
@@ -363,6 +372,7 @@ class NiconiComments {
           this.timeline,
           false,
           this.ctx.config,
+          touchedTimeline,
         );
       } else {
         processFixedComment(
@@ -371,6 +381,7 @@ class NiconiComments {
           this.timeline,
           false,
           this.ctx.config,
+          touchedTimeline,
         );
       }
     }
@@ -384,14 +395,19 @@ class NiconiComments {
     if (!this.ctx.options.lazy) {
       const prePushTail = baseOffset - 1;
       if (this.processedCommentIndex < prePushTail) {
-        this.getCommentPos(this.comments, prePushTail + 1);
+        this.getCommentPos(
+          this.comments,
+          prePushTail + 1,
+          false,
+          touchedTimeline,
+        );
       }
       this.processedCommentIndex = Math.max(
         this.processedCommentIndex,
         this.comments.length - 1,
       );
     }
-    this.sortTimelineComment();
+    this.sortTimelineComment(touchedTimeline);
     this._cachedSplit = null;
   }
 

--- a/src/utils/comment.ts
+++ b/src/utils/comment.ts
@@ -45,6 +45,19 @@ const RE_WAKU = /^nico:waku:(.+)$/;
 const RE_FILL = /^nico:fill:(.+)$/;
 const RE_OPACITY = /^nico:opacity:(.+)$/;
 const RE_COLOR_CODE = /^#(?:[0-9a-z]{3}|[0-9a-z]{6})$/;
+const processedTimelineComments = new WeakMap<IComment, WeakSet<Timeline>>();
+
+const isTimelineProcessed = (timeline: Timeline, comment: IComment) =>
+  processedTimelineComments.get(comment)?.has(timeline) ?? false;
+
+const markTimelineProcessed = (timeline: Timeline, comment: IComment) => {
+  const processed = processedTimelineComments.get(comment);
+  if (processed) {
+    processed.add(timeline);
+    return;
+  }
+  processedTimelineComments.set(comment, new WeakSet([timeline]));
+};
 
 /**
  * 改行リサイズが発生するか
@@ -733,18 +746,22 @@ const processFixedComment = (
   timeline: Timeline,
   lazy = false,
   config: BaseConfig,
+  touchedTimeline?: Set<number>,
 ) => {
   const commentVpos = comment.vpos;
   const commentLong = comment.long;
   const collisionEnd = Math.max(commentLong - 20, 0);
   const posY = lazy ? -1 : getFixedPosY(comment, collision, config);
-  for (let j = 0; j < commentLong; j++) {
-    const vpos = commentVpos + j;
-    if (timeline[vpos]?.includes(comment)) continue;
-    arrayPush(timeline, vpos, comment);
-    if (j <= collisionEnd) {
-      arrayPush(collision, vpos, comment);
+  if (!isTimelineProcessed(timeline, comment)) {
+    for (let j = 0; j < commentLong; j++) {
+      const vpos = commentVpos + j;
+      arrayPush(timeline, vpos, comment);
+      touchedTimeline?.add(vpos);
+      if (j <= collisionEnd) {
+        arrayPush(collision, vpos, comment);
+      }
     }
+    markTimelineProcessed(timeline, comment);
   }
   comment.posY = posY;
 };
@@ -763,6 +780,7 @@ const processMovableComment = (
   timeline: Timeline,
   lazy = false,
   config: BaseConfig,
+  touchedTimeline?: Set<number>,
 ) => {
   const commentWidth = comment.width;
   const commentLong = comment.long;
@@ -782,23 +800,26 @@ const processMovableComment = (
     ? -1
     : getMovablePosY(comment, collision, beforeVpos, config, speed);
   const n = commentLong + 125;
-  for (let j = beforeVpos; j < n; j++) {
-    const vpos = commentVpos + j;
-    const leftPos = drawPadding + drawRange - (j + 100) * speed;
-    if (timeline[vpos]?.includes(comment)) continue;
-    arrayPush(timeline, vpos, comment);
-    if (
-      leftPos + commentWidth + collisionPadding >= collisionRight &&
-      leftPos <= collisionRight
-    ) {
-      arrayPush(collision.right, vpos, comment);
+  if (!isTimelineProcessed(timeline, comment)) {
+    for (let j = beforeVpos; j < n; j++) {
+      const vpos = commentVpos + j;
+      const leftPos = drawPadding + drawRange - (j + 100) * speed;
+      arrayPush(timeline, vpos, comment);
+      touchedTimeline?.add(vpos);
+      if (
+        leftPos + commentWidth + collisionPadding >= collisionRight &&
+        leftPos <= collisionRight
+      ) {
+        arrayPush(collision.right, vpos, comment);
+      }
+      if (
+        leftPos + commentWidth + collisionPadding >= collisionLeft &&
+        leftPos <= collisionLeft
+      ) {
+        arrayPush(collision.left, vpos, comment);
+      }
     }
-    if (
-      leftPos + commentWidth + collisionPadding >= collisionLeft &&
-      leftPos <= collisionLeft
-    ) {
-      arrayPush(collision.left, vpos, comment);
-    }
+    markTimelineProcessed(timeline, comment);
   }
   comment.posY = posY;
 };

--- a/tests/unit/timeline.spec.ts
+++ b/tests/unit/timeline.spec.ts
@@ -1,0 +1,223 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { FormattedComment, IComment, IRenderer, Timeline } from "@/@types";
+import { defaultConfig } from "@/definition/config";
+import { initConfig } from "@/definition/initConfig";
+import NiconiComments from "@/main";
+import { processFixedComment } from "@/utils/comment";
+
+const emptyTextMetrics = (width: number): TextMetrics =>
+  ({
+    width,
+    actualBoundingBoxLeft: 0,
+    actualBoundingBoxRight: width,
+    actualBoundingBoxAscent: 0,
+    actualBoundingBoxDescent: 0,
+    alphabeticBaseline: 0,
+    hangingBaseline: 0,
+    emHeightAscent: 0,
+    emHeightDescent: 0,
+    fontBoundingBoxAscent: 0,
+    fontBoundingBoxDescent: 0,
+    ideographicBaseline: 0,
+  }) as TextMetrics;
+
+class FakeRenderer implements IRenderer {
+  public readonly rendererName = "FakeRenderer";
+  public readonly canvas = {} as HTMLCanvasElement;
+  private font = "";
+  private size = { width: 1920, height: 1080 };
+
+  destroy() {}
+  drawVideo() {}
+  getFont() {
+    return this.font;
+  }
+  getFillStyle() {
+    return "#000000";
+  }
+  setScale() {}
+  fillRect() {}
+  strokeRect() {}
+  fillText() {}
+  strokeText() {}
+  quadraticCurveTo() {}
+  clearRect() {}
+  setFont(font: string) {
+    this.font = font;
+  }
+  setFillStyle() {}
+  setStrokeStyle() {}
+  setLineWidth() {}
+  setGlobalAlpha() {}
+  setSize(width: number, height: number) {
+    this.size = { width, height };
+  }
+  getSize() {
+    return this.size;
+  }
+  measureText() {
+    return emptyTextMetrics(120);
+  }
+  beginPath() {}
+  closePath() {}
+  moveTo() {}
+  lineTo() {}
+  stroke() {}
+  save() {}
+  restore() {}
+  getCanvas() {
+    return this;
+  }
+  drawImage() {}
+  flush() {}
+  invalidateImage() {}
+}
+
+const ensureCanvasElement = () => {
+  if (!("HTMLCanvasElement" in globalThis)) {
+    Object.defineProperty(globalThis, "HTMLCanvasElement", {
+      configurable: true,
+      value: class HTMLCanvasElement {},
+    });
+  }
+};
+
+const formattedComment = (
+  id: number,
+  vpos: number,
+  owner = false,
+): FormattedComment => ({
+  id,
+  vpos,
+  content: `comment ${id}`,
+  date: id,
+  date_usec: 0,
+  owner,
+  premium: false,
+  mail: ["ue"],
+  user_id: id,
+  layer: -1,
+  is_my_post: false,
+});
+
+const timelineIndexes = (timeline: Timeline, vpos: number) =>
+  timeline[vpos]?.map((comment) => comment.index) ?? [];
+
+const createFixedComment = (index: number, vpos: number, long: number) =>
+  ({
+    comment: {},
+    invisible: false,
+    index,
+    loc: "ue",
+    width: 120,
+    long,
+    height: 24,
+    vpos,
+    flash: false,
+    posY: -1,
+    owner: false,
+    layer: -1,
+    mail: ["ue"],
+    content: `comment ${index}`,
+    draw() {},
+    isHovered: () => false,
+  }) as IComment;
+
+describe("timeline construction", () => {
+  beforeEach(() => {
+    initConfig();
+  });
+
+  test("reprocessing a fixed comment computes posY without duplicating timeline or collision buckets", () => {
+    const timeline: Timeline = {};
+    const collision: Timeline = {};
+    const touchedOnFirstPass = new Set<number>();
+    const touchedOnSecondPass = new Set<number>();
+    const comment = createFixedComment(1, 100, 30);
+
+    processFixedComment(
+      comment,
+      collision,
+      timeline,
+      true,
+      defaultConfig,
+      touchedOnFirstPass,
+    );
+    processFixedComment(
+      comment,
+      collision,
+      timeline,
+      false,
+      defaultConfig,
+      touchedOnSecondPass,
+    );
+
+    expect(comment.posY).toBe(0);
+    expect(touchedOnFirstPass.size).toBe(30);
+    expect(touchedOnSecondPass.size).toBe(0);
+    expect(timeline[100]).toHaveLength(1);
+    expect(timeline[129]).toHaveLength(1);
+    expect(collision[100]).toHaveLength(1);
+    expect(collision[110]).toHaveLength(1);
+  });
+
+  test("dense fixed comments do not use per-bucket includes scans", () => {
+    const timeline: Timeline = {};
+    const collision: Timeline = {};
+    const originalIncludes = Array.prototype.includes;
+    let includesCalls = 0;
+    Array.prototype.includes = function includes(...args) {
+      includesCalls++;
+      return originalIncludes.apply(this, args);
+    };
+
+    try {
+      for (let i = 0; i < 500; i++) {
+        processFixedComment(
+          createFixedComment(i, 200, 1),
+          collision,
+          timeline,
+          true,
+          defaultConfig,
+        );
+      }
+    } finally {
+      Array.prototype.includes = originalIncludes;
+    }
+
+    expect(includesCalls).toBe(0);
+    expect(timeline[200]).toHaveLength(500);
+  });
+});
+
+describe("addComments", () => {
+  test("sorts overlapping touched buckets without resorting unrelated timeline buckets", () => {
+    ensureCanvasElement();
+    const renderer = new FakeRenderer();
+    const niconiComments = new NiconiComments(
+      renderer,
+      [
+        formattedComment(1, 100, false),
+        formattedComment(2, 100, true),
+        formattedComment(3, 900, false),
+        formattedComment(4, 900, true),
+      ],
+      { format: "formatted" },
+    );
+    const timeline = (
+      niconiComments as unknown as {
+        timeline: Timeline;
+      }
+    ).timeline;
+    const unrelatedSort = vi.spyOn(timeline[900] ?? [], "sort");
+
+    niconiComments.addComments(
+      formattedComment(5, 100, true),
+      formattedComment(6, 100, false),
+    );
+
+    expect(timelineIndexes(timeline, 100)).toEqual([0, 5, 1, 4]);
+    expect(unrelatedSort).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- avoid per-bucket timeline membership scans by tracking processed comment/timeline pairs
- sort only timeline buckets touched by addComments and add-time catch-up processing
- add focused unit coverage for duplicate avoidance, includes-scan regression, and addComments bucket sorting scope

## Validation
- rtk pnpm check-types
- rtk pnpm test:unit
- rtk pnpm lint
- rtk git diff --check

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR optimizes timeline insertion by replacing per-bucket `Array.includes` scans with a `WeakMap<IComment, WeakSet<Timeline>>` module-level registry (`processedTimelineComments`), and narrows `sortTimelineComment` to sort only the vpos buckets actually touched in each operation.

- Replaces O(n·m) `timeline[vpos]?.includes(comment)` guards in `processFixedComment` and `processMovableComment` with a single `isTimelineProcessed` look-up per call, eliminating repeated linear scans over growing timeline buckets.
- Adds a `touchedTimeline: Set<number>` parameter threaded through `getCommentPos`, `addComments`, and `resolveLazyCommentWindow`, so `sortTimelineComment` skips unrelated vpos buckets entirely.
- Adds a focused unit test suite covering duplicate-insertion avoidance, the removal of `includes` calls, and the scoped bucket-sorting invariant for `addComments`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the optimization is logically equivalent to the replaced code for all existing call sites, and the new unit tests verify the key invariants directly.

The processedTimelineComments WeakMap is correctly memory-managed. The posY update is intentionally kept outside the isTimelineProcessed guard so lazy→non-lazy recalculation still fires. The touchedTimeline set is correctly threaded through every call site. No behavioral difference was found between the old per-vpos includes approach and the new atomic all-or-nothing insertion.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/utils/comment.ts | Introduces module-level WeakMap/WeakSet registry to track processed (comment, timeline) pairs, replacing per-vpos includes scans with atomic all-or-nothing insertion. posY update is correctly kept outside the guard block so lazy→non-lazy recalculation still works. |
| src/main.ts | Threads touchedTimeline Set through getCommentPos, addComments, and resolveLazyCommentWindow; sortTimelineComment now accepts an optional iterable so it only revisits touched buckets. The processedCommentIndex and catch-up logic is unchanged and remains correct. |
| tests/unit/timeline.spec.ts | New test file with meaningful coverage: verifies posY recalculation on second pass, confirms zero includes calls for dense insertion, and validates that addComments sorts only touched buckets leaving unrelated ones untouched. |

</details>

</details>

<sub>Reviews (3): Last reviewed commit: ["Limit lazy timeline sorting scope"](https://github.com/xpadev-net/niconicomments/commit/600bd098d0f2fdaee93b30afd54a6729594053f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35310122)</sub>

<!-- /greptile_comment -->