### PR TITLE
Configure Renovate minimum release age

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "minimumReleaseAge": "7 days",
   "packageRules": [
     {
       "matchUpdateTypes": ["patch"],


### PR DESCRIPTION
## Summary
- Add a top-level Renovate minimumReleaseAge of 7 days so regular dependency updates wait before PR creation.
- Keep the existing vulnerability alert release-age setting unchanged.

## Verification
- Parsed renovate.json with Node.js.
- Pre-commit Biome check passed for renovate.json.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds a top-level `minimumReleaseAge: "7 days"` to `renovate.json` so that minor and major dependency update PRs are only opened after a package has been published for at least a week, reducing noise from quickly-yanked releases. The `vulnerabilityAlerts` section already carried the same `minimumReleaseAge` value explicitly, so its behaviour is unaffected.

- **Top-level `minimumReleaseAge`**: non-patch updates (patch updates are already disabled via `packageRules`) now wait 7 days before Renovate opens a PR.
- **`vulnerabilityAlerts.minimumReleaseAge`** stays at `"7 days"` — the pre-existing explicit override inside `vulnerabilityAlerts` takes precedence over the new global setting, so no net change for security PRs.
</details>

<h3>Confidence Score: 5/5</h3>

Single-line config addition; the only changed behaviour is a 7-day wait before non-patch update PRs are opened, and vulnerability alerts are explicitly overriding that value so they are unaffected.

The change is a single well-understood Renovate field. The vulnerabilityAlerts block already carries an explicit minimumReleaseAge that will continue to win over the new global setting, so security PR timing is not altered. Patch updates were already disabled, so the only practical effect is delaying minor/major update PRs by 7 days — an intentional improvement.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| renovate.json | Adds top-level `minimumReleaseAge: "7 days"` so non-patch dependency update PRs are delayed 7 days; existing `vulnerabilityAlerts.minimumReleaseAge` remains explicitly set to the same value, so vulnerability alert behaviour is unchanged. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[New package version released] --> B{Update type?}
    B -->|patch| C[Disabled — no PR created]
    B -->|minor / major| D{minimumReleaseAge elapsed?\n≥ 7 days}
    D -->|No| E[Wait — no PR yet]
    D -->|Yes| F[Renovate creates update PR]
    B -->|vulnerability alert| G{vulnerabilityAlerts\nminimumReleaseAge elapsed?\n≥ 7 days}
    G -->|No| H[Wait — no security PR yet]
    G -->|Yes| I[Renovate creates security PR]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Configure Renovate minimum release age"](https://github.com/xpadev-net/niconicomments/commit/9d923971c0e0a03fa90b60805ede16591af8458c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35582452)</sub>

<!-- /greptile_comment -->