### PR TITLE
Harden Flash at-button resource bounds

### DIFF
--- a/src/comments/FlashComment.ts
+++ b/src/comments/FlashComment.ts
@@ -53,6 +53,13 @@ const isWithinFlashImageBounds = (width: number, height: number) => {
   );
 };
 
+const takeFlashDisplayPart = (value: string, remaining: { value: string }) => {
+  if (!value || !remaining.value) return "";
+  const part = remaining.value.slice(0, value.length);
+  remaining.value = remaining.value.slice(part.length);
+  return part;
+};
+
 class FlashComment extends BaseComment {
   private _globalScale: number;
   override readonly pluginName: string = "FlashComment";
@@ -200,14 +207,22 @@ class FlashComment extends BaseComment {
     const displayText = button
       ? `${button.message.before}${button.message.body}${button.message.after}`
       : input;
-    if (button) {
-      appendContent(button.message.before);
-      appendContent(button.message.body, true);
-      appendContent(button.message.after);
-    } else {
-      appendContent(input);
-    }
     const clamped = clampFlashContent(displayText);
+    if (button) {
+      const remainingDisplayText = { value: clamped.content };
+      appendContent(
+        takeFlashDisplayPart(button.message.before, remainingDisplayText),
+      );
+      appendContent(
+        takeFlashDisplayPart(button.message.body, remainingDisplayText),
+        true,
+      );
+      appendContent(
+        takeFlashDisplayPart(button.message.after, remainingDisplayText),
+      );
+    } else {
+      appendContent(clamped.content);
+    }
     const lineCount = clamped.lineCount;
     const lineOffset =
       (clamped.content.match(this._flashScriptCharRegex.super)?.length ?? 0) *

--- a/src/comments/FlashComment.ts
+++ b/src/comments/FlashComment.ts
@@ -13,14 +13,17 @@ import type {
 } from "@/@types/";
 import type { CommentInstanceContext } from "@/contexts/";
 import { TypeGuardError } from "@/errors/TypeGuardError";
+import { MAX_CANVAS_AREA } from "@/renderer/canvas";
 import typeGuard from "@/typeGuard";
 import {
+  clampFlashContent,
   getButtonParts,
   getConfig,
   getStrokeColor,
   isLineBreakResize,
+  MAX_FLASH_CONTENT_ITEMS,
   parseCommandAndNicoScript,
-  parseContent,
+  parseContent as parseFlashContent,
   parseFont,
 } from "@/utils";
 import {
@@ -35,6 +38,20 @@ const flashScriptCharRegexCache = new WeakMap<
   BaseConfig,
   { super: RegExp; sub: RegExp }
 >();
+const MAX_FLASH_COMMENT_IMAGE_WIDTH = 8192;
+const MAX_FLASH_COMMENT_IMAGE_HEIGHT = 8192;
+
+const isWithinFlashImageBounds = (width: number, height: number) => {
+  return (
+    Number.isFinite(width) &&
+    Number.isFinite(height) &&
+    width > 0 &&
+    height > 0 &&
+    width <= MAX_FLASH_COMMENT_IMAGE_WIDTH &&
+    height <= MAX_FLASH_COMMENT_IMAGE_HEIGHT &&
+    width * height <= MAX_CANVAS_AREA
+  );
+};
 
 class FlashComment extends BaseComment {
   private _globalScale: number;
@@ -168,22 +185,35 @@ class FlashComment extends BaseComment {
   }
 
   override parseContent(input: string, button?: ButtonParams) {
-    const content: CommentContentItem[] = button
-      ? [
-          ...parseContent(button.message.before, this.config),
-          ...parseContent(button.message.body, this.config).map((val) => {
-            val.isButton = true;
-            return val;
-          }),
-          ...parseContent(button.message.after, this.config),
-        ]
-      : parseContent(input, this.config);
-    const lineCount = (input.match(/\n/g)?.length ?? 0) + 1;
+    const content: CommentContentItem[] = [];
+    const appendContent = (value: string, isButton = false) => {
+      const remaining = MAX_FLASH_CONTENT_ITEMS - content.length;
+      if (remaining <= 0) return;
+      const parsed = parseFlashContent(value, this.config).slice(0, remaining);
+      if (isButton) {
+        for (const val of parsed) {
+          val.isButton = true;
+        }
+      }
+      content.push(...parsed);
+    };
+    const displayText = button
+      ? `${button.message.before}${button.message.body}${button.message.after}`
+      : input;
+    if (button) {
+      appendContent(button.message.before);
+      appendContent(button.message.body, true);
+      appendContent(button.message.after);
+    } else {
+      appendContent(input);
+    }
+    const clamped = clampFlashContent(displayText);
+    const lineCount = clamped.lineCount;
     const lineOffset =
-      (input.match(this._flashScriptCharRegex.super)?.length ?? 0) *
+      (clamped.content.match(this._flashScriptCharRegex.super)?.length ?? 0) *
         -1 *
         this.config.flashScriptCharOffset +
-      (input.match(this._flashScriptCharRegex.sub)?.length ?? 0) *
+      (clamped.content.match(this._flashScriptCharRegex.sub)?.length ?? 0) *
         this.config.flashScriptCharOffset;
     return {
       content,
@@ -439,6 +469,16 @@ class FlashComment extends BaseComment {
       isLastButton = !!item.isButton;
     }
     return renderer;
+  }
+
+  protected override canGenerateTextImage(): boolean {
+    const atButtonPadding = this.comment.button
+      ? getConfig(this.config.atButtonPadding, true) * 2
+      : 0;
+    return isWithinFlashImageBounds(
+      this.comment.width,
+      this.comment.height + atButtonPadding,
+    );
   }
 
   override getButtonImage(posX: number, posY: number, cursor?: Position) {

--- a/src/utils/comment.ts
+++ b/src/utils/comment.ts
@@ -49,6 +49,15 @@ export const DEFAULT_COMMENT_LONG = 300;
 export const DEFAULT_NICOSCRIPT_LONG = 30 * 100;
 export const MAX_COMMENT_LONG = 120 * 100;
 export const MAX_NICOSCRIPT_LONG = 60 * 60 * 100;
+export const MAX_AT_BUTTON_COMMAND_CHARS = 16_384;
+export const MAX_AT_BUTTON_TEXT_CHARS = 4096;
+export const MAX_AT_BUTTON_MAIL_ENTRIES = 16;
+export const MAX_AT_BUTTON_MAIL_CHARS = 64;
+export const MAX_AT_BUTTON_LIMIT = 100;
+export const MAX_PARSED_COMMAND_MAIL_ENTRIES = 64;
+export const MAX_PARSED_COMMAND_MAIL_CHARS = 128;
+export const MAX_NICOSCRIPT_COMMAND_CHARS = 16_384;
+export const MAX_NICOSCRIPT_TEXT_CHARS = 4096;
 const LAZY_LOOKAHEAD_LEAD_IN = 288;
 const LAZY_LOOKAHEAD_MOTION_MARGIN = 125;
 const LAZY_LOOKAHEAD_SAFETY_BUFFER = 100;
@@ -122,6 +131,43 @@ const normalizeNicoscriptLong = (value: number | undefined) => {
     normalizeLongCentiseconds(value * 100, MAX_NICOSCRIPT_LONG) ||
     DEFAULT_NICOSCRIPT_LONG
   );
+};
+
+const clampString = (value: string, maxLength: number) =>
+  value.length > maxLength ? value.slice(0, maxLength) : value;
+
+const takeButtonText = (
+  value: string | undefined,
+  remaining: { value: number },
+) => {
+  if (!value || remaining.value <= 0) return "";
+  const text = clampString(value, remaining.value);
+  remaining.value -= text.length;
+  return text;
+};
+
+const normalizeAtButtonLimit = (value: string | undefined) => {
+  const limit = Number(value ?? 1);
+  if (!Number.isFinite(limit) || limit <= 0) {
+    return 0;
+  }
+  return Math.min(Math.floor(limit), MAX_AT_BUTTON_LIMIT);
+};
+
+const normalizeAtButtonMail = (value: string | undefined) => {
+  if (!value) return [];
+  return value
+    .split(",", MAX_AT_BUTTON_MAIL_ENTRIES)
+    .map((command) => clampString(command, MAX_AT_BUTTON_MAIL_CHARS))
+    .filter((command) => command.length > 0);
+};
+
+const hasParsedMailCommand = (commands: string[], target: string) => {
+  const len = Math.min(commands.length, MAX_PARSED_COMMAND_MAIL_ENTRIES);
+  for (let i = 0; i < len; i++) {
+    if (commands[i] === target) return true;
+  }
+  return false;
 };
 
 const processedTimelineComments = new WeakMap<IComment, WeakSet<Timeline>>();
@@ -343,9 +389,10 @@ const addNicoscriptReplace = (
   comment: FormattedComment,
   commands: ParsedCommand,
   nicoScripts: NicoScript,
+  commandInput: string,
 ) => {
   //@置換
-  const result = parseBrackets(comment.content.slice(4));
+  const result = parseBrackets(commandInput.slice(4));
   if (
     result[0] === undefined ||
     (result[2] !== undefined &&
@@ -359,8 +406,8 @@ const addNicoscriptReplace = (
   nicoScripts.replace.unshift({
     start: comment.vpos,
     long: normalizeOptionalNicoscriptLong(commands.long),
-    keyword: result[0],
-    replace: result[1] ?? "",
+    keyword: clampString(result[0], MAX_NICOSCRIPT_TEXT_CHARS),
+    replace: clampString(result[1] ?? "", MAX_NICOSCRIPT_TEXT_CHARS),
     range: result[2] ?? "単", //単
     target: result[3] ?? "コメ", //コメ
     condition: result[4] ?? "部分一致", //部分一致
@@ -400,10 +447,15 @@ const processNicoscript = (
   nicoScripts: NicoScript,
   rangeCache: RangeCacheContext,
 ) => {
-  const nicoscript = RE_NICOSCRIPT.exec(comment.content);
+  const nicoscriptInput = clampString(
+    comment.content,
+    MAX_NICOSCRIPT_COMMAND_CHARS,
+  );
+  const nicoscript = RE_NICOSCRIPT.exec(nicoscriptInput);
   if (!nicoscript) return;
   if (nicoscript[1] === "ボタン" && nicoscript[2]) {
     //ボタン
+    if (hasParsedMailCommand(comment.mail, "from_button")) return;
     processAtButton(comment, commands);
     return;
   }
@@ -436,7 +488,7 @@ const processNicoscript = (
   }
   if (nicoscript[1] === "置換") {
     //置換
-    addNicoscriptReplace(comment, commands, nicoScripts);
+    addNicoscriptReplace(comment, commands, nicoScripts, nicoscriptInput);
   }
 };
 
@@ -561,26 +613,31 @@ const processAtButton = (
   comment: FormattedComment,
   commands: ParsedCommand,
 ) => {
-  const args = parseBrackets(comment.content);
+  const args = parseBrackets(
+    clampString(comment.content, MAX_AT_BUTTON_COMMAND_CHARS),
+  );
   if (args[1] === undefined) return;
   commands.invisible = false;
   const content = RE_BUTTON_CONTENT.exec(args[1]) as {
     groups: { before?: string; body?: string; after?: string };
   };
+  const remainingText = { value: MAX_AT_BUTTON_TEXT_CHARS };
   const message = {
-    before: content.groups?.before ?? "",
-    body: content.groups?.body ?? "",
-    after: content.groups?.after ?? "",
+    before: takeButtonText(content.groups?.before, remainingText),
+    body: takeButtonText(content.groups?.body, remainingText),
+    after: takeButtonText(content.groups?.after, remainingText),
   };
   commands.button = {
     message,
-    commentMessage:
+    commentMessage: clampString(
       args[2] ?? `${message.before}${message.body}${message.after}`,
+      MAX_AT_BUTTON_TEXT_CHARS,
+    ),
     commentVisible: args[3] !== "非表示",
-    commentMail: args[4]?.split(",") ?? [],
-    limit: Number(args[5] ?? 1),
-    local: comment.mail.includes("local"),
-    hidden: comment.mail.includes("hidden"),
+    commentMail: normalizeAtButtonMail(args[4]),
+    limit: normalizeAtButtonLimit(args[5]),
+    local: hasParsedMailCommand(comment.mail, "local"),
+    hidden: hasParsedMailCommand(comment.mail, "hidden"),
   };
 };
 
@@ -596,7 +653,6 @@ const parseCommands = (
   config: BaseConfig,
   options: BaseOptions,
 ): ParsedCommand => {
-  const commands = comment.mail;
   const isFlash = isFlashComment(comment, config, options);
   const result: ParsedCommand = {
     loc: undefined,
@@ -612,7 +668,11 @@ const parseCommands = (
     invisible: false,
     long: undefined,
   };
-  for (const command of commands) {
+  const len = Math.min(comment.mail.length, MAX_PARSED_COMMAND_MAIL_ENTRIES);
+  for (let i = 0; i < len; i++) {
+    const command = comment.mail[i];
+    if (command === undefined) continue;
+    if (command.length > MAX_PARSED_COMMAND_MAIL_CHARS) continue;
     parseCommand(comment, command, result, isFlash, config);
   }
   if (comment.content.startsWith("/")) {
@@ -735,12 +795,12 @@ const isFlashComment = (
   options.mode === "flash" ||
   (options.mode === "default" &&
     !(
-      comment.mail.includes("gothic") ||
-      comment.mail.includes("defont") ||
-      comment.mail.includes("mincho")
+      hasParsedMailCommand(comment.mail, "gothic") ||
+      hasParsedMailCommand(comment.mail, "defont") ||
+      hasParsedMailCommand(comment.mail, "mincho")
     ) &&
     (comment.date < config.flashThreshold ||
-      comment.mail.includes("nico:flash")));
+      hasParsedMailCommand(comment.mail, "nico:flash")));
 
 /**
  * コメントが逆コマンド適用対象かを返す

--- a/src/utils/flash.ts
+++ b/src/utils/flash.ts
@@ -40,11 +40,10 @@ const clampFlashContent = (input: string) => {
   let end = 0;
   for (; end < input.length && end < MAX_FLASH_COMMENT_CHARS; end++) {
     if (input[end] === "\n") {
-      lineCount++;
       if (lineCount >= MAX_FLASH_COMMENT_LINES) {
-        end++;
         break;
       }
+      lineCount++;
     }
   }
   return {

--- a/src/utils/flash.ts
+++ b/src/utils/flash.ts
@@ -12,6 +12,10 @@ import type {
 import { getConfig } from "@/utils/config";
 import { nativeSort } from "@/utils/sort";
 
+export const MAX_FLASH_COMMENT_CHARS = 16_384;
+export const MAX_FLASH_COMMENT_LINES = 256;
+export const MAX_FLASH_CONTENT_ITEMS = 2048;
+
 const flashCharRegexCache = new WeakMap<
   BaseConfig,
   { simsunStrong: RegExp; simsunWeak: RegExp; gulim: RegExp; gothic: RegExp }
@@ -29,6 +33,24 @@ const getFlashCharRegex = (config: BaseConfig) => {
     flashCharRegexCache.set(config, cached);
   }
   return cached;
+};
+
+const clampFlashContent = (input: string) => {
+  let lineCount = 1;
+  let end = 0;
+  for (; end < input.length && end < MAX_FLASH_COMMENT_CHARS; end++) {
+    if (input[end] === "\n") {
+      lineCount++;
+      if (lineCount >= MAX_FLASH_COMMENT_LINES) {
+        end++;
+        break;
+      }
+    }
+  }
+  return {
+    content: input.slice(0, end),
+    lineCount,
+  };
 };
 
 /**
@@ -81,14 +103,17 @@ const getFlashFontName = (font: CommentFlashFontParsed): CommentFlashFont => {
  */
 const parseContent = (content: string, config: BaseConfig) => {
   const results: CommentContentItem[] = [];
-  const lines = Array.from(content.match(/\n|[^\n]+/g) ?? []);
+  const clamped = clampFlashContent(content);
+  const lines = Array.from(clamped.content.match(/\n|[^\n]+/g) ?? []);
   for (const line of lines) {
     const lineContent = parseLine(line, config);
     const firstContent = lineContent[0];
+    const remainingItems = MAX_FLASH_CONTENT_ITEMS - results.length;
+    if (remainingItems <= 0) break;
     const defaultFont = firstContent?.font;
     if (defaultFont) {
       results.push(
-        ...lineContent.map((val) => {
+        ...lineContent.slice(0, remainingItems).map((val) => {
           val.font ??= defaultFont;
           if (val.type === "spacer") {
             const spacer = config.compatSpacer.flash[val.char];
@@ -101,7 +126,7 @@ const parseContent = (content: string, config: BaseConfig) => {
         }),
       );
     } else {
-      results.push(...lineContent);
+      results.push(...lineContent.slice(0, remainingItems));
     }
   }
   return results;
@@ -139,7 +164,7 @@ const addPartToResult = (
   config: BaseConfig,
   font?: CommentFlashFont,
 ) => {
-  if (part === "") return;
+  if (part === "" || lineContent.length >= MAX_FLASH_CONTENT_ITEMS) return;
   for (const key of Object.keys(config.compatSpacer.flash)) {
     const spacerWidth = config.compatSpacer.flash[key]?.[font ?? "defont"];
     if (!spacerWidth) continue;
@@ -379,6 +404,7 @@ const buildAtButtonComment = (
 
 export {
   buildAtButtonComment,
+  clampFlashContent,
   getButtonParts,
   getFlashFontIndex,
   getFlashFontName,

--- a/tests/unit/flash-resource-bounds.spec.ts
+++ b/tests/unit/flash-resource-bounds.spec.ts
@@ -189,6 +189,25 @@ describe("Flash and at-button resource bounds", () => {
     );
   });
 
+  test("keeps the last allowed Flash line content when clamping", () => {
+    const renderer = new RecordingRenderer();
+    const comment = new TestFlashComment(
+      formattedComment(
+        `${"\n".repeat(MAX_FLASH_COMMENT_LINES - 1)}last-line-kept`,
+      ),
+      renderer,
+      0,
+      createContext(),
+    );
+
+    expect(comment.comment.lineCount).toBe(MAX_FLASH_COMMENT_LINES);
+    expect(
+      comment.comment.content.some(
+        (item) => item.type === "text" && item.content === "last-line-kept",
+      ),
+    ).toBe(true);
+  });
+
   test("preserves normal Flash multiline rendering", () => {
     const renderer = new RecordingRenderer();
     const comment = new TestFlashComment(
@@ -236,6 +255,27 @@ describe("Flash and at-button resource bounds", () => {
     );
     expect(comment.comment.lineCount).toBe(MAX_FLASH_COMMENT_LINES);
     expect(renderer.measureCalls).toBeLessThanOrEqual(
+      MAX_FLASH_COMMENT_LINES * 4,
+    );
+  });
+
+  test("caps combined at-button display parts to the Flash line budget", () => {
+    const renderer = new RecordingRenderer();
+    const comment = new TestFlashComment(
+      formattedComment(
+        `@ボタン "${"\n".repeat(100)}[${"\n".repeat(100)}]${"\n".repeat(100)}"`,
+      ),
+      renderer,
+      0,
+      createContext(),
+    );
+    const image = comment.exposeTextImage() as RecordingRenderer | null;
+
+    expect(comment.comment.lineCount).toBe(MAX_FLASH_COMMENT_LINES);
+    expect(renderer.measureCalls).toBeLessThanOrEqual(
+      MAX_FLASH_COMMENT_LINES * 4,
+    );
+    expect(image?.fillTextCalls ?? 0).toBeLessThanOrEqual(
       MAX_FLASH_COMMENT_LINES * 4,
     );
   });

--- a/tests/unit/flash-resource-bounds.spec.ts
+++ b/tests/unit/flash-resource-bounds.spec.ts
@@ -1,0 +1,367 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import type {
+  FormattedComment,
+  FormattedCommentWithSize,
+  IRenderer,
+} from "@/@types";
+import { FlashComment } from "@/comments";
+import { createNicoScripts, ImageCacheContext } from "@/contexts";
+import { defaultConfig, defaultOptions } from "@/definition/config";
+import { initConfig } from "@/definition/initConfig";
+import {
+  buildAtButtonComment,
+  MAX_AT_BUTTON_LIMIT,
+  MAX_AT_BUTTON_MAIL_ENTRIES,
+  MAX_AT_BUTTON_TEXT_CHARS,
+  MAX_FLASH_COMMENT_LINES,
+  MAX_NICOSCRIPT_COMMAND_CHARS,
+  MAX_NICOSCRIPT_TEXT_CHARS,
+  MAX_PARSED_COMMAND_MAIL_ENTRIES,
+  parseCommandAndNicoScript,
+  RangeCacheContext,
+} from "@/utils";
+
+const textMetrics = (width: number): TextMetrics =>
+  ({
+    width,
+    actualBoundingBoxLeft: 0,
+    actualBoundingBoxRight: width,
+    actualBoundingBoxAscent: 0,
+    actualBoundingBoxDescent: 0,
+    alphabeticBaseline: 0,
+    hangingBaseline: 0,
+    emHeightAscent: 0,
+    emHeightDescent: 0,
+    fontBoundingBoxAscent: 0,
+    fontBoundingBoxDescent: 0,
+    ideographicBaseline: 0,
+  }) as TextMetrics;
+
+class RecordingRenderer implements IRenderer {
+  public readonly rendererName = "RecordingRenderer";
+  public readonly canvas = {} as HTMLCanvasElement;
+  public readonly children: RecordingRenderer[] = [];
+  public measureCalls = 0;
+  public fillTextCalls = 0;
+  public strokeTextCalls = 0;
+  private font = "10px sans-serif";
+  private size = { width: 0, height: 0 };
+
+  destroy() {}
+  drawVideo() {}
+  getFont() {
+    return this.font;
+  }
+  getFillStyle() {
+    return "#000000";
+  }
+  setScale() {}
+  fillRect() {}
+  strokeRect() {}
+  fillText() {
+    this.fillTextCalls++;
+  }
+  strokeText() {
+    this.strokeTextCalls++;
+  }
+  quadraticCurveTo() {}
+  clearRect() {}
+  setFont(font: string) {
+    this.font = font;
+  }
+  setFillStyle() {}
+  setStrokeStyle() {}
+  setLineWidth() {}
+  setGlobalAlpha() {}
+  setSize(width: number, height: number) {
+    this.size = { width, height };
+  }
+  getSize() {
+    return this.size;
+  }
+  measureText(text: string) {
+    this.measureCalls++;
+    const fontSize = Number(/([0-9.]+)px/.exec(this.font)?.[1] ?? 10);
+    return textMetrics(text.length * fontSize * 0.5);
+  }
+  beginPath() {}
+  closePath() {}
+  moveTo() {}
+  lineTo() {}
+  stroke() {}
+  save() {}
+  restore() {}
+  getCanvas() {
+    const child = new RecordingRenderer();
+    this.children.push(child);
+    return child;
+  }
+  drawImage() {}
+  flush() {}
+  invalidateImage() {}
+}
+
+class TestFlashComment extends FlashComment {
+  exposeTextImage() {
+    return this.getTextImage();
+  }
+}
+
+const formattedComment = (
+  content: string,
+  mail: string[] = [],
+): FormattedComment => ({
+  id: 1,
+  vpos: 0,
+  content,
+  date: 1_400_000_000,
+  date_usec: 0,
+  owner: false,
+  premium: false,
+  mail,
+  user_id: 1,
+  layer: -1,
+  is_my_post: false,
+});
+
+const sizedComment = (
+  comment: FormattedComment,
+  data: ReturnType<typeof parseCommandAndNicoScript>,
+): FormattedCommentWithSize =>
+  ({
+    ...comment,
+    ...data,
+    rawContent: comment.content,
+    content: [],
+    lineCount: 1,
+    lineOffset: 0,
+    height: 0,
+    width: 0,
+    lineHeight: 1,
+    resized: false,
+    resizedX: false,
+    resizedY: false,
+    charSize: 0,
+    scale: 1,
+    scaleX: 1,
+  }) as FormattedCommentWithSize;
+
+const createContext = () => ({
+  config: defaultConfig,
+  options: { ...defaultOptions, mode: "flash" as const },
+  nicoScripts: createNicoScripts(),
+  imageCache: new ImageCacheContext(),
+  rangeCache: new RangeCacheContext(),
+});
+
+describe("Flash and at-button resource bounds", () => {
+  beforeEach(() => {
+    initConfig();
+    let timeoutId = 0;
+    vi.stubGlobal("window", {
+      setTimeout: vi.fn(() => ++timeoutId),
+    });
+    vi.stubGlobal("clearTimeout", vi.fn());
+  });
+
+  test("caps newline-heavy Flash comments before measurement and drawing", () => {
+    const renderer = new RecordingRenderer();
+    const comment = new TestFlashComment(
+      formattedComment("\n".repeat(10_000)),
+      renderer,
+      0,
+      createContext(),
+    );
+
+    expect(comment.comment.lineCount).toBe(MAX_FLASH_COMMENT_LINES);
+    expect(renderer.measureCalls).toBeLessThanOrEqual(
+      MAX_FLASH_COMMENT_LINES * 2,
+    );
+
+    const image = comment.exposeTextImage() as RecordingRenderer | null;
+
+    expect(image?.fillTextCalls ?? 0).toBeLessThanOrEqual(
+      MAX_FLASH_COMMENT_LINES * 2,
+    );
+    expect(image?.strokeTextCalls ?? 0).toBeLessThanOrEqual(
+      MAX_FLASH_COMMENT_LINES * 2,
+    );
+  });
+
+  test("preserves normal Flash multiline rendering", () => {
+    const renderer = new RecordingRenderer();
+    const comment = new TestFlashComment(
+      formattedComment("one\ntwo\nthree"),
+      renderer,
+      0,
+      createContext(),
+    );
+
+    const image = comment.exposeTextImage() as RecordingRenderer | null;
+
+    expect(comment.comment.lineCount).toBe(3);
+    expect(image).not.toBeNull();
+    expect(image?.fillTextCalls).toBeGreaterThan(0);
+    expect(image?.fillTextCalls).toBeLessThanOrEqual(8);
+    expect(image?.strokeTextCalls).toBeGreaterThan(0);
+    expect(image?.strokeTextCalls).toBeLessThanOrEqual(8);
+  });
+
+  test("does not allocate Flash text images outside bounded dimensions", () => {
+    const renderer = new RecordingRenderer();
+    const comment = new TestFlashComment(
+      formattedComment("x".repeat(50_000)),
+      renderer,
+      0,
+      createContext(),
+    );
+    const initialCanvasCount = renderer.children.length;
+
+    expect(comment.exposeTextImage()).toBeNull();
+    expect(renderer.children).toHaveLength(initialCanvasCount);
+  });
+
+  test("caps escaped-newline at-button display text from the displayed body", () => {
+    const renderer = new RecordingRenderer();
+    const comment = new TestFlashComment(
+      formattedComment(`@ボタン "[${"x\\n".repeat(300)}]"`),
+      renderer,
+      0,
+      createContext(),
+    );
+
+    expect(comment.comment.button?.message.body.length).toBeLessThanOrEqual(
+      MAX_AT_BUTTON_TEXT_CHARS,
+    );
+    expect(comment.comment.lineCount).toBe(MAX_FLASH_COMMENT_LINES);
+    expect(renderer.measureCalls).toBeLessThanOrEqual(
+      MAX_FLASH_COMMENT_LINES * 4,
+    );
+  });
+
+  test("normalizes hostile at-button payload fields", () => {
+    const longBody = "x".repeat(MAX_AT_BUTTON_TEXT_CHARS + 500);
+    const longMessage = "posted".repeat(1000);
+    const mail = Array.from({ length: 100 }, (_, i) => `mail${i}`).join(",");
+    const data = parseCommandAndNicoScript(
+      formattedComment(
+        `@ボタン "[${longBody}]" "${longMessage}" "表示" "${mail}" "999999"`,
+      ),
+      createContext(),
+    );
+
+    expect(data.button?.message.body).toHaveLength(MAX_AT_BUTTON_TEXT_CHARS);
+    expect(data.button?.commentMessage).toHaveLength(MAX_AT_BUTTON_TEXT_CHARS);
+    expect(data.button?.commentMail).toHaveLength(MAX_AT_BUTTON_MAIL_ENTRIES);
+    expect(data.button?.limit).toBe(MAX_AT_BUTTON_LIMIT);
+  });
+
+  test("bounds at-button parsing before the first nicoscript regex capture", () => {
+    const data = parseCommandAndNicoScript(
+      formattedComment(
+        `@ボタン "[${"x".repeat(MAX_NICOSCRIPT_COMMAND_CHARS + 500)}]"`,
+      ),
+      createContext(),
+    );
+
+    expect(data.button?.message.body.length).toBeLessThanOrEqual(
+      MAX_AT_BUTTON_TEXT_CHARS,
+    );
+  });
+
+  test("bounds stored nicoscript replacement text", () => {
+    const ctx = createContext();
+
+    parseCommandAndNicoScript(
+      {
+        ...formattedComment(
+          `@置換 "${"k".repeat(MAX_NICOSCRIPT_TEXT_CHARS + 500)}" "${"r".repeat(MAX_NICOSCRIPT_TEXT_CHARS + 500)}" 単`,
+        ),
+        owner: true,
+      },
+      ctx,
+    );
+
+    expect(ctx.nicoScripts.replace[0]?.keyword).toHaveLength(
+      MAX_NICOSCRIPT_TEXT_CHARS,
+    );
+    expect(ctx.nicoScripts.replace[0]?.replace).toHaveLength(
+      MAX_NICOSCRIPT_TEXT_CHARS,
+    );
+  });
+
+  test("bounds original mail command parsing", () => {
+    const ignoredCommands = Array.from(
+      { length: MAX_PARSED_COMMAND_MAIL_ENTRIES },
+      () => "x".repeat(10_000),
+    );
+    const data = parseCommandAndNicoScript(
+      formattedComment("normal", [...ignoredCommands, "red", "big"]),
+      createContext(),
+    );
+
+    expect(data.color).toBe("#FFFFFF");
+    expect(data.size).toBe("medium");
+  });
+
+  test("normalizes invalid at-button limits to no generated comments", () => {
+    const data = parseCommandAndNicoScript(
+      formattedComment('@ボタン "[Push]" "@ボタン [Loop]" "表示" "" "NaN"'),
+      createContext(),
+    );
+
+    expect(data.button?.limit).toBe(0);
+    expect(
+      buildAtButtonComment(sizedComment(formattedComment(""), data), 10),
+    ).toBeUndefined();
+  });
+
+  test("bounds generated at-button comments and prevents recursive buttons", () => {
+    const data = parseCommandAndNicoScript(
+      formattedComment(
+        '@ボタン "[Push]" "@ボタン [Loop]" "表示" "red,big" "100000"',
+      ),
+      createContext(),
+    );
+    const parsed = sizedComment(formattedComment(""), data);
+    const generated: FormattedComment[] = [];
+
+    for (let i = 0; i < MAX_AT_BUTTON_LIMIT + 10; i++) {
+      const next = buildAtButtonComment(parsed, i);
+      if (next) generated.push(next);
+    }
+
+    expect(generated).toHaveLength(MAX_AT_BUTTON_LIMIT);
+    expect(data.button?.limit).toBe(0);
+    expect(generated[0]?.content).toBe("@ボタン [Loop]");
+    expect(generated[0]?.mail).toContain("from_button");
+
+    const generatedData = parseCommandAndNicoScript(
+      generated[0] as FormattedComment,
+      createContext(),
+    );
+
+    expect(generatedData.button).toBeUndefined();
+  });
+
+  test("preserves normal at-button generated comments", () => {
+    const data = parseCommandAndNicoScript(
+      formattedComment('@ボタン "[Push]" "posted" "表示" "red,big" "2"'),
+      createContext(),
+    );
+    const parsed = sizedComment(formattedComment(""), data);
+    const first = buildAtButtonComment(parsed, 50);
+    const second = buildAtButtonComment(parsed, 51);
+    const third = buildAtButtonComment(parsed, 52);
+
+    expect(data.button?.message.body).toBe("Push");
+    expect(first).toMatchObject({
+      vpos: 50,
+      content: "posted",
+      mail: ["red", "big", "from_button"],
+    });
+    expect(second).toBeDefined();
+    expect(third).toBeUndefined();
+  });
+});


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens the Flash comment renderer against resource exhaustion by bounding character/line counts, canvas dimensions, and AT-button payload sizes before any parsing or rendering work is done.

- **`src/utils/flash.ts`**: Adds `clampFlashContent` — a single-pass scanner that caps input at `MAX_FLASH_COMMENT_CHARS` (16,384) AND `MAX_FLASH_COMMENT_LINES` (256) before the content is parsed into `CommentContentItem` arrays. Also adds `MAX_FLASH_CONTENT_ITEMS` (2,048) guards inside `parseContent` and `addPartToResult`.
- **`src/comments/FlashComment.ts`**: Rewrites `parseContent` to concatenate button parts, run the combined string through `clampFlashContent`, then redistribute the clamped budget back to each segment via `takeFlashDisplayPart`. Adds a `canGenerateTextImage` override that refuses to allocate a canvas whose dimensions exceed `8192 × 8192` or `MAX_CANVAS_AREA`.
- **`src/utils/comment.ts`**: Adds bounded normalization for AT-button fields (`commentMail`, `limit`, `commentMessage`), caps nicoscript command/text sizes, limits `parseCommands` to the first `MAX_PARSED_COMMAND_MAIL_ENTRIES` mail entries, and blocks recursive AT-button generation via a `from_button` mail guard.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge. All bounds are enforced consistently across parsing, content accumulation, and canvas allocation, with comprehensive test coverage confirming each guard.

The previous lineCount-undercounting bug is fully resolved by concatenating button parts first, running a single clampFlashContent pass, then distributing the budget back via takeFlashDisplayPart. The canGenerateTextImage override matches exactly the canvas size computed by _setupCanvas. All new normalization helpers are internally consistent with the parseCommands loop bound.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/utils/flash.ts | Adds clampFlashContent (char+line bounds in one pass), MAX_FLASH_CONTENT_ITEMS guards in parseContent and addPartToResult, and exports the new constants. Logic is correct. |
| src/comments/FlashComment.ts | Rewrites parseContent to clamp the concatenated button display text first, then splits the budget back to segments via takeFlashDisplayPart; adds canGenerateTextImage bounds guard. Addresses the previous lineCount-undercounting P1. |
| src/utils/comment.ts | Adds AT-button and nicoscript payload normalization (mail entries, limit, text chars), bounded parseCommands loop, and from_button recursion guard. All limits are internally consistent. |
| tests/unit/flash-resource-bounds.spec.ts | New test file with thorough coverage of all added bounds (line cap, canvas bounds, button text truncation, mail normalization, limit normalization, recursion prevention). Tests are well-structured and independent. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["comment.content (raw)"] --> B["clampString(content, MAX_NICOSCRIPT_COMMAND_CHARS)"]
    B --> C{RE_NICOSCRIPT match?}
    C -- "ボタン + no from_button" --> D["processAtButton"]
    C -- "置換" --> E["addNicoscriptReplace\n(uses clamped input)"]
    C -- other --> F["processDefault/Seek/Jump"]
    D --> G["parseBrackets(clampString(...))"]
    G --> H["takeButtonText x3\n(budget = MAX_AT_BUTTON_TEXT_CHARS)"]
    H --> I["normalizeAtButtonMail"]
    H --> J["normalizeAtButtonLimit"]
    H --> K["clampString(commentMessage)"]
    I & J & K --> L["button params stored"]
    L --> M["FlashComment.parseContent"]
    M --> N["displayText = before + body + after"]
    N --> O["clampFlashContent(displayText)"]
    O --> P["takeFlashDisplayPart x3"]
    P --> Q["appendContent → parseFlashContent → slice MAX_FLASH_CONTENT_ITEMS"]
    Q --> R["content[] + lineCount"]
    R --> S["getCommentSize → width/height"]
    S --> T{canGenerateTextImage?}
    T -- within bounds --> U["_generateTextImage"]
    T -- out of bounds --> V["null"]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/comments/FlashComment.ts`, line 187-223 ([link](https://github.com/xpadev-net/niconicomments/blob/811d581bc08cf3164b250eb6843556e04ae014f5/src/comments/FlashComment.ts#L187-L223)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`lineCount` undercounts when button parts collectively exceed `MAX_FLASH_COMMENT_LINES`**

   `appendContent` processes `before`, `body`, and `after` through separate `parseFlashContent` calls, each of which internally runs `clampFlashContent` per-segment — so each segment is capped at 256 lines independently and its items are accumulated in `content`. But `lineCount` is then derived from `clampFlashContent(displayText)` on the *concatenated* string, which stops at 256 total newlines regardless of which segment they fall in.

   Concrete failure: `before = "\n".repeat(100)`, `body = "\n".repeat(100)`, `after = "\n".repeat(100)` — all within `MAX_AT_BUTTON_TEXT_CHARS`. Each segment alone is well under 256 lines so per-segment clamping does nothing; `content` accumulates items for ~303 lines. But `clampFlashContent(before+body+after)` caps at 256, so `lineCount = 256`. `_measureContent` uses `lineCount` directly to compute canvas height, sizing the canvas for 256 lines while `_generateTextImage` iterates all 303 lines of content, rendering the tail outside the canvas bounds.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/comments/FlashComment.ts
   Line: 187-223

   Comment:
   **`lineCount` undercounts when button parts collectively exceed `MAX_FLASH_COMMENT_LINES`**

   `appendContent` processes `before`, `body`, and `after` through separate `parseFlashContent` calls, each of which internally runs `clampFlashContent` per-segment — so each segment is capped at 256 lines independently and its items are accumulated in `content`. But `lineCount` is then derived from `clampFlashContent(displayText)` on the *concatenated* string, which stops at 256 total newlines regardless of which segment they fall in.

   Concrete failure: `before = "\n".repeat(100)`, `body = "\n".repeat(100)`, `after = "\n".repeat(100)` — all within `MAX_AT_BUTTON_TEXT_CHARS`. Each segment alone is well under 256 lines so per-segment clamping does nothing; `content` accumulates items for ~303 lines. But `clampFlashContent(before+body+after)` caps at 256, so `lineCount = 256`. `_measureContent` uses `lineCount` directly to compute canvas height, sizing the canvas for 256 lines while `_generateTextImage` iterates all 303 lines of content, rendering the tail outside the canvas bounds.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fcomments%2FFlashComment.ts%0ALine%3A%20187-223%0A%0AComment%3A%0A**%60lineCount%60%20undercounts%20when%20button%20parts%20collectively%20exceed%20%60MAX_FLASH_COMMENT_LINES%60**%0A%0A%60appendContent%60%20processes%20%60before%60%2C%20%60body%60%2C%20and%20%60after%60%20through%20separate%20%60parseFlashContent%60%20calls%2C%20each%20of%20which%20internally%20runs%20%60clampFlashContent%60%20per-segment%20%E2%80%94%20so%20each%20segment%20is%20capped%20at%20256%20lines%20independently%20and%20its%20items%20are%20accumulated%20in%20%60content%60.%20But%20%60lineCount%60%20is%20then%20derived%20from%20%60clampFlashContent%28displayText%29%60%20on%20the%20*concatenated*%20string%2C%20which%20stops%20at%20256%20total%20newlines%20regardless%20of%20which%20segment%20they%20fall%20in.%0A%0AConcrete%20failure%3A%20%60before%20%3D%20%22%5Cn%22.repeat%28100%29%60%2C%20%60body%20%3D%20%22%5Cn%22.repeat%28100%29%60%2C%20%60after%20%3D%20%22%5Cn%22.repeat%28100%29%60%20%E2%80%94%20all%20within%20%60MAX_AT_BUTTON_TEXT_CHARS%60.%20Each%20segment%20alone%20is%20well%20under%20256%20lines%20so%20per-segment%20clamping%20does%20nothing%3B%20%60content%60%20accumulates%20items%20for%20~303%20lines.%20But%20%60clampFlashContent%28before%2Bbody%2Bafter%29%60%20caps%20at%20256%2C%20so%20%60lineCount%20%3D%20256%60.%20%60_measureContent%60%20uses%20%60lineCount%60%20directly%20to%20compute%20canvas%20height%2C%20sizing%20the%20canvas%20for%20256%20lines%20while%20%60_generateTextImage%60%20iterates%20all%20303%20lines%20of%20content%2C%20rendering%20the%20tail%20outside%20the%20canvas%20bounds.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=xpadev-net%2Fniconicomments&pr=294&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Fix Flash button line clamping"](https://github.com/xpadev-net/niconicomments/commit/a0fc5c51c952a8f4a6cd01824ebf073e734bfbff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35328734)</sub>

<!-- /greptile_comment -->