### PR TITLE
Restrict npm publish workflow dispatch

### DIFF
--- a/.github/workflows/release-publish-package.yml
+++ b/.github/workflows/release-publish-package.yml
@@ -4,12 +4,12 @@ on:
   push:
     branches:
       - master
-  workflow_dispatch:
 
 jobs:
   publish:
     name: Publish npm package
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
     permissions:
       contents: read # Checkout repository contents for the publish build.
       id-token: write # Request an OIDC token for npm provenance.
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pnpm install
+          pnpm install --frozen-lockfile
 
       - name: Publish package
         run: npm publish --provenance
@@ -43,9 +43,17 @@ jobs:
     name: Create GitHub release
     runs-on: ubuntu-latest
     needs: publish
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
     permissions:
       contents: write # Create the GitHub release for the published ref.
     steps:
+      - name: Validate release ref
+        run: |
+          if [ "${GITHUB_REF}" != "refs/heads/master" ]; then
+            echo "::error::Ref ${GITHUB_REF} is not allowed to create a release"
+            exit 1
+          fi
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda
         with:


### PR DESCRIPTION
## Summary
- Remove `workflow_dispatch` from the npm publish workflow so package publishing cannot be manually run against an arbitrary ref.
- Keep publishing on protected `master` push only, with explicit job/ref guards for publish and release.
- Use `pnpm install --frozen-lockfile` while preserving `contents: read`, `id-token: write`, and `persist-credentials: false` on the publish job.

## Security notes
- Manual execution is intentionally not retained, so no environment reviewer gate is needed.
- The release job remains dependent on `publish` and validates `GITHUB_REF` before invoking the release action.
- The publish lifecycle does not receive a write-scoped repository credential; the write-scoped token is limited to the post-publish release job.

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-publish-package.yml"); puts "yaml ok"'`\n- `rg -n "workflow_dispatch|workflow_call|pnpm install$|persist-credentials|contents: read|id-token: write|GITHUB_REF|refs/heads/master" .github/workflows/release-publish-package.yml`\n- `gh workflow view release-publish-package.yml --repo xpadev-net/niconicomments`\n\n## Review\n- `$deep-review` self-review: no findings.\n- Independent automation/security subagent review: no findings; residual risk is external repo/npm protection settings outside this file.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens the npm publish workflow by removing `workflow_dispatch` (preventing manual triggering against arbitrary refs) and adding explicit `if` guards on both the `publish` and `release` jobs. It also switches to `pnpm install --frozen-lockfile` for reproducible dependency installs and adds a runtime ref-validation step before the GitHub release action.

- **`workflow_dispatch` removed**: Publishing can now only be triggered by a push to `master`, eliminating the risk of a maintainer accidentally (or maliciously) publishing from an unintended ref.
- **Layered ref guards added**: Both jobs now carry an `if` condition checking `github.event_name == 'push' && github.ref == 'refs/heads/master'`, and the `release` job adds a redundant shell-level `GITHUB_REF` check as defense-in-depth.
- **`--frozen-lockfile` flag added**: Ensures CI installs exactly the versions committed to `pnpm-lock.yaml`, closing a potential supply-chain window where a mutable lockfile could pull in different transitive versions at publish time.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change only removes a trigger and adds redundant guards; no new code paths are introduced and no existing publish or release logic is altered.

The diff is limited to the workflow trigger definition and two defensive if conditions. Removing workflow_dispatch closes the window for publishing from an arbitrary ref without introducing any regression in the normal push-to-master path. The --frozen-lockfile addition strengthens supply-chain integrity. The runtime GITHUB_REF shell check in the release job is unreachable given the job-level guard but is harmless.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-publish-package.yml | Removes workflow_dispatch, adds job-level if-guards on both publish and release jobs, switches to --frozen-lockfile, and adds a redundant but harmless shell-level ref check before the GitHub release step. No functional defects found. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Push to master] --> B{event_name == push\nAND ref == refs/heads/master?}
    B -- No --> SKIP1[publish job SKIPPED]
    B -- Yes --> C[publish job runs]
    C --> D[checkout @ pinned SHA\npersist-credentials: false]
    D --> E[pnpm install --frozen-lockfile]
    E --> F[npm publish --provenance\nOIDC provenance via id-token: write]
    F --> G{needs: publish succeeded?\nAND event_name+ref guard?}
    G -- No --> SKIP2[release job SKIPPED]
    G -- Yes --> H[Validate release ref\nshell: GITHUB_REF == refs/heads/master]
    H -- Mismatch --> ERR[exit 1 — never reachable\ngiven job-level guard]
    H -- Match --> I[softprops/action-gh-release\ncontents: write]
    I --> J[GitHub Release created]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Restrict npm publish workflow dispatch"](https://github.com/xpadev-net/niconicomments/commit/63643c540165b362d33e748a99d328bc637f605d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35584541)</sub>

<!-- /greptile_comment -->