### PR TITLE
Harden CI artifact handoff

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -39,7 +39,7 @@ jobs:
         run: pnpm build
 
       - name: Package build artifact
-        run: tar -czf dev-build-artifacts.tgz dist/bundle.js
+        run: tar --hard-dereference -czf dev-build-artifacts.tgz dist/bundle.js
 
       - name: Upload build artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
@@ -66,16 +66,65 @@ jobs:
           name: dev-build-artifacts
           path: ${{ runner.temp }}/dev-build-artifacts
 
+      - name: Validate build artifact
+        run: |
+          archive="${RUNNER_TEMP}/dev-build-artifacts/dev-build-artifacts.tgz"
+          validated_dir="${RUNNER_TEMP}/validated-artifacts"
+          rm -rf "$validated_dir"
+          mkdir -p "$validated_dir"
+          python3 - "$archive" "$validated_dir" <<'PY'
+          import pathlib
+          import shutil
+          import sys
+          import tarfile
+
+          archive = sys.argv[1]
+          destination = pathlib.Path(sys.argv[2])
+          allowed = {"dist/bundle.js"}
+          seen = set()
+
+          with tarfile.open(archive, "r:gz") as tar:
+              for member in tar.getmembers():
+                  name = member.name
+                  normalized_name = pathlib.PurePosixPath(name).as_posix()
+                  parts = pathlib.PurePosixPath(name).parts
+                  if (
+                      pathlib.PurePosixPath(name).is_absolute()
+                      or name != normalized_name
+                      or ".." in parts
+                      or ".git" in parts
+                      or normalized_name not in allowed
+                      or normalized_name in seen
+                      or not member.isfile()
+                  ):
+                      raise SystemExit(f"Unexpected artifact entry: {name!r}")
+                  seen.add(normalized_name)
+
+              if seen != allowed:
+                  missing = ", ".join(sorted(allowed - seen))
+                  raise SystemExit(f"Missing artifact entry: {missing}")
+
+              for member in tar.getmembers():
+                  target = destination / member.name
+                  target.parent.mkdir(parents=True, exist_ok=True)
+                  source = tar.extractfile(member)
+                  if source is None:
+                      raise SystemExit(f"Unable to read artifact entry: {member.name!r}")
+                  with source, target.open("wb") as output:
+                      shutil.copyfileobj(source, output)
+          PY
+
       - name: Push to dev-build branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.email "github-actions@xpadev.net"
           git config user.name "github-actions"
-          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git checkout --orphan dev-build
           git rm -rf . --quiet || true
-          tar -xzf "${RUNNER_TEMP}/dev-build-artifacts/dev-build-artifacts.tgz"
+          mkdir -p dist
+          cp "${RUNNER_TEMP}/validated-artifacts/dist/bundle.js" dist/bundle.js
           git add dist/bundle.js -f
-          git commit -m "dev build"
+          git -c core.hooksPath=/dev/null commit -m "dev build"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push -f origin dev-build

--- a/.github/workflows/release-typedoc.yml
+++ b/.github/workflows/release-typedoc.yml
@@ -58,7 +58,7 @@ jobs:
         run: pnpm build
 
       - name: Package generated artifacts
-        run: tar -czf typedoc-artifacts.tgz .gitignore docs/type dist/bundle.js
+        run: find .gitignore docs/type dist/bundle.js -type f -print0 | tar --null --hard-dereference -czf typedoc-artifacts.tgz --files-from -
 
       - name: Upload generated artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
@@ -85,17 +85,73 @@ jobs:
           name: typedoc-artifacts
           path: ${{ runner.temp }}/typedoc-artifacts
 
+      - name: Validate generated artifacts
+        run: |
+          archive="${RUNNER_TEMP}/typedoc-artifacts/typedoc-artifacts.tgz"
+          validated_dir="${RUNNER_TEMP}/validated-artifacts"
+          rm -rf "$validated_dir"
+          mkdir -p "$validated_dir"
+          python3 - "$archive" "$validated_dir" <<'PY'
+          import pathlib
+          import shutil
+          import sys
+          import tarfile
+
+          archive = sys.argv[1]
+          destination = pathlib.Path(sys.argv[2])
+          required = {".gitignore", "dist/bundle.js"}
+          seen = set()
+
+          def is_allowed(name):
+              return name in required or name.startswith("docs/type/")
+
+          with tarfile.open(archive, "r:gz") as tar:
+              for member in tar.getmembers():
+                  name = member.name
+                  normalized_name = pathlib.PurePosixPath(name).as_posix()
+                  parts = pathlib.PurePosixPath(name).parts
+                  if (
+                      pathlib.PurePosixPath(name).is_absolute()
+                      or name != normalized_name
+                      or ".." in parts
+                      or ".git" in parts
+                      or not is_allowed(normalized_name)
+                      or normalized_name in seen
+                      or not member.isfile()
+                  ):
+                      raise SystemExit(f"Unexpected artifact entry: {name!r}")
+                  seen.add(normalized_name)
+
+              missing = required - seen
+              if missing:
+                  raise SystemExit(f"Missing artifact entry: {', '.join(sorted(missing))}")
+
+              for member in tar.getmembers():
+                  target = destination / member.name
+                  target.parent.mkdir(parents=True, exist_ok=True)
+                  source = tar.extractfile(member)
+                  if source is None:
+                      raise SystemExit(f"Unable to read artifact entry: {member.name!r}")
+                  with source, target.open("wb") as output:
+                      shutil.copyfileobj(source, output)
+          PY
+
       - name: Create new Branch
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.email "github-actions@xpadev.net"
           git config user.name "github-actions"
-          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git checkout -b typedoc
           git rm -rf . --quiet || true
-          tar -xzf "${RUNNER_TEMP}/typedoc-artifacts/typedoc-artifacts.tgz"
-          cp -f ./dist/bundle.js ./docs/
+          mkdir -p dist docs/type
+          cp "${RUNNER_TEMP}/validated-artifacts/.gitignore" .gitignore
+          cp "${RUNNER_TEMP}/validated-artifacts/dist/bundle.js" dist/bundle.js
+          if [ -d "${RUNNER_TEMP}/validated-artifacts/docs/type" ]; then
+            cp -a "${RUNNER_TEMP}/validated-artifacts/docs/type/." docs/type/
+          fi
+          cp -f dist/bundle.js docs/
           git add .
-          git commit -m "auto generate" -n
+          git -c core.hooksPath=/dev/null commit -m "auto generate"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git push -f origin typedoc

--- a/.github/workflows/release-typedoc.yml
+++ b/.github/workflows/release-typedoc.yml
@@ -125,6 +125,8 @@ jobs:
               missing = required - seen
               if missing:
                   raise SystemExit(f"Missing artifact entry: {', '.join(sorted(missing))}")
+              if not any(name.startswith("docs/type/") for name in seen):
+                  raise SystemExit("Missing artifact entry: docs/type/ (no TypeDoc files found)")
 
               for member in tar.getmembers():
                   target = destination / member.name


### PR DESCRIPTION
## Summary
- validate downloaded build and TypeDoc tarball members before use
- reject unsafe tar entries and extract only into RUNNER_TEMP validated-artifacts
- copy validated files explicitly before branch pushes and set tokenized origin only immediately before push

## Validation
- git diff --check
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' .github/workflows/dev-build.yml .github/workflows/release-typedoc.yml\n- focused local tar validation snippets: accepted good artifacts; rejected normalized duplicate, absolute path, traversal, .git component, unexpected file, and hardlink cases\n\n## Review\n- deep-review self-review completed\n- independent subagent review found normalized duplicate risk; fixed and re-reviewed with no required findings\n\n## Waiver\n- npm run check-types not run because only GitHub workflow YAML changed; hooks also skipped typecheck due no matching staged files

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens the CI artifact handoff for both `dev-build` and `release-typedoc` workflows by adding Python-based tar validation between the download and extraction steps, and by restricting the GITHUB_TOKEN remote URL to the narrowest possible window before `git push`.

- **Packaging hardening**: both workflows now use `--hard-dereference` (and `find -type f` for typedoc) so symlinks are resolved to regular file data before archiving; the Python validator then rejects any entry that is absolute, non-normalized, contains `..` or `.git` components, is not in the allowlist, is a duplicate, or is not a plain regular file.
- **Staged extraction**: validated content is materialized into `$RUNNER_TEMP/validated-artifacts` via `shutil.copyfileobj` (bypassing tar's attribute-setting logic), then copied explicitly into the workspace.
- **Token window reduction**: `git remote set-url` with the token-injected URL is now set immediately before `git push`, reducing the time the credential lives in `.git/config`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are confined to CI workflow YAML and introduce defence-in-depth validation without affecting any production code paths.

Both workflows only gained new validation logic and a tighter token-exposure window; no source code, build config, or published API is touched. The Python validation correctly blocks path traversal, absolute paths, `..`/`.git` components, duplicates, non-file entries, and missing required members. No functional regressions were identified.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/dev-build.yml | Adds Python-based tar validation before extracting to a validated staging dir; defers GITHUB_TOKEN remote URL setup to immediately before push. |
| .github/workflows/release-typedoc.yml | Switches packaging to find -type f | tar --hard-dereference, adds Python validation with a non-empty docs/type/ check, copies from validated staging dir; defers token-injected remote URL to immediately before push. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant B as Build Job
    participant A as Artifact Store
    participant P as Push Job
    participant V as Python Validator
    participant S as Staging Dir
    participant G as GitHub remote

    B->>B: pnpm build / pnpm typedoc
    B->>B: tar --hard-dereference
    B->>A: upload-artifact
    A->>P: download-artifact
    P->>V: python3 validate
    loop Each tar member
        V->>V: reject unsafe entries
    end
    V->>V: assert required files present
    loop Each valid member
        V->>S: shutil.copyfileobj
    end
    P->>P: git checkout + git rm
    P->>S: cp validated files
    P->>P: git commit
    P->>P: git remote set-url with token
    P->>G: git push -f
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/dev..."](https://github.com/xpadev-net/niconicomments/commit/36bb46d5fb555e859b732f653371c421e48ab87d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35585227)</sub>

<!-- /greptile_comment -->