### PR TITLE
Bound HTML5 comment rendering resources

### DIFF
--- a/src/comments/BaseComment.ts
+++ b/src/comments/BaseComment.ts
@@ -18,7 +18,7 @@ import { getPosX, isBanActive, isReverseActive, parseFont } from "@/utils";
 const MAX_CACHE_KEY_CONTENT_LENGTH = 512;
 const MAX_CACHE_KEY_EDGE_LENGTH = 256;
 const MAX_IMAGE_CACHE_ENTRIES = 1024;
-const imageCacheEntries = new WeakMap<object, Map<string, number>>();
+const imageCacheEntries = new WeakMap<object, Set<string>>();
 const destroyedTextImages = new WeakSet<IRenderer>();
 
 const hashString = (input: string) => {
@@ -334,9 +334,8 @@ class BaseComment implements IComment {
     const cache = imageCache.get(key);
     if (cache) {
       const entries = imageCacheEntries.get(imageCache);
-      if (entries?.has(key)) {
-        entries.delete(key);
-        entries.set(key, Date.now());
+      if (entries?.delete(key)) {
+        entries.add(key);
       }
       this.image = cache.image;
       window.setTimeout(
@@ -384,13 +383,15 @@ class BaseComment implements IComment {
     const lifetime = this.comment.long * 10 + config.cacheAge;
     let entries = imageCacheEntries.get(imageCache);
     if (!entries) {
-      entries = new Map();
+      entries = new Set();
       imageCacheEntries.set(imageCache, entries);
     }
-    for (const entryKey of entries.keys()) {
-      if (!imageCache.get(entryKey)) entries.delete(entryKey);
-    }
     this.image = image;
+    if (!entries.has(key) && entries.size >= MAX_IMAGE_CACHE_ENTRIES) {
+      for (const entryKey of entries) {
+        if (!imageCache.get(entryKey)) entries.delete(entryKey);
+      }
+    }
     if (!entries.has(key) && entries.size >= MAX_IMAGE_CACHE_ENTRIES) {
       const oldestKey = entries.keys().next().value;
       if (oldestKey !== undefined) {
@@ -419,7 +420,7 @@ class BaseComment implements IComment {
       image,
     });
     entries.delete(key);
-    entries.set(key, Date.now());
+    entries.add(key);
   }
 
   protected canGenerateTextImage(): boolean {

--- a/src/comments/BaseComment.ts
+++ b/src/comments/BaseComment.ts
@@ -15,6 +15,24 @@ import type { CommentInstanceContext } from "@/contexts";
 import { NotImplementedError } from "@/errors/";
 import { getPosX, isBanActive, isReverseActive, parseFont } from "@/utils";
 
+const MAX_CACHE_KEY_CONTENT_LENGTH = 512;
+const MAX_IMAGE_CACHE_ENTRIES = 1024;
+const imageCacheEntries = new WeakMap<object, Map<string, number>>();
+
+const hashString = (input: string) => {
+  let hash = 2166136261;
+  for (let i = 0, n = input.length; i < n; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
+};
+
+const boundedCachePart = (input: string) => {
+  if (input.length <= MAX_CACHE_KEY_CONTENT_LENGTH) return input;
+  return `${input.slice(0, MAX_CACHE_KEY_CONTENT_LENGTH)}\0${input.length}\0${hashString(input)}`;
+};
+
 /**
  * コメントの描画を行うクラスの基底クラス
  */
@@ -302,13 +320,19 @@ class BaseComment implements IComment {
       this.comment.invisible ||
       (this.comment.lineCount === 1 && this.comment.width === 0) ||
       this.comment.height - (this.comment.charSize - this.comment.lineHeight) <=
-        0
+        0 ||
+      !this.canGenerateTextImage()
     )
       return null;
     const key = this.cacheKey;
     const { imageCache, config } = this.ctx;
     const cache = imageCache.get(key);
     if (cache) {
+      const entries = imageCacheEntries.get(imageCache);
+      if (entries?.has(key)) {
+        entries.delete(key);
+        entries.set(key, Date.now());
+      }
       this.image = cache.image;
       window.setTimeout(
         () => {
@@ -317,10 +341,14 @@ class BaseComment implements IComment {
         this.comment.long * 10 + config.cacheAge,
       );
       clearTimeout(cache.timeout);
+      const cachedImage = cache.image;
       cache.timeout = window.setTimeout(
         () => {
-          imageCache.get(key)?.image.destroy();
-          imageCache.delete(key);
+          if (imageCache.get(key)?.image === cachedImage) {
+            cachedImage.destroy();
+            imageCache.delete(key);
+            imageCacheEntries.get(imageCache)?.delete(key);
+          }
         },
         this.comment.long * 10 + config.cacheAge,
       );
@@ -347,6 +375,23 @@ class BaseComment implements IComment {
   protected _cacheImage(image: IRenderer) {
     const key = this.cacheKey;
     const { imageCache, config } = this.ctx;
+    let entries = imageCacheEntries.get(imageCache);
+    if (!entries) {
+      entries = new Map();
+      imageCacheEntries.set(imageCache, entries);
+    }
+    if (!entries.has(key) && entries.size >= MAX_IMAGE_CACHE_ENTRIES) {
+      const oldestKey = entries.keys().next().value;
+      if (oldestKey !== undefined) {
+        const oldest = imageCache.get(oldestKey);
+        if (oldest) {
+          clearTimeout(oldest.timeout);
+          oldest.image.destroy();
+        }
+        imageCache.delete(oldestKey);
+        entries.delete(oldestKey);
+      }
+    }
     this.image = image;
     window.setTimeout(
       () => {
@@ -357,13 +402,22 @@ class BaseComment implements IComment {
     imageCache.set(key, {
       timeout: window.setTimeout(
         () => {
-          imageCache.get(key)?.image.destroy();
-          imageCache.delete(key);
+          if (imageCache.get(key)?.image === image) {
+            image.destroy();
+            imageCache.delete(key);
+            imageCacheEntries.get(imageCache)?.delete(key);
+          }
         },
         this.comment.long * 10 + config.cacheAge,
       ),
       image,
     });
+    entries.delete(key);
+    entries.set(key, Date.now());
+  }
+
+  protected canGenerateTextImage(): boolean {
+    return true;
   }
 
   protected getButtonImage(
@@ -387,7 +441,7 @@ class BaseComment implements IComment {
 
   protected getCacheKey() {
     const sortedMail = [...this.comment.mail].sort().join(",");
-    return `${this.pluginName}\0${sortedMail}\0${this.comment.rawContent}`;
+    return `${this.pluginName}\0${sortedMail}\0${boundedCachePart(this.comment.rawContent)}`;
   }
 }
 

--- a/src/comments/BaseComment.ts
+++ b/src/comments/BaseComment.ts
@@ -19,6 +19,7 @@ const MAX_CACHE_KEY_CONTENT_LENGTH = 512;
 const MAX_CACHE_KEY_EDGE_LENGTH = 256;
 const MAX_IMAGE_CACHE_ENTRIES = 1024;
 const imageCacheEntries = new WeakMap<object, Map<string, number>>();
+const destroyedTextImages = new WeakSet<IRenderer>();
 
 const hashString = (input: string) => {
   let hash = 2166136261;
@@ -218,6 +219,9 @@ class BaseComment implements IComment {
    * @param cursor カーソルの位置
    */
   protected _draw(posX: number, posY: number, cursor?: Position) {
+    if (this.image && destroyedTextImages.has(this.image)) {
+      this.image = undefined;
+    }
     if (this.image === undefined) {
       this.image = this.getTextImage();
     }
@@ -346,6 +350,7 @@ class BaseComment implements IComment {
       cache.timeout = window.setTimeout(
         () => {
           if (imageCache.get(key)?.image === cachedImage) {
+            destroyedTextImages.add(cachedImage);
             cachedImage.destroy();
             imageCache.delete(key);
             imageCacheEntries.get(imageCache)?.delete(key);
@@ -387,11 +392,17 @@ class BaseComment implements IComment {
     }
     this.image = image;
     if (!entries.has(key) && entries.size >= MAX_IMAGE_CACHE_ENTRIES) {
-      window.setTimeout(() => {
-        if (this.image === image) this.image = undefined;
-        image.destroy();
-      }, lifetime);
-      return;
+      const oldestKey = entries.keys().next().value;
+      if (oldestKey !== undefined) {
+        const oldest = imageCache.get(oldestKey);
+        if (oldest) {
+          clearTimeout(oldest.timeout);
+          destroyedTextImages.add(oldest.image);
+          oldest.image.destroy();
+        }
+        imageCache.delete(oldestKey);
+        entries.delete(oldestKey);
+      }
     }
     window.setTimeout(() => {
       this.image = undefined;
@@ -399,6 +410,7 @@ class BaseComment implements IComment {
     imageCache.set(key, {
       timeout: window.setTimeout(() => {
         if (imageCache.get(key)?.image === image) {
+          destroyedTextImages.add(image);
           image.destroy();
           imageCache.delete(key);
           imageCacheEntries.get(imageCache)?.delete(key);

--- a/src/comments/BaseComment.ts
+++ b/src/comments/BaseComment.ts
@@ -16,6 +16,7 @@ import { NotImplementedError } from "@/errors/";
 import { getPosX, isBanActive, isReverseActive, parseFont } from "@/utils";
 
 const MAX_CACHE_KEY_CONTENT_LENGTH = 512;
+const MAX_CACHE_KEY_EDGE_LENGTH = 256;
 const MAX_IMAGE_CACHE_ENTRIES = 1024;
 const imageCacheEntries = new WeakMap<object, Map<string, number>>();
 
@@ -30,7 +31,7 @@ const hashString = (input: string) => {
 
 const boundedCachePart = (input: string) => {
   if (input.length <= MAX_CACHE_KEY_CONTENT_LENGTH) return input;
-  return `${input.slice(0, MAX_CACHE_KEY_CONTENT_LENGTH)}\0${input.length}\0${hashString(input)}`;
+  return `${input.slice(0, MAX_CACHE_KEY_EDGE_LENGTH)}\0${input.slice(-MAX_CACHE_KEY_EDGE_LENGTH)}\0${input.length}\0${hashString(input)}`;
 };
 
 /**
@@ -375,41 +376,34 @@ class BaseComment implements IComment {
   protected _cacheImage(image: IRenderer) {
     const key = this.cacheKey;
     const { imageCache, config } = this.ctx;
+    const lifetime = this.comment.long * 10 + config.cacheAge;
     let entries = imageCacheEntries.get(imageCache);
     if (!entries) {
       entries = new Map();
       imageCacheEntries.set(imageCache, entries);
     }
-    if (!entries.has(key) && entries.size >= MAX_IMAGE_CACHE_ENTRIES) {
-      const oldestKey = entries.keys().next().value;
-      if (oldestKey !== undefined) {
-        const oldest = imageCache.get(oldestKey);
-        if (oldest) {
-          clearTimeout(oldest.timeout);
-          oldest.image.destroy();
-        }
-        imageCache.delete(oldestKey);
-        entries.delete(oldestKey);
-      }
+    for (const entryKey of entries.keys()) {
+      if (!imageCache.get(entryKey)) entries.delete(entryKey);
     }
     this.image = image;
-    window.setTimeout(
-      () => {
-        this.image = undefined;
-      },
-      this.comment.long * 10 + config.cacheAge,
-    );
+    if (!entries.has(key) && entries.size >= MAX_IMAGE_CACHE_ENTRIES) {
+      window.setTimeout(() => {
+        if (this.image === image) this.image = undefined;
+        image.destroy();
+      }, lifetime);
+      return;
+    }
+    window.setTimeout(() => {
+      this.image = undefined;
+    }, lifetime);
     imageCache.set(key, {
-      timeout: window.setTimeout(
-        () => {
-          if (imageCache.get(key)?.image === image) {
-            image.destroy();
-            imageCache.delete(key);
-            imageCacheEntries.get(imageCache)?.delete(key);
-          }
-        },
-        this.comment.long * 10 + config.cacheAge,
-      ),
+      timeout: window.setTimeout(() => {
+        if (imageCache.get(key)?.image === image) {
+          image.destroy();
+          imageCache.delete(key);
+          imageCacheEntries.get(imageCache)?.delete(key);
+        }
+      }, lifetime),
       image,
     });
     entries.delete(key);

--- a/src/comments/HTML5Comment.ts
+++ b/src/comments/HTML5Comment.ts
@@ -51,14 +51,19 @@ const clampHTML5Content = (input: string) => {
   };
 };
 
-const isWithinImageBounds = (width: number, height: number) =>
-  Number.isFinite(width) &&
-  Number.isFinite(height) &&
-  width > 0 &&
-  height > 0 &&
-  width <= MAX_HTML5_COMMENT_IMAGE_WIDTH &&
-  height <= MAX_HTML5_COMMENT_IMAGE_HEIGHT &&
-  width * height <= MAX_HTML5_COMMENT_IMAGE_AREA;
+const isWithinImageBounds = (width: number, height: number) => {
+  const paddedWidth = width + HTML5_COMMENT_IMAGE_PADDING * 2;
+  const paddedHeight = height + HTML5_COMMENT_IMAGE_PADDING * 2;
+  return (
+    Number.isFinite(width) &&
+    Number.isFinite(height) &&
+    width > 0 &&
+    height > 0 &&
+    width <= MAX_HTML5_COMMENT_IMAGE_WIDTH &&
+    height <= MAX_HTML5_COMMENT_IMAGE_HEIGHT &&
+    paddedWidth * paddedHeight <= MAX_HTML5_COMMENT_IMAGE_AREA
+  );
+};
 
 class HTML5Comment extends BaseComment {
   override readonly pluginName: string = "HTML5Comment";

--- a/src/comments/HTML5Comment.ts
+++ b/src/comments/HTML5Comment.ts
@@ -40,8 +40,11 @@ const clampHTML5Content = (input: string) => {
   let end = 0;
   for (; end < input.length && end < MAX_HTML5_COMMENT_CHARS; end++) {
     if (input[end] === "\n") {
-      if (lineCount >= MAX_HTML5_COMMENT_LINES) break;
       lineCount++;
+      if (lineCount >= MAX_HTML5_COMMENT_LINES) {
+        end++;
+        break;
+      }
     }
   }
   const content = input.slice(0, end);

--- a/src/comments/HTML5Comment.ts
+++ b/src/comments/HTML5Comment.ts
@@ -28,6 +28,36 @@ import { addHTML5PartToResult } from "@/utils/niconico";
 import { BaseComment } from "./BaseComment";
 
 const MAX_RESIZE_ITERATIONS = 20;
+const MAX_HTML5_COMMENT_CHARS = 16_384;
+const MAX_HTML5_COMMENT_LINES = 256;
+const MAX_HTML5_COMMENT_IMAGE_WIDTH = 8192;
+const MAX_HTML5_COMMENT_IMAGE_HEIGHT = 8192;
+const MAX_HTML5_COMMENT_IMAGE_AREA = 16_777_216;
+
+const clampHTML5Content = (input: string) => {
+  let lineCount = 1;
+  let end = 0;
+  for (; end < input.length && end < MAX_HTML5_COMMENT_CHARS; end++) {
+    if (input[end] === "\n") {
+      if (lineCount >= MAX_HTML5_COMMENT_LINES) break;
+      lineCount++;
+    }
+  }
+  const content = input.slice(0, end);
+  return {
+    content,
+    lineCount,
+  };
+};
+
+const isWithinImageBounds = (width: number, height: number) =>
+  Number.isFinite(width) &&
+  Number.isFinite(height) &&
+  width > 0 &&
+  height > 0 &&
+  width <= MAX_HTML5_COMMENT_IMAGE_WIDTH &&
+  height <= MAX_HTML5_COMMENT_IMAGE_HEIGHT &&
+  width * height <= MAX_HTML5_COMMENT_IMAGE_AREA;
 
 class HTML5Comment extends BaseComment {
   override readonly pluginName: string = "HTML5Comment";
@@ -127,8 +157,14 @@ class HTML5Comment extends BaseComment {
 
   override parseContent(input: string, font?: HTML5Fonts) {
     const content: CommentContentItemText[] = [];
-    addHTML5PartToResult(content, input, this.config, font ?? "defont");
-    const lineCount = input.split("\n").length;
+    const clamped = clampHTML5Content(input);
+    addHTML5PartToResult(
+      content,
+      clamped.content,
+      this.config,
+      font ?? "defont",
+    );
+    const lineCount = clamped.lineCount;
     const lineOffset = 0;
     return {
       content,
@@ -319,6 +355,10 @@ class HTML5Comment extends BaseComment {
       }
       this.renderer.restore();
     }
+  }
+
+  protected override canGenerateTextImage(): boolean {
+    return isWithinImageBounds(this.comment.width, this.comment.height);
   }
 
   override _generateTextImage(): IRenderer {

--- a/src/comments/HTML5Comment.ts
+++ b/src/comments/HTML5Comment.ts
@@ -11,6 +11,7 @@ import type {
 } from "@/@types/";
 import type { CommentInstanceContext } from "@/contexts/";
 import { TypeGuardError } from "@/errors/TypeGuardError";
+import { MAX_CANVAS_AREA } from "@/renderer/canvas";
 import typeGuard from "@/typeGuard";
 import {
   getCharSize,
@@ -33,8 +34,7 @@ const MAX_HTML5_COMMENT_LINES = 256;
 const HTML5_COMMENT_IMAGE_PADDING = 4;
 const MAX_HTML5_COMMENT_IMAGE_WIDTH = 8192 - HTML5_COMMENT_IMAGE_PADDING * 2;
 const MAX_HTML5_COMMENT_IMAGE_HEIGHT = 8192 - HTML5_COMMENT_IMAGE_PADDING * 2;
-// Must match MAX_CANVAS_AREA in src/renderer/canvas.ts so accepted images are not downscaled.
-const MAX_HTML5_COMMENT_IMAGE_AREA = 16_777_216;
+const MAX_HTML5_COMMENT_IMAGE_AREA = MAX_CANVAS_AREA;
 
 const clampHTML5Content = (input: string) => {
   let lineCount = 1;

--- a/src/comments/HTML5Comment.ts
+++ b/src/comments/HTML5Comment.ts
@@ -33,6 +33,7 @@ const MAX_HTML5_COMMENT_LINES = 256;
 const HTML5_COMMENT_IMAGE_PADDING = 4;
 const MAX_HTML5_COMMENT_IMAGE_WIDTH = 8192 - HTML5_COMMENT_IMAGE_PADDING * 2;
 const MAX_HTML5_COMMENT_IMAGE_HEIGHT = 8192 - HTML5_COMMENT_IMAGE_PADDING * 2;
+// Must match MAX_CANVAS_AREA in src/renderer/canvas.ts so accepted images are not downscaled.
 const MAX_HTML5_COMMENT_IMAGE_AREA = 16_777_216;
 
 const clampHTML5Content = (input: string) => {

--- a/src/comments/HTML5Comment.ts
+++ b/src/comments/HTML5Comment.ts
@@ -30,8 +30,9 @@ import { BaseComment } from "./BaseComment";
 const MAX_RESIZE_ITERATIONS = 20;
 const MAX_HTML5_COMMENT_CHARS = 16_384;
 const MAX_HTML5_COMMENT_LINES = 256;
-const MAX_HTML5_COMMENT_IMAGE_WIDTH = 8192;
-const MAX_HTML5_COMMENT_IMAGE_HEIGHT = 8192;
+const HTML5_COMMENT_IMAGE_PADDING = 4;
+const MAX_HTML5_COMMENT_IMAGE_WIDTH = 8192 - HTML5_COMMENT_IMAGE_PADDING * 2;
+const MAX_HTML5_COMMENT_IMAGE_HEIGHT = 8192 - HTML5_COMMENT_IMAGE_PADDING * 2;
 const MAX_HTML5_COMMENT_IMAGE_AREA = 16_777_216;
 
 const clampHTML5Content = (input: string) => {
@@ -373,8 +374,7 @@ class HTML5Comment extends BaseComment {
       getConfig(this.config.commentScale, false) *
       scale *
       (this.comment.layer === -1 ? this.ctx.options.scale : 1);
-    const DEFAULT_COMMENT_PADDING = 4;
-    const image = this.renderer.getCanvas(DEFAULT_COMMENT_PADDING);
+    const image = this.renderer.getCanvas(HTML5_COMMENT_IMAGE_PADDING);
     image.setSize(this.comment.width, this.comment.height);
     image.setStrokeStyle(getStrokeColor(this.comment, this.config));
     image.setFillStyle(this.comment.color);

--- a/src/renderer/canvas.ts
+++ b/src/renderer/canvas.ts
@@ -176,12 +176,6 @@ class CanvasRenderer implements IRenderer {
     this.height = Math.max(0, size.height - paddingSize);
     this.canvas.width = size.width;
     this.canvas.height = size.height;
-    this.context.textAlign = "start";
-    this.context.textBaseline = "alphabetic";
-    this.context.lineJoin = "round";
-    if (this.padding > 0) {
-      this.context.translate(this.padding, this.padding);
-    }
   }
 
   getSize(): { width: number; height: number } {

--- a/src/renderer/canvas.ts
+++ b/src/renderer/canvas.ts
@@ -170,11 +170,12 @@ class CanvasRenderer implements IRenderer {
     this.context.globalAlpha = alpha;
   }
   setSize(width: number, height: number) {
-    const size = clampCanvasSize(width, height);
-    this.width = size.width;
-    this.height = size.height;
-    this.canvas.width = size.width + this.padding * 2;
-    this.canvas.height = size.height + this.padding * 2;
+    const paddingSize = this.padding * 2;
+    const size = clampCanvasSize(width + paddingSize, height + paddingSize);
+    this.width = Math.max(0, size.width - paddingSize);
+    this.height = Math.max(0, size.height - paddingSize);
+    this.canvas.width = size.width;
+    this.canvas.height = size.height;
   }
 
   getSize(): { width: number; height: number } {

--- a/src/renderer/canvas.ts
+++ b/src/renderer/canvas.ts
@@ -176,6 +176,9 @@ class CanvasRenderer implements IRenderer {
     this.height = Math.max(0, size.height - paddingSize);
     this.canvas.width = size.width;
     this.canvas.height = size.height;
+    this.context.textAlign = "start";
+    this.context.textBaseline = "alphabetic";
+    this.context.lineJoin = "round";
     if (this.padding > 0) {
       this.context.translate(this.padding, this.padding);
     }

--- a/src/renderer/canvas.ts
+++ b/src/renderer/canvas.ts
@@ -3,7 +3,7 @@ import { CanvasRenderingContext2DError } from "@/errors";
 import { canvasPool } from "@/renderer/canvasPool";
 
 const MAX_CANVAS_DIMENSION = 8192;
-const MAX_CANVAS_AREA = 16_777_216;
+export const MAX_CANVAS_AREA = 16_777_216;
 const MAX_MEASURE_TEXT_CACHE_TEXT_LENGTH = 512;
 
 const clampCanvasSize = (width: number, height: number) => {

--- a/src/renderer/canvas.ts
+++ b/src/renderer/canvas.ts
@@ -2,6 +2,34 @@ import type { IRenderer } from "@/@types/";
 import { CanvasRenderingContext2DError } from "@/errors";
 import { canvasPool } from "@/renderer/canvasPool";
 
+const MAX_CANVAS_DIMENSION = 8192;
+const MAX_CANVAS_AREA = 16_777_216;
+const MAX_MEASURE_TEXT_CACHE_TEXT_LENGTH = 512;
+
+const clampCanvasSize = (width: number, height: number) => {
+  let nextWidth = Number.isFinite(width) ? Math.max(0, Math.floor(width)) : 0;
+  let nextHeight = Number.isFinite(height)
+    ? Math.max(0, Math.floor(height))
+    : 0;
+  if (nextWidth > MAX_CANVAS_DIMENSION || nextHeight > MAX_CANVAS_DIMENSION) {
+    const scale = Math.min(
+      MAX_CANVAS_DIMENSION / Math.max(1, nextWidth),
+      MAX_CANVAS_DIMENSION / Math.max(1, nextHeight),
+    );
+    nextWidth = Math.floor(nextWidth * scale);
+    nextHeight = Math.floor(nextHeight * scale);
+  }
+  if (nextWidth * nextHeight > MAX_CANVAS_AREA) {
+    const scale = Math.sqrt(MAX_CANVAS_AREA / (nextWidth * nextHeight));
+    nextWidth = Math.floor(nextWidth * scale);
+    nextHeight = Math.floor(nextHeight * scale);
+  }
+  return {
+    width: nextWidth,
+    height: nextHeight,
+  };
+};
+
 /**
  * Canvasを使ったレンダラー
  * dom/canvas周りのAPIを切り出したもの
@@ -142,10 +170,11 @@ class CanvasRenderer implements IRenderer {
     this.context.globalAlpha = alpha;
   }
   setSize(width: number, height: number) {
-    this.width = width;
-    this.height = height;
-    this.canvas.width = width + this.padding * 2;
-    this.canvas.height = height + this.padding * 2;
+    const size = clampCanvasSize(width, height);
+    this.width = size.width;
+    this.height = size.height;
+    this.canvas.width = size.width + this.padding * 2;
+    this.canvas.height = size.height + this.padding * 2;
   }
 
   getSize(): { width: number; height: number } {
@@ -156,6 +185,9 @@ class CanvasRenderer implements IRenderer {
   }
 
   measureText(text: string): TextMetrics {
+    if (text.length > MAX_MEASURE_TEXT_CACHE_TEXT_LENGTH) {
+      return this.context.measureText(text);
+    }
     const key = `${this.context.font}\0${text}`;
     const cached = CanvasRenderer._mtCache.get(key);
     if (cached !== undefined) return cached;

--- a/src/renderer/canvas.ts
+++ b/src/renderer/canvas.ts
@@ -176,6 +176,9 @@ class CanvasRenderer implements IRenderer {
     this.height = Math.max(0, size.height - paddingSize);
     this.canvas.width = size.width;
     this.canvas.height = size.height;
+    if (this.padding > 0) {
+      this.context.translate(this.padding, this.padding);
+    }
   }
 
   getSize(): { width: number; height: number } {

--- a/src/utils/niconico.ts
+++ b/src/utils/niconico.ts
@@ -143,7 +143,7 @@ const measureWidth = (
       lineWidth.push(Math.ceil(currentWidth * scale));
       continue;
     }
-    const lines = item.content.split("\n");
+    const lines = item.slicedContent;
     const font = parseFont(item.font ?? comment.font, fontSize, config);
     if (font !== lastFont) {
       renderer.setFont(font);
@@ -164,8 +164,12 @@ const measureWidth = (
     itemWidth.push(width);
     lineWidth.push(Math.ceil(currentWidth * scale));
   }
+  let maxWidth = 0;
+  for (const width of lineWidth) {
+    if (width > maxWidth) maxWidth = width;
+  }
   return {
-    width: Math.max(...lineWidth),
+    width: maxWidth,
     lineWidth,
     itemWidth,
   };

--- a/src/utils/niconico.ts
+++ b/src/utils/niconico.ts
@@ -143,7 +143,7 @@ const measureWidth = (
       lineWidth.push(Math.ceil(currentWidth * scale));
       continue;
     }
-    const lines = item.slicedContent;
+    const lines = item.slicedContent ?? item.content.split("\n");
     const font = parseFont(item.font ?? comment.font, fontSize, config);
     if (font !== lastFont) {
       renderer.setFont(font);

--- a/tests/unit/html5-resource-bounds.spec.ts
+++ b/tests/unit/html5-resource-bounds.spec.ts
@@ -270,7 +270,5 @@ describe("HTML5 comment resource bounds", () => {
     expect(canvas.height).toBeLessThanOrEqual(8192);
     expect(renderer.getSize().width).toBe(canvas.width - 8);
     expect(renderer.getSize().height).toBe(canvas.height - 8);
-    expect(context.lineJoin).toBe("round");
-    expect(context.translate).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/unit/html5-resource-bounds.spec.ts
+++ b/tests/unit/html5-resource-bounds.spec.ts
@@ -1,0 +1,234 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { FormattedComment, IRenderer } from "@/@types";
+import { HTML5Comment } from "@/comments";
+import { createNicoScripts, ImageCacheContext } from "@/contexts";
+import { defaultConfig } from "@/definition/config";
+import { initConfig } from "@/definition/initConfig";
+import { RangeCacheContext } from "@/utils";
+
+const textMetrics = (width: number): TextMetrics =>
+  ({
+    width,
+    actualBoundingBoxLeft: 0,
+    actualBoundingBoxRight: width,
+    actualBoundingBoxAscent: 0,
+    actualBoundingBoxDescent: 0,
+    alphabeticBaseline: 0,
+    hangingBaseline: 0,
+    emHeightAscent: 0,
+    emHeightDescent: 0,
+    fontBoundingBoxAscent: 0,
+    fontBoundingBoxDescent: 0,
+    ideographicBaseline: 0,
+  }) as TextMetrics;
+
+class RecordingRenderer implements IRenderer {
+  public readonly rendererName = "RecordingRenderer";
+  public readonly canvas = {} as HTMLCanvasElement;
+  public readonly children: RecordingRenderer[] = [];
+  public measureCalls = 0;
+  public fillTextCalls = 0;
+  public strokeTextCalls = 0;
+  public destroyed = false;
+  private font = "10px sans-serif";
+  private size = { width: 0, height: 0 };
+
+  destroy() {
+    this.destroyed = true;
+  }
+  drawVideo() {}
+  getFont() {
+    return this.font;
+  }
+  getFillStyle() {
+    return "#000000";
+  }
+  setScale() {}
+  fillRect() {}
+  strokeRect() {}
+  fillText() {
+    this.fillTextCalls++;
+  }
+  strokeText() {
+    this.strokeTextCalls++;
+  }
+  quadraticCurveTo() {}
+  clearRect() {}
+  setFont(font: string) {
+    this.font = font;
+  }
+  setFillStyle() {}
+  setStrokeStyle() {}
+  setLineWidth() {}
+  setGlobalAlpha() {}
+  setSize(width: number, height: number) {
+    this.size = { width, height };
+  }
+  getSize() {
+    return this.size;
+  }
+  measureText(text: string) {
+    this.measureCalls++;
+    const fontSize = Number(/([0-9.]+)px/.exec(this.font)?.[1] ?? 10);
+    return textMetrics(text.length * fontSize * 0.5);
+  }
+  beginPath() {}
+  closePath() {}
+  moveTo() {}
+  lineTo() {}
+  stroke() {}
+  save() {}
+  restore() {}
+  getCanvas() {
+    const child = new RecordingRenderer();
+    this.children.push(child);
+    return child;
+  }
+  drawImage() {}
+  flush() {}
+  invalidateImage() {}
+}
+
+class TestHTML5Comment extends HTML5Comment {
+  exposeTextImage() {
+    return this.getTextImage();
+  }
+  exposeCacheKey() {
+    return this.getCacheKey();
+  }
+}
+
+const formattedComment = (
+  id: number,
+  content: string,
+  mail: string[] = [],
+): FormattedComment => ({
+  id,
+  vpos: 0,
+  content,
+  date: 1_700_000_000,
+  date_usec: 0,
+  owner: false,
+  premium: false,
+  mail,
+  user_id: id,
+  layer: -1,
+  is_my_post: false,
+});
+
+const createContext = () => ({
+  config: defaultConfig,
+  options: {
+    config: {},
+    debug: false,
+    enableLegacyPiP: false,
+    format: "formatted" as const,
+    formatted: false,
+    keepCA: false,
+    mode: "default" as const,
+    scale: 1,
+    showCollision: false,
+    showCommentCount: false,
+    showFPS: false,
+    useLegacy: false,
+    video: undefined,
+    lazy: false,
+  },
+  nicoScripts: createNicoScripts(),
+  imageCache: new ImageCacheContext(),
+  rangeCache: new RangeCacheContext(),
+});
+
+const cacheSize = (imageCache: ImageCacheContext) =>
+  Object.keys(
+    (imageCache as unknown as { _cache: Record<string, unknown> })._cache,
+  ).length;
+
+describe("HTML5 comment resource bounds", () => {
+  beforeEach(() => {
+    initConfig();
+    let timeoutId = 0;
+    vi.stubGlobal("window", {
+      setTimeout: vi.fn(() => ++timeoutId),
+    });
+    vi.stubGlobal("clearTimeout", vi.fn());
+  });
+
+  test("caps newline-heavy comments before measurement and image generation", () => {
+    const renderer = new RecordingRenderer();
+    const comment = new TestHTML5Comment(
+      formattedComment(1, "\n".repeat(10_000)),
+      renderer,
+      0,
+      createContext(),
+    );
+
+    expect(comment.comment.lineCount).toBe(256);
+    expect(renderer.measureCalls).toBeLessThanOrEqual(256);
+    expect(comment.exposeTextImage()).toBeNull();
+    expect(renderer.children).toHaveLength(0);
+  });
+
+  test("preserves normal multiline rendering", () => {
+    const renderer = new RecordingRenderer();
+    const comment = new TestHTML5Comment(
+      formattedComment(1, "one\ntwo\nthree"),
+      renderer,
+      0,
+      createContext(),
+    );
+
+    const image = comment.exposeTextImage();
+
+    expect(image).not.toBeNull();
+    expect(comment.comment.lineCount).toBe(3);
+    expect(renderer.children).toHaveLength(1);
+    expect(renderer.children[0]?.getSize().width).toBeGreaterThan(0);
+    expect(renderer.children[0]?.fillTextCalls).toBe(3);
+    expect(renderer.children[0]?.strokeTextCalls).toBe(3);
+  });
+
+  test("keeps fixed-comment resize measurement bounded for huge text", () => {
+    const renderer = new RecordingRenderer();
+    const comment = new TestHTML5Comment(
+      formattedComment(1, "x".repeat(5000), ["ue"]),
+      renderer,
+      0,
+      createContext(),
+    );
+
+    expect(comment.comment.resizedX).toBe(true);
+    expect(renderer.measureCalls).toBeLessThanOrEqual(80);
+  });
+
+  test("bounds cache keys and per-context image cache growth", () => {
+    const ctx = createContext();
+    const longContentComment = new TestHTML5Comment(
+      formattedComment(1, "x".repeat(10_000)),
+      new RecordingRenderer(),
+      0,
+      ctx,
+    );
+
+    expect(longContentComment.exposeCacheKey().length).toBeLessThan(600);
+    expect(longContentComment.exposeCacheKey()).not.toContain("x".repeat(1000));
+
+    let firstImage: RecordingRenderer | undefined;
+    for (let i = 0; i < 1050; i++) {
+      const renderer = new RecordingRenderer();
+      const comment = new TestHTML5Comment(
+        formattedComment(i + 2, `cacheable ${i}`),
+        renderer,
+        i,
+        ctx,
+      );
+      const image = comment.exposeTextImage() as RecordingRenderer | null;
+      expect(image).not.toBeNull();
+      firstImage ??= image ?? undefined;
+    }
+
+    expect(cacheSize(ctx.imageCache)).toBeLessThanOrEqual(1024);
+    expect(firstImage?.destroyed).toBe(true);
+  });
+});

--- a/tests/unit/html5-resource-bounds.spec.ts
+++ b/tests/unit/html5-resource-bounds.spec.ts
@@ -5,6 +5,7 @@ import { HTML5Comment } from "@/comments";
 import { createNicoScripts, ImageCacheContext } from "@/contexts";
 import { defaultConfig } from "@/definition/config";
 import { initConfig } from "@/definition/initConfig";
+import { CanvasRenderer } from "@/renderer/canvas";
 import { RangeCacheContext } from "@/utils";
 
 const textMetrics = (width: number): TextMetrics =>
@@ -95,7 +96,7 @@ class TestHTML5Comment extends HTML5Comment {
     return this.getTextImage();
   }
   exposeCacheKey() {
-    return this.getCacheKey();
+    return this.cacheKey;
   }
 }
 
@@ -140,10 +141,8 @@ const createContext = () => ({
   rangeCache: new RangeCacheContext(),
 });
 
-const cacheSize = (imageCache: ImageCacheContext) =>
-  Object.keys(
-    (imageCache as unknown as { _cache: Record<string, unknown> })._cache,
-  ).length;
+const cachedKeyCount = (imageCache: ImageCacheContext, keys: string[]) =>
+  keys.filter((key) => imageCache.get(key)).length;
 
 describe("HTML5 comment resource bounds", () => {
   beforeEach(() => {
@@ -214,6 +213,7 @@ describe("HTML5 comment resource bounds", () => {
     expect(longContentComment.exposeCacheKey().length).toBeLessThan(600);
     expect(longContentComment.exposeCacheKey()).not.toContain("x".repeat(1000));
 
+    const cacheKeys: string[] = [];
     let firstImage: RecordingRenderer | undefined;
     for (let i = 0; i < 1050; i++) {
       const renderer = new RecordingRenderer();
@@ -223,12 +223,39 @@ describe("HTML5 comment resource bounds", () => {
         i,
         ctx,
       );
+      cacheKeys.push(comment.exposeCacheKey());
       const image = comment.exposeTextImage() as RecordingRenderer | null;
       expect(image).not.toBeNull();
       firstImage ??= image ?? undefined;
     }
 
-    expect(cacheSize(ctx.imageCache)).toBeLessThanOrEqual(1024);
-    expect(firstImage?.destroyed).toBe(true);
+    const cachedCount = cachedKeyCount(ctx.imageCache, cacheKeys);
+    expect(cachedCount).toBeGreaterThan(0);
+    expect(cachedCount).toBeLessThanOrEqual(1024);
+    expect(cachedCount).toBeLessThan(cacheKeys.length);
+    expect(firstImage?.destroyed).toBe(false);
+  });
+
+  test("clamps backing canvas dimensions including padding", () => {
+    const context = {
+      textAlign: "start",
+      textBaseline: "alphabetic",
+      lineJoin: "round",
+      translate: vi.fn(),
+      measureText: vi.fn(() => textMetrics(1)),
+    };
+    const canvas = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn(() => context),
+    } as unknown as HTMLCanvasElement;
+    const renderer = new CanvasRenderer(canvas, undefined, 4);
+
+    renderer.setSize(10_000, 10_000);
+
+    expect(canvas.width).toBeLessThanOrEqual(8192);
+    expect(canvas.height).toBeLessThanOrEqual(8192);
+    expect(renderer.getSize().width).toBe(canvas.width - 8);
+    expect(renderer.getSize().height).toBe(canvas.height - 8);
   });
 });

--- a/tests/unit/html5-resource-bounds.spec.ts
+++ b/tests/unit/html5-resource-bounds.spec.ts
@@ -98,6 +98,12 @@ class TestHTML5Comment extends HTML5Comment {
   exposeCacheKey() {
     return this.cacheKey;
   }
+  exposeCurrentImage() {
+    return this.image;
+  }
+  drawBodyForTest() {
+    this._draw(0, 0);
+  }
 }
 
 const formattedComment = (
@@ -214,6 +220,7 @@ describe("HTML5 comment resource bounds", () => {
     expect(longContentComment.exposeCacheKey()).not.toContain("x".repeat(1000));
 
     const cacheKeys: string[] = [];
+    let firstComment: TestHTML5Comment | undefined;
     let firstImage: RecordingRenderer | undefined;
     for (let i = 0; i < 1050; i++) {
       const renderer = new RecordingRenderer();
@@ -226,6 +233,7 @@ describe("HTML5 comment resource bounds", () => {
       cacheKeys.push(comment.exposeCacheKey());
       const image = comment.exposeTextImage() as RecordingRenderer | null;
       expect(image).not.toBeNull();
+      firstComment ??= comment;
       firstImage ??= image ?? undefined;
     }
 
@@ -233,7 +241,12 @@ describe("HTML5 comment resource bounds", () => {
     expect(cachedCount).toBeGreaterThan(0);
     expect(cachedCount).toBeLessThanOrEqual(1024);
     expect(cachedCount).toBeLessThan(cacheKeys.length);
-    expect(firstImage?.destroyed).toBe(false);
+    expect(firstImage?.destroyed).toBe(true);
+
+    firstComment?.drawBodyForTest();
+
+    expect(firstComment?.exposeCurrentImage()).not.toBe(firstImage);
+    expect(firstComment?.exposeCurrentImage()).toBeTruthy();
   });
 
   test("clamps backing canvas dimensions including padding", () => {
@@ -257,5 +270,6 @@ describe("HTML5 comment resource bounds", () => {
     expect(canvas.height).toBeLessThanOrEqual(8192);
     expect(renderer.getSize().width).toBe(canvas.width - 8);
     expect(renderer.getSize().height).toBe(canvas.height - 8);
+    expect(context.translate).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/unit/html5-resource-bounds.spec.ts
+++ b/tests/unit/html5-resource-bounds.spec.ts
@@ -270,6 +270,7 @@ describe("HTML5 comment resource bounds", () => {
     expect(canvas.height).toBeLessThanOrEqual(8192);
     expect(renderer.getSize().width).toBe(canvas.width - 8);
     expect(renderer.getSize().height).toBe(canvas.height - 8);
+    expect(context.lineJoin).toBe("round");
     expect(context.translate).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary
- Clamp HTML5 comment parsing to bounded character and line counts before repeated split/measure/draw loops.
- Skip impossible HTML5 text image generation, bound canvas sizing and long measureText cache keys, and cap per-context image cache entries.
- Add focused Vitest coverage for hostile newline-heavy input, resize measurement bounds, normal multiline rendering, bounded cache keys, and cache eviction release.

## Validation
- rtk pnpm test:unit -- tests/unit/html5-resource-bounds.spec.ts
- rtk pnpm check-types
- rtk pnpm test:unit
- rtk pnpm lint (exit 0; existing warnings remain in src/typeGuard.ts optional-chain suggestions)
- rtk git diff --check

## Review
- deep-review self-review completed; fixed cache eviction lifecycle issue found during review.
- Independent reviewer approved after fix; residual risk limited to hard caps being internal policy values.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds resource bounds to HTML5 comment rendering: it clamps raw comment text to 16 384 characters and 256 lines before parsing, guards `setSize` and `measureText` in the canvas renderer, caps the per-context text-image LRU cache to 1 024 entries, and shortens cache keys for very long comment content. A `destroyedTextImages` WeakSet is used to prevent `_draw` from using a renderer that was synchronously destroyed by LRU eviction.

- **Input clamping (`HTML5Comment.ts`):** `clampHTML5Content` truncates both by character count and by newline count before text is parsed or measured, and `isWithinImageBounds` / `canGenerateTextImage` gate image creation before any canvas allocation.
- **Canvas bounds (`canvas.ts`):** `clampCanvasSize` caps per-canvas dimensions to 8 192 and area to 16 777 216; `measureText` bypasses the in-process cache for strings longer than 512 characters to prevent unbounded key growth.
- **LRU eviction fix (`BaseComment.ts`):** Evicted renderers are added to a module-level `destroyedTextImages` WeakSet; `_draw` checks the set and resets `this.image` before re-acquiring, closing the use-after-destroy window identified in the prior review cycle.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all resource-bound paths are guarded, the eviction lifecycle is correctly closed, and the new test suite exercises the critical edge cases.

The changes are tightly scoped defensive additions: input clamping, canvas dimension caps, LRU eviction with a WeakSet guard, and bounded cache keys. Each boundary interacts consistently with the others (e.g. isWithinImageBounds matches the padded canvas limits exactly). The eviction fix correctly adds the renderer to destroyedTextImages before destroying it and resets this.image in _draw before re-acquiring, closing the use-after-destroy window. No correctness regressions were found in the sizing, caching, or rendering paths.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/comments/BaseComment.ts | Adds LRU eviction cap (1 024 entries), destroyedTextImages WeakSet to guard _draw, bounded cache key via boundedCachePart, and identity-checked eviction timeouts — lifecycle logic looks correct. |
| src/comments/HTML5Comment.ts | clampHTML5Content correctly limits input to MAX_HTML5_COMMENT_CHARS/LINES before parsing; isWithinImageBounds prevents oversized canvas allocation; canGenerateTextImage override wires the guard into getTextImage. |
| src/renderer/canvas.ts | clampCanvasSize correctly handles dimension + area limits with two sequential scale steps; measureText cache bypass for long strings is safe; setSize correctly back-computes content dimensions from clamped totals. |
| src/utils/niconico.ts | measureWidth now uses pre-split slicedContent to avoid redundant splits; Math.max loop replaces spread-based Math.max(...lineWidth) which could stack-overflow on very large arrays — clean improvement. |
| tests/unit/html5-resource-bounds.spec.ts | New focused Vitest suite covering hostile newline input, resize bounds, multiline rendering, cache key length, LRU eviction, and destroyed-image re-render — good coverage of the new paths. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[BaseComment._draw] --> B{this.image in\ndestroyedTextImages?}
    B -- yes --> C[this.image = undefined]
    B -- no --> D{this.image\n=== undefined?}
    C --> D
    D -- no --> E[draw with this.image]
    D -- yes --> F[getTextImage]
    F --> G{canGenerateTextImage?}
    G -- no --> H[return null]
    G -- yes --> I{imageCache hit?}
    I -- yes --> J[promote key in LRU Set\nrefresh eviction timeout\nthis.image = cache.image]
    I -- no --> K[_generateTextImage]
    K --> L[_cacheImage]
    L --> M{entries.size >= 1024?}
    M -- yes --> N[clean stale entries\nthen evict oldest:\ndestroy + destroyedTextImages.add]
    M -- no --> O[imageCache.set\nentries.add key]
    N --> O
    J --> E
    O --> E
```
</details>

<sub>Reviews (7): Last reviewed commit: ["Share canvas area bound constant"](https://github.com/xpadev-net/niconicomments/commit/3f4886941804798320625aab6e669d53bcb95b47) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35313873)</sub>

<!-- /greptile_comment -->