### PR TITLE
Lazy allocate Flash button canvases

### DIFF
--- a/src/comments/FlashComment.ts
+++ b/src/comments/FlashComment.ts
@@ -62,8 +62,12 @@ const takeFlashDisplayPart = (value: string, remaining: { value: string }) => {
 
 class FlashComment extends BaseComment {
   private _globalScale: number;
+  private _buttonImageState?: {
+    height: number;
+    strokeStyle: string;
+    width: number;
+  };
   override readonly pluginName: string = "FlashComment";
-  override buttonImage: IRenderer;
   constructor(
     comment: FormattedComment,
     renderer: IRenderer,
@@ -72,7 +76,6 @@ class FlashComment extends BaseComment {
   ) {
     super(comment, renderer, index, ctx);
     this._globalScale ??= getConfig(this.config.commentScale, true);
-    this.buttonImage = renderer.getCanvas();
   }
 
   private get _flashScriptCharRegex(): { super: RegExp; sub: RegExp } {
@@ -498,22 +501,36 @@ class FlashComment extends BaseComment {
 
   override getButtonImage(posX: number, posY: number, cursor?: Position) {
     if (!this.comment.button || this.comment.button.hidden) return undefined;
-    const { renderer } = this._setupCanvas(this.buttonImage);
     const parts = this.comment.buttonObjects;
     if (!parts) return undefined;
-    const atButtonRadius = getConfig(this.config.atButtonRadius, true);
     const isHover = this.isHovered(cursor, posX, posY);
-    renderer.save();
-    const getStrokeStyle = () => {
-      if (isHover) {
-        return this.comment.color;
-      }
-      if (this.comment.button && this.comment.button.limit < 1) {
+    const strokeStyle = (() => {
+      if (isHover) return this.comment.color;
+      if (this.comment.button && this.comment.button.limit < 1)
         return "#777777";
-      }
       return "white";
+    })();
+    const atButtonPadding = getConfig(this.config.atButtonPadding, true);
+    const nextState = {
+      height: this.comment.height + atButtonPadding * 2,
+      strokeStyle,
+      width: this.comment.width,
     };
-    renderer.setStrokeStyle(getStrokeStyle());
+    const shouldRedraw =
+      !this.buttonImage ||
+      !this._buttonImageState ||
+      this._buttonImageState.width !== nextState.width ||
+      this._buttonImageState.height !== nextState.height ||
+      this._buttonImageState.strokeStyle !== nextState.strokeStyle;
+
+    if (!shouldRedraw) return this.buttonImage ?? undefined;
+
+    const renderer = this.buttonImage ?? this.renderer.getCanvas();
+    this.buttonImage = renderer;
+    this._setupCanvas(renderer);
+    const atButtonRadius = getConfig(this.config.atButtonRadius, true);
+    renderer.save();
+    renderer.setStrokeStyle(strokeStyle);
     drawLeftBorder(
       renderer,
       parts.left.left,
@@ -533,6 +550,7 @@ class FlashComment extends BaseComment {
       atButtonRadius,
     );
     renderer.restore();
+    this._buttonImageState = nextState;
     return renderer;
   }
 

--- a/tests/unit/flash-resource-bounds.spec.ts
+++ b/tests/unit/flash-resource-bounds.spec.ts
@@ -44,6 +44,7 @@ class RecordingRenderer implements IRenderer {
   public readonly children: RecordingRenderer[] = [];
   public measureCalls = 0;
   public fillTextCalls = 0;
+  public setSizeCalls = 0;
   public strokeTextCalls = 0;
   private font = "10px sans-serif";
   private size = { width: 0, height: 0 };
@@ -75,6 +76,7 @@ class RecordingRenderer implements IRenderer {
   setLineWidth() {}
   setGlobalAlpha() {}
   setSize(width: number, height: number) {
+    this.setSizeCalls++;
     this.size = { width, height };
   }
   getSize() {
@@ -239,6 +241,66 @@ describe("Flash and at-button resource bounds", () => {
 
     expect(comment.exposeTextImage()).toBeNull();
     expect(renderer.children).toHaveLength(initialCanvasCount);
+  });
+
+  test("does not allocate button canvases for many normal Flash comments", () => {
+    const renderer = new RecordingRenderer();
+    const comments: TestFlashComment[] = [];
+
+    for (let i = 0; i < 500; i++) {
+      comments.push(
+        new TestFlashComment(formattedComment(`normal-${i}`), renderer, i, {
+          ...createContext(),
+          imageCache: new ImageCacheContext(),
+        }),
+      );
+    }
+
+    expect(renderer.children).toHaveLength(0);
+
+    for (const comment of comments) {
+      comment.draw(0, false);
+    }
+
+    expect(renderer.children).toHaveLength(comments.length);
+  });
+
+  test("allocates a visible at-button canvas only on first draw", () => {
+    const renderer = new RecordingRenderer();
+    const comment = new TestFlashComment(
+      formattedComment('@ボタン "[Push]" "posted" "表示" "" "3"'),
+      renderer,
+      0,
+      createContext(),
+    );
+
+    expect(renderer.children).toHaveLength(0);
+
+    comment.draw(0, false);
+
+    expect(renderer.children).toHaveLength(2);
+    const buttonImage = renderer.children[1];
+    expect(buttonImage?.setSizeCalls).toBe(1);
+
+    comment.draw(0, false);
+
+    expect(renderer.children).toHaveLength(2);
+    expect(buttonImage?.setSizeCalls).toBe(1);
+  });
+
+  test("does not allocate button canvases for hidden at-buttons", () => {
+    const renderer = new RecordingRenderer();
+    const comment = new TestFlashComment(
+      formattedComment('@ボタン "[Hidden]" "posted" "表示" "" "3"', ["hidden"]),
+      renderer,
+      0,
+      createContext(),
+    );
+
+    comment.draw(0, false);
+
+    expect(comment.comment.button?.hidden).toBe(true);
+    expect(renderer.children).toHaveLength(1);
   });
 
   test("caps escaped-newline at-button display text from the displayed body", () => {


### PR DESCRIPTION
## Summary
- Stop allocating a Flash button canvas in every FlashComment constructor
- Lazily create the button canvas only when a visible @ボタン is first drawn with button layout parts
- Cache the drawn border by button image size and stroke color so stable visible buttons reuse the same canvas without per-frame setSize/redraw
- Add focused resource-bound tests for normal Flash comments, visible @ボタン, and hidden @ボタン

## Lifecycle / redraw note
There is no existing per-comment dispose lifecycle hook in BaseComment/FlashComment; text image cleanup is handled through the shared image cache expiry path, and button images are per-instance resources. This change avoids allocating button images unless needed, but does not add a new disposal API outside the task scope. Border redraw is limited to size or stroke-color changes, covering hover and exhausted-limit color transitions.

## Validation
- npm run test:unit -- tests/unit/flash-resource-bounds.spec.ts
- npm run check-types
- npm run lint (exit 0; reports existing optional-chain warnings in src/typeGuard.ts)
- git diff --check

## Review
- deep-review self-review: no actionable findings after tightening the normal-comment draw test
- independent subagent review: no findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR eliminates eager button canvas allocation in `FlashComment` — previously every `FlashComment` constructor called `renderer.getCanvas()` regardless of whether the comment had a visible `@ボタン`. The canvas is now allocated lazily on the first draw, and subsequent redraws are skipped unless the button size (`width`/`height`) or stroke colour (`strokeStyle`) has changed.

- **Lazy allocation**: removed `this.buttonImage = renderer.getCanvas()` from the constructor and the non-nullable `override buttonImage: IRenderer` field declaration; `buttonImage` now inherits the base-class optional type and is populated only when `getButtonImage` first fires for a visible, non-hidden button.
- **Cache invalidation guard**: added `_buttonImageState` tracking `{width, height, strokeStyle}` so stable buttons skip `_setupCanvas`/`setSize`/border redraw on every frame; the guard correctly covers hover and exhausted-limit colour transitions.
- **Tests**: three new resource-bound tests validate that normal comments allocate zero button canvases on construction, that a visible `@ボタン` allocates exactly once and reuses on subsequent draws, and that hidden `@ボタン` produce no button canvas at all.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to lazy allocation and per-frame redraw skipping; no existing callers in related repos access buttonImage directly, and all dynamic state transitions are covered by the cache key.

The removed eager allocation in the constructor and the new _buttonImageState guard are both logically sound. The cache key (width, height, strokeStyle) captures every runtime factor that changes the visual output of the button border — hover state and exhausted-limit colour are included via strokeStyle, and size changes propagate through width/height. No related-repo consumers access buttonImage directly, so the type relaxation has no external impact.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/comments/FlashComment.ts | Lazy button canvas allocation with state-keyed redraw guard; logic is correct across all state transitions (hover, limit exhaustion, resize). |
| tests/unit/flash-resource-bounds.spec.ts | Three new focused tests verify the allocation invariants for normal comments, visible @ボタン (first-draw-only setSizeCalls), and hidden @ボタン; all three tests use the recording renderer correctly. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/dev..."](https://github.com/xpadev-net/niconicomments/commit/260ecd581da9ec519fe565b3712e3fcc4abffdc7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35584841)</sub>

<!-- /greptile_comment -->