### PR TITLE
SEC-03: ban frame draw path DoS guard

### DIFF
--- a/src/eventHandler.ts
+++ b/src/eventHandler.ts
@@ -18,14 +18,23 @@ type EventRangeScanState<T extends EventRange> = {
 
 const rangeEnd = (range: EventRange) => range.end ?? Infinity;
 
+const compareRangeEnd = (a: EventRange, b: EventRange) => {
+  const endA = rangeEnd(a);
+  const endB = rangeEnd(b);
+  if (endA === endB) return 0;
+  return endA < endB ? -1 : 1;
+};
+
 const getRangeScanState = <T extends EventRange>(
   ranges: T[],
   scanCache: WeakMap<T[], EventRangeScanState<T>>,
 ) => {
   const cached = scanCache.get(ranges);
   if (cached?.sourceLength === ranges.length) return cached;
+  // NicoScript event ranges are append-only and immutable after creation; this
+  // length check must be revisited if future code mutates start/end in place.
   const sortedByStart = [...ranges].sort((a, b) => a.start - b.start);
-  const sortedByEnd = [...ranges].sort((a, b) => rangeEnd(a) - rangeEnd(b));
+  const sortedByEnd = [...ranges].sort(compareRangeEnd);
   const next = {
     sourceLength: ranges.length,
     sortedByStart,

--- a/src/eventHandler.ts
+++ b/src/eventHandler.ts
@@ -5,6 +5,133 @@ import type {
   ValueOf,
 } from "@/@types/";
 
+type EventRange = {
+  start: number;
+  end?: number;
+};
+
+type EventRangeScanState<T extends EventRange> = {
+  sourceLength: number;
+  sortedByStart: T[];
+  sortedByEnd: T[];
+};
+
+const rangeEnd = (range: EventRange) => range.end ?? Infinity;
+
+const getRangeScanState = <T extends EventRange>(
+  ranges: T[],
+  scanCache: WeakMap<T[], EventRangeScanState<T>>,
+) => {
+  const cached = scanCache.get(ranges);
+  if (cached?.sourceLength === ranges.length) return cached;
+  const sortedByStart = [...ranges].sort((a, b) => a.start - b.start);
+  const sortedByEnd = [...ranges].sort((a, b) => rangeEnd(a) - rangeEnd(b));
+  const next = {
+    sourceLength: ranges.length,
+    sortedByStart,
+    sortedByEnd,
+  };
+  scanCache.set(ranges, next);
+  return next;
+};
+
+const rangeEndsAfter = (range: EventRange, vpos: number) =>
+  range.end === undefined || vpos < range.end;
+
+const lowerBoundStart = <T extends EventRange>(ranges: T[], vpos: number) => {
+  let low = 0;
+  let high = ranges.length;
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2);
+    const range = ranges[mid];
+    if (range && range.start < vpos) {
+      low = mid + 1;
+    } else {
+      high = mid;
+    }
+  }
+  return low;
+};
+
+const upperBoundEnd = <T extends EventRange>(ranges: T[], vpos: number) => {
+  let low = 0;
+  let high = ranges.length;
+  while (low < high) {
+    const mid = Math.floor((low + high) / 2);
+    const range = ranges[mid];
+    if (range && rangeEnd(range) <= vpos) {
+      low = mid + 1;
+    } else {
+      high = mid;
+    }
+  }
+  return low;
+};
+
+const getTransitionRanges = <T extends EventRange>(
+  ranges: T[],
+  vpos: number,
+  lastVpos: number,
+  scanCache: WeakMap<T[], EventRangeScanState<T>>,
+) => {
+  if (!Number.isFinite(vpos) || !Number.isFinite(lastVpos)) {
+    return { entered: [], exited: [] };
+  }
+  const state = getRangeScanState(ranges, scanCache);
+  const entered: T[] = [];
+  const exited: T[] = [];
+
+  if (lastVpos <= vpos) {
+    for (
+      let i = lowerBoundStart(state.sortedByStart, lastVpos),
+        end = lowerBoundStart(state.sortedByStart, vpos);
+      i < end;
+      i++
+    ) {
+      const range = state.sortedByStart[i];
+      if (range && rangeEndsAfter(range, vpos)) {
+        entered.push(range);
+      }
+    }
+    for (
+      let i = upperBoundEnd(state.sortedByEnd, lastVpos),
+        end = upperBoundEnd(state.sortedByEnd, vpos);
+      i < end;
+      i++
+    ) {
+      const range = state.sortedByEnd[i];
+      if (range && range.start < lastVpos) {
+        exited.push(range);
+      }
+    }
+  } else {
+    for (
+      let i = upperBoundEnd(state.sortedByEnd, vpos),
+        end = upperBoundEnd(state.sortedByEnd, lastVpos);
+      i < end;
+      i++
+    ) {
+      const range = state.sortedByEnd[i];
+      if (range && range.start < vpos) {
+        entered.push(range);
+      }
+    }
+    for (
+      let i = lowerBoundStart(state.sortedByStart, vpos),
+        end = lowerBoundStart(state.sortedByStart, lastVpos);
+      i < end;
+      i++
+    ) {
+      const range = state.sortedByStart[i];
+      if (range && rangeEndsAfter(range, lastVpos)) {
+        exited.push(range);
+      }
+    }
+  }
+
+  return { entered, exited };
+};
+
 class EventHandler {
   private handlerList: {
     eventName: keyof CommentEventHandlerMap;
@@ -18,6 +145,19 @@ class EventHandler {
     commentEnable: 0,
     jump: 0,
   };
+
+  private readonly banActiveRangeScans = new WeakMap<
+    NicoScript["ban"],
+    EventRangeScanState<NicoScript["ban"][number]>
+  >();
+  private readonly seekDisableActiveRangeScans = new WeakMap<
+    NicoScript["seekDisable"],
+    EventRangeScanState<NicoScript["seekDisable"][number]>
+  >();
+  private readonly jumpActiveRangeScans = new WeakMap<
+    NicoScript["jump"],
+    EventRangeScanState<NicoScript["jump"][number]>
+  >();
 
   register<K extends keyof CommentEventHandlerMap>(
     eventName: K,
@@ -62,22 +202,25 @@ class EventHandler {
       this.handlerCounts.commentEnable < 1
     )
       return;
-    for (const range of nicoScripts.ban) {
-      const vposInRange = range.start < vpos && vpos < range.end;
-      const lastVposInRange = range.start < lastVpos && lastVpos < range.end;
-      if (vposInRange && !lastVposInRange) {
-        this._execute("commentDisable", {
-          type: "commentDisable",
-          timeStamp: Date.now(),
-          vpos,
-        });
-      } else if (!vposInRange && lastVposInRange) {
-        this._execute("commentEnable", {
-          type: "commentEnable",
-          timeStamp: Date.now(),
-          vpos,
-        });
-      }
+    const { entered, exited } = getTransitionRanges(
+      nicoScripts.ban,
+      vpos,
+      lastVpos,
+      this.banActiveRangeScans,
+    );
+    for (const _range of entered) {
+      this._execute("commentDisable", {
+        type: "commentDisable",
+        timeStamp: Date.now(),
+        vpos,
+      });
+    }
+    for (const _range of exited) {
+      this._execute("commentEnable", {
+        type: "commentEnable",
+        timeStamp: Date.now(),
+        vpos,
+      });
     }
   }
 
@@ -88,22 +231,25 @@ class EventHandler {
   ) {
     if (this.handlerCounts.seekDisable < 1 && this.handlerCounts.seekEnable < 1)
       return;
-    for (const range of nicoScripts.seekDisable) {
-      const vposInRange = range.start < vpos && vpos < range.end;
-      const lastVposInRange = range.start < lastVpos && lastVpos < range.end;
-      if (vposInRange && !lastVposInRange) {
-        this._execute("seekDisable", {
-          type: "seekDisable",
-          timeStamp: Date.now(),
-          vpos,
-        });
-      } else if (!vposInRange && lastVposInRange) {
-        this._execute("seekEnable", {
-          type: "seekEnable",
-          timeStamp: Date.now(),
-          vpos,
-        });
-      }
+    const { entered, exited } = getTransitionRanges(
+      nicoScripts.seekDisable,
+      vpos,
+      lastVpos,
+      this.seekDisableActiveRangeScans,
+    );
+    for (const _range of entered) {
+      this._execute("seekDisable", {
+        type: "seekDisable",
+        timeStamp: Date.now(),
+        vpos,
+      });
+    }
+    for (const _range of exited) {
+      this._execute("seekEnable", {
+        type: "seekEnable",
+        timeStamp: Date.now(),
+        vpos,
+      });
     }
   }
 
@@ -113,20 +259,20 @@ class EventHandler {
     nicoScripts: NicoScript,
   ) {
     if (this.handlerCounts.jump < 1) return;
-    for (const range of nicoScripts.jump) {
-      const vposInRange =
-        range.start < vpos && (!range.end || vpos < range.end);
-      const lastVposInRange =
-        range.start < lastVpos && (!range.end || lastVpos < range.end);
-      if (vposInRange && !lastVposInRange) {
-        this._execute("jump", {
-          type: "jump",
-          timeStamp: Date.now(),
-          vpos,
-          to: range.to,
-          message: range.message,
-        });
-      }
+    const { entered } = getTransitionRanges(
+      nicoScripts.jump,
+      vpos,
+      lastVpos,
+      this.jumpActiveRangeScans,
+    );
+    for (const range of entered) {
+      this._execute("jump", {
+        type: "jump",
+        timeStamp: Date.now(),
+        vpos,
+        to: range.to,
+        message: range.message,
+      });
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -219,7 +219,9 @@ class NiconiComments {
 
     this.comments = this.preRendering(parsedData);
     this._rebuildCommentArrayIndex(this.comments);
-    this._advanceNextUnprocessedCommentIndex();
+    if (!this.ctx.options.lazy || !this.lazyCommentOrderSortedByVpos) {
+      this._advanceNextUnprocessedCommentIndex();
+    }
 
     this._log(
       `constructor complete: ${performance.now() - constructorStart}ms`,
@@ -239,8 +241,18 @@ class NiconiComments {
     }
   }
 
-  private _advanceNextUnprocessedCommentIndex(comments = this.comments) {
-    while (this.nextUnprocessedCommentIndex < comments.length) {
+  private _advanceNextUnprocessedCommentIndex(
+    comments = this.comments,
+    scanBudget?: number,
+  ) {
+    const scanEndIndex =
+      scanBudget === undefined
+        ? comments.length
+        : Math.min(
+            comments.length,
+            this.nextUnprocessedCommentIndex + scanBudget,
+          );
+    while (this.nextUnprocessedCommentIndex < scanEndIndex) {
       const comment = comments[this.nextUnprocessedCommentIndex];
       if (comment && !comment.invisible && comment.posY < 0) {
         break;
@@ -319,6 +331,7 @@ class NiconiComments {
     data: IComment[],
     end: number,
     touchedTimeline?: Set<number>,
+    advanceBudget?: number,
   ) {
     const getCommentPosStart = performance.now();
     const startIndex = this.processedCommentIndex + 1;
@@ -352,19 +365,28 @@ class NiconiComments {
       this.nextUnprocessedCommentIndex,
       this.processedCommentIndex + 1,
     );
-    this._advanceNextUnprocessedCommentIndex(data);
+    this._advanceNextUnprocessedCommentIndex(data, advanceBudget);
     this._log(
       `getCommentPos complete: ${performance.now() - getCommentPosStart}ms`,
     );
   }
 
-  private resolveLazyCommentWindow(vpos: number) {
+  private resolveLazyCommentWindow(vpos: number, resolutionBudget?: number) {
     if (!this.ctx.options.lazy) return false;
-    const startIndex = this._advanceNextUnprocessedCommentIndex();
+    const scanStartIndex = this.nextUnprocessedCommentIndex;
+    const scanEndIndex =
+      resolutionBudget === undefined
+        ? this.comments.length
+        : Math.min(this.comments.length, scanStartIndex + resolutionBudget);
+    const startIndex = this._advanceNextUnprocessedCommentIndex(
+      this.comments,
+      resolutionBudget,
+    );
+    if (startIndex >= scanEndIndex) return false;
     const resolveUntil =
       vpos + getLazyCommentLookahead(this.ctx.config.canvasWidth);
     let endIndex = startIndex - 1;
-    for (let i = startIndex; i < this.comments.length; i++) {
+    for (let i = startIndex; i < scanEndIndex; i++) {
       const comment = this.comments[i];
       if (!comment || comment.invisible || comment.posY > -1) {
         continue;
@@ -379,7 +401,12 @@ class NiconiComments {
       return false;
     }
     const touchedTimeline = new Set<number>();
-    this.getCommentPos(this.comments, endIndex + 1, touchedTimeline);
+    this.getCommentPos(
+      this.comments,
+      Math.min(endIndex + 1, scanEndIndex),
+      touchedTimeline,
+      resolutionBudget === undefined ? undefined : 0,
+    );
     this.sortTimelineComment(touchedTimeline);
     return true;
   }
@@ -512,7 +539,15 @@ class NiconiComments {
     const triggerHandlerStart = profile ? performance.now() : 0;
     this.eventHandler.trigger(vposInt, this.lastVposInt, this.ctx.nicoScripts);
     setProfile("triggerHandler", triggerHandlerStart);
-    this.resolveLazyCommentWindow(vposInt);
+    const frameBanActive = isBanActive(
+      vpos,
+      this.ctx.nicoScripts,
+      this.ctx.rangeCache,
+    );
+    this.resolveLazyCommentWindow(
+      vposInt,
+      frameBanActive ? BAN_FRAME_POSITION_RESOLUTION_BUDGET : undefined,
+    );
     const timelineRange = this.timeline[vposInt] ?? EMPTY_TIMELINE;
     const lastTimelineRange = this.timeline[this.lastVposInt] ?? EMPTY_TIMELINE;
     const currentHasNaka = hasNakaComment(timelineRange);
@@ -560,7 +595,12 @@ class NiconiComments {
     setProfile("drawCollision", drawCollisionStart);
 
     const drawCommentsStart = profile ? performance.now() : 0;
-    const drawnCount = this._drawComments(timelineRange, vpos, cursor);
+    const drawnCount = this._drawComments(
+      timelineRange,
+      vpos,
+      cursor,
+      frameBanActive,
+    );
     setProfile("drawComments", drawCommentsStart);
 
     const drawFPSStart = profile ? performance.now() : 0;
@@ -606,8 +646,13 @@ class NiconiComments {
     timelineRange: readonly IComment[],
     vpos: number,
     cursor?: Position,
+    frameBanActive?: boolean,
   ): number {
     const { config, nicoScripts, rangeCache } = this.ctx;
+    const banActive =
+      frameBanActive ?? isBanActive(vpos, nicoScripts, rangeCache);
+    if (banActive) return 0;
+
     let startIndex = 0;
     let endIndex = timelineRange.length;
     if (config.commentLimit !== undefined) {
@@ -625,7 +670,7 @@ class NiconiComments {
       }
     }
     const frameActiveState: FrameActiveState = {
-      banActive: isBanActive(vpos, nicoScripts, rangeCache),
+      banActive,
       reverseActiveOwner: isReverseActive(vpos, true, nicoScripts, rangeCache),
       reverseActiveViewer: isReverseActive(
         vpos,
@@ -634,7 +679,6 @@ class NiconiComments {
         rangeCache,
       ),
     };
-    if (frameActiveState.banActive && !this.ctx.options.lazy) return 0;
     let maxCommentOffset = -1;
     let requiresFullScan = false;
     for (let i = startIndex; i < endIndex; i++) {
@@ -648,28 +692,6 @@ class NiconiComments {
       if (maxCommentOffset < commentOffset) {
         maxCommentOffset = commentOffset;
       }
-    }
-    if (frameActiveState.banActive) {
-      const resolutionEnd =
-        this.processedCommentIndex + 1 + BAN_FRAME_POSITION_RESOLUTION_BUDGET;
-      if (
-        requiresFullScan &&
-        this.processedCommentIndex < this.comments.length - 1
-      ) {
-        this.getCommentPos(
-          this.comments,
-          Math.min(this.comments.length, resolutionEnd),
-        );
-      } else if (
-        maxCommentOffset >= 0 &&
-        this.processedCommentIndex < maxCommentOffset
-      ) {
-        this.getCommentPos(
-          this.comments,
-          Math.min(maxCommentOffset + 1, resolutionEnd),
-        );
-      }
-      return 0;
     }
     if (
       requiresFullScan &&

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,7 +41,7 @@ import { RangeCacheContext } from "@/utils/rangeCache";
 import * as internal from "./internal";
 
 const EMPTY_TIMELINE = Object.freeze([]) as readonly IComment[];
-export const BAN_FRAME_POSITION_RESOLUTION_BUDGET = 256;
+const BAN_FRAME_POSITION_RESOLUTION_BUDGET = 256;
 const TIMELINE_COMMENT_SORT = (a: IComment, b: IComment) =>
   Number(a.owner) - Number(b.owner) || a.index - b.index;
 
@@ -127,6 +127,8 @@ class NiconiComments {
   private plugins: IPluginList = [];
   static typeGuard = typeGuard;
   static default = NiconiComments;
+  static readonly BAN_FRAME_POSITION_RESOLUTION_BUDGET =
+    BAN_FRAME_POSITION_RESOLUTION_BUDGET;
   static FlashComment = {
     condition: isFlashComment,
     class: FlashComment,

--- a/src/main.ts
+++ b/src/main.ts
@@ -41,7 +41,7 @@ import { RangeCacheContext } from "@/utils/rangeCache";
 import * as internal from "./internal";
 
 const EMPTY_TIMELINE = Object.freeze([]) as readonly IComment[];
-const BAN_FRAME_POSITION_RESOLUTION_BUDGET = 256;
+export const BAN_FRAME_POSITION_RESOLUTION_BUDGET = 256;
 const TIMELINE_COMMENT_SORT = (a: IComment, b: IComment) =>
   Number(a.owner) - Number(b.owner) || a.index - b.index;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -107,6 +107,7 @@ class NiconiComments {
   public showFPS: boolean;
   public showCommentCount: boolean;
   private lastVpos: number;
+  private lastFrameBanActive: boolean;
   private get lastVposInt() {
     return Math.floor(this.lastVpos);
   }
@@ -214,6 +215,7 @@ class NiconiComments {
       right: {},
     };
     this.lastVpos = -1;
+    this.lastFrameBanActive = false;
     this.lazyCommentOrderSortedByVpos = true;
     this.nextUnprocessedCommentIndex = 0;
     this.commentArrayIndexMap = new WeakMap();
@@ -562,7 +564,8 @@ class NiconiComments {
       !forceRendering &&
       this.plugins.length === 0 &&
       !currentHasNaka &&
-      !lastHasNaka
+      !lastHasNaka &&
+      frameBanActive === this.lastFrameBanActive
     ) {
       if (arrayEqual(timelineRange, lastTimelineRange)) return false;
     }
@@ -573,6 +576,7 @@ class NiconiComments {
       this.ctx.config.canvasHeight,
     );
     this.lastVpos = vpos;
+    this.lastFrameBanActive = frameBanActive;
 
     const drawVideoStart = profile ? performance.now() : 0;
     this._drawVideo();

--- a/src/utils/comment.ts
+++ b/src/utils/comment.ts
@@ -188,14 +188,38 @@ type ActiveRangeScanState<T extends TimedRange> = {
   lastVpos: number;
 };
 
-const reverseActiveRangeScans = new WeakMap<
-  NicoScript["reverse"],
-  ActiveRangeScanState<NicoScript["reverse"][number]>
+type ActiveRangeScanCaches = {
+  reverse: WeakMap<
+    NicoScript["reverse"],
+    ActiveRangeScanState<NicoScript["reverse"][number]>
+  >;
+  ban: WeakMap<
+    NicoScript["ban"],
+    ActiveRangeScanState<NicoScript["ban"][number]>
+  >;
+};
+
+const activeRangeScanCaches = new WeakMap<
+  RangeCacheContext,
+  ActiveRangeScanCaches
 >();
-const banActiveRangeScans = new WeakMap<
-  NicoScript["ban"],
-  ActiveRangeScanState<NicoScript["ban"][number]>
->();
+
+const getActiveRangeScanCaches = (rangeCache: RangeCacheContext) => {
+  const cached = activeRangeScanCaches.get(rangeCache);
+  if (cached) return cached;
+  const next = {
+    reverse: new WeakMap<
+      NicoScript["reverse"],
+      ActiveRangeScanState<NicoScript["reverse"][number]>
+    >(),
+    ban: new WeakMap<
+      NicoScript["ban"],
+      ActiveRangeScanState<NicoScript["ban"][number]>
+    >(),
+  };
+  activeRangeScanCaches.set(rangeCache, next);
+  return next;
+};
 
 const getActiveRangeScanState = <T extends TimedRange>(
   ranges: T[],
@@ -203,6 +227,8 @@ const getActiveRangeScanState = <T extends TimedRange>(
 ) => {
   const cached = scanCache.get(ranges);
   if (cached?.sourceLength === ranges.length) return cached;
+  // NicoScript ranges are append-only and immutable after creation; this
+  // length check must be revisited if future code mutates start/end in place.
   const sortedByStart = [...ranges].sort((a, b) => a.start - b.start);
   const sortedByEnd = [...ranges].sort((a, b) => a.end - b.end);
   const next = {
@@ -918,7 +944,7 @@ const isReverseActive = (
   const activeState = getActiveRangeState(
     nicoScripts.reverse,
     vpos,
-    reverseActiveRangeScans,
+    getActiveRangeScanCaches(rangeCache).reverse,
   );
   const result = isOwner
     ? (activeState?.targetCounts.投コメ ?? 0) > 0 ||
@@ -944,8 +970,11 @@ const isBanActive = (
   const cached = rangeCache.banActive.get(vpos);
   if (cached !== undefined) return cached;
   const result =
-    (getActiveRangeState(nicoScripts.ban, vpos, banActiveRangeScans)
-      ?.activeCount ?? 0) > 0;
+    (getActiveRangeState(
+      nicoScripts.ban,
+      vpos,
+      getActiveRangeScanCaches(rangeCache).ban,
+    )?.activeCount ?? 0) > 0;
   rangeCache.setCachedActiveState(rangeCache.banActive, vpos, result);
   return result;
 };

--- a/src/utils/comment.ts
+++ b/src/utils/comment.ts
@@ -172,6 +172,100 @@ const hasParsedMailCommand = (commands: string[], target: string) => {
 
 const processedTimelineComments = new WeakMap<IComment, WeakSet<Timeline>>();
 
+type TimedRange = {
+  start: number;
+  end: number;
+};
+
+type ActiveRangeScanState<T extends TimedRange> = {
+  sourceLength: number;
+  sortedByStart: T[];
+  sortedByEnd: T[];
+  startIndex: number;
+  endIndex: number;
+  activeCount: number;
+  targetCounts: Record<NicoScript["reverse"][number]["target"], number>;
+  lastVpos: number;
+};
+
+const reverseActiveRangeScans = new WeakMap<
+  NicoScript["reverse"],
+  ActiveRangeScanState<NicoScript["reverse"][number]>
+>();
+const banActiveRangeScans = new WeakMap<
+  NicoScript["ban"],
+  ActiveRangeScanState<NicoScript["ban"][number]>
+>();
+
+const getActiveRangeScanState = <T extends TimedRange>(
+  ranges: T[],
+  scanCache: WeakMap<T[], ActiveRangeScanState<T>>,
+) => {
+  const cached = scanCache.get(ranges);
+  if (cached?.sourceLength === ranges.length) return cached;
+  const sortedByStart = [...ranges].sort((a, b) => a.start - b.start);
+  const sortedByEnd = [...ranges].sort((a, b) => a.end - b.end);
+  const next = {
+    sourceLength: ranges.length,
+    sortedByStart,
+    sortedByEnd,
+    startIndex: 0,
+    endIndex: 0,
+    activeCount: 0,
+    targetCounts: { コメ: 0, 投コメ: 0, 全: 0 },
+    lastVpos: -Infinity,
+  };
+  scanCache.set(ranges, next);
+  return next;
+};
+
+const changeReverseTargetCount = (
+  counts: Record<NicoScript["reverse"][number]["target"], number>,
+  range: TimedRange,
+  delta: number,
+) => {
+  const target = (range as NicoScript["reverse"][number]).target;
+  if (target === "コメ" || target === "投コメ" || target === "全") {
+    counts[target] += delta;
+  }
+};
+
+const getActiveRangeState = <T extends TimedRange>(
+  ranges: T[],
+  vpos: number,
+  scanCache: WeakMap<T[], ActiveRangeScanState<T>>,
+) => {
+  if (!Number.isFinite(vpos)) return;
+  const state = getActiveRangeScanState(ranges, scanCache);
+  if (vpos < state.lastVpos) {
+    state.startIndex = 0;
+    state.endIndex = 0;
+    state.activeCount = 0;
+    state.targetCounts = { コメ: 0, 投コメ: 0, 全: 0 };
+  }
+  state.lastVpos = vpos;
+
+  while (state.startIndex < state.sortedByStart.length) {
+    const range = state.sortedByStart[state.startIndex];
+    if (!range || vpos <= range.start) break;
+    state.startIndex++;
+    state.activeCount++;
+    changeReverseTargetCount(state.targetCounts, range, 1);
+  }
+
+  while (state.endIndex < state.sortedByEnd.length) {
+    const range = state.sortedByEnd[state.endIndex];
+    if (!range || vpos < range.end) break;
+    state.endIndex++;
+    if (range.start < vpos) {
+      state.activeCount--;
+      changeReverseTargetCount(state.targetCounts, range, -1);
+    }
+  }
+
+  return state;
+};
+
 const isTimelineProcessed = (timeline: Timeline, comment: IComment) =>
   processedTimelineComments.get(comment)?.has(timeline) ?? false;
 
@@ -821,18 +915,16 @@ const isReverseActive = (
     : rangeCache.reverseActiveViewer;
   const cached = cache.get(vpos);
   if (cached !== undefined) return cached;
-  let result = false;
-  for (const range of nicoScripts.reverse) {
-    if (
-      (range.target === "コメ" && isOwner) ||
-      (range.target === "投コメ" && !isOwner)
-    )
-      continue;
-    if (range.start < vpos && vpos < range.end) {
-      result = true;
-      break;
-    }
-  }
+  const activeState = getActiveRangeState(
+    nicoScripts.reverse,
+    vpos,
+    reverseActiveRangeScans,
+  );
+  const result = isOwner
+    ? (activeState?.targetCounts.投コメ ?? 0) > 0 ||
+      (activeState?.targetCounts.全 ?? 0) > 0
+    : (activeState?.targetCounts.コメ ?? 0) > 0 ||
+      (activeState?.targetCounts.全 ?? 0) > 0;
   rangeCache.setCachedActiveState(cache, vpos, result);
   return result;
 };
@@ -851,13 +943,9 @@ const isBanActive = (
 ): boolean => {
   const cached = rangeCache.banActive.get(vpos);
   if (cached !== undefined) return cached;
-  let result = false;
-  for (const range of nicoScripts.ban) {
-    if (range.start < vpos && vpos < range.end) {
-      result = true;
-      break;
-    }
-  }
+  const result =
+    (getActiveRangeState(nicoScripts.ban, vpos, banActiveRangeScans)
+      ?.activeCount ?? 0) > 0;
   rangeCache.setCachedActiveState(rangeCache.banActive, vpos, result);
   return result;
 };

--- a/src/utils/comment.ts
+++ b/src/utils/comment.ts
@@ -184,7 +184,7 @@ type ActiveRangeScanState<T extends TimedRange> = {
   startIndex: number;
   endIndex: number;
   activeCount: number;
-  targetCounts: Record<NicoScript["reverse"][number]["target"], number>;
+  targetCounts?: Record<NicoScript["reverse"][number]["target"], number>;
   lastVpos: number;
 };
 
@@ -207,7 +207,7 @@ const activeRangeScanCaches = new WeakMap<
 const getActiveRangeScanCaches = (rangeCache: RangeCacheContext) => {
   const cached = activeRangeScanCaches.get(rangeCache);
   if (cached) return cached;
-  const next = {
+  const next: ActiveRangeScanCaches = {
     reverse: new WeakMap<
       NicoScript["reverse"],
       ActiveRangeScanState<NicoScript["reverse"][number]>
@@ -229,16 +229,16 @@ const getActiveRangeScanState = <T extends TimedRange>(
   if (cached?.sourceLength === ranges.length) return cached;
   // NicoScript ranges are append-only and immutable after creation; this
   // length check must be revisited if future code mutates start/end in place.
-  const sortedByStart = [...ranges].sort((a, b) => a.start - b.start);
-  const sortedByEnd = [...ranges].sort((a, b) => a.end - b.end);
-  const next = {
+  const validRanges = ranges.filter((range) => range.start < range.end);
+  const sortedByStart = [...validRanges].sort((a, b) => a.start - b.start);
+  const sortedByEnd = [...validRanges].sort((a, b) => a.end - b.end);
+  const next: ActiveRangeScanState<T> = {
     sourceLength: ranges.length,
     sortedByStart,
     sortedByEnd,
     startIndex: 0,
     endIndex: 0,
     activeCount: 0,
-    targetCounts: { コメ: 0, 投コメ: 0, 全: 0 },
     lastVpos: -Infinity,
   };
   scanCache.set(ranges, next);
@@ -247,19 +247,21 @@ const getActiveRangeScanState = <T extends TimedRange>(
 
 const changeReverseTargetCount = (
   counts: Record<NicoScript["reverse"][number]["target"], number>,
-  range: TimedRange,
+  range: NicoScript["reverse"][number],
   delta: number,
 ) => {
-  const target = (range as NicoScript["reverse"][number]).target;
-  if (target === "コメ" || target === "投コメ" || target === "全") {
-    counts[target] += delta;
-  }
+  counts[range.target] += delta;
 };
 
 const getActiveRangeState = <T extends TimedRange>(
   ranges: T[],
   vpos: number,
   scanCache: WeakMap<T[], ActiveRangeScanState<T>>,
+  changeTargetCount?: (
+    counts: Record<NicoScript["reverse"][number]["target"], number>,
+    range: T,
+    delta: number,
+  ) => void,
 ) => {
   if (!Number.isFinite(vpos)) return;
   const state = getActiveRangeScanState(ranges, scanCache);
@@ -267,6 +269,9 @@ const getActiveRangeState = <T extends TimedRange>(
     state.startIndex = 0;
     state.endIndex = 0;
     state.activeCount = 0;
+    state.targetCounts = undefined;
+  }
+  if (changeTargetCount && !state.targetCounts) {
     state.targetCounts = { コメ: 0, 投コメ: 0, 全: 0 };
   }
   state.lastVpos = vpos;
@@ -276,7 +281,9 @@ const getActiveRangeState = <T extends TimedRange>(
     if (!range || vpos <= range.start) break;
     state.startIndex++;
     state.activeCount++;
-    changeReverseTargetCount(state.targetCounts, range, 1);
+    if (state.targetCounts) {
+      changeTargetCount?.(state.targetCounts, range, 1);
+    }
   }
 
   while (state.endIndex < state.sortedByEnd.length) {
@@ -285,7 +292,9 @@ const getActiveRangeState = <T extends TimedRange>(
     state.endIndex++;
     if (range.start < vpos) {
       state.activeCount--;
-      changeReverseTargetCount(state.targetCounts, range, -1);
+      if (state.targetCounts) {
+        changeTargetCount?.(state.targetCounts, range, -1);
+      }
     }
   }
 
@@ -945,12 +954,13 @@ const isReverseActive = (
     nicoScripts.reverse,
     vpos,
     getActiveRangeScanCaches(rangeCache).reverse,
+    changeReverseTargetCount,
   );
   const result = isOwner
-    ? (activeState?.targetCounts.投コメ ?? 0) > 0 ||
-      (activeState?.targetCounts.全 ?? 0) > 0
-    : (activeState?.targetCounts.コメ ?? 0) > 0 ||
-      (activeState?.targetCounts.全 ?? 0) > 0;
+    ? (activeState?.targetCounts?.投コメ ?? 0) > 0 ||
+      (activeState?.targetCounts?.全 ?? 0) > 0
+    : (activeState?.targetCounts?.コメ ?? 0) > 0 ||
+      (activeState?.targetCounts?.全 ?? 0) > 0;
   rangeCache.setCachedActiveState(cache, vpos, result);
   return result;
 };

--- a/tests/unit/duration-lazy.spec.ts
+++ b/tests/unit/duration-lazy.spec.ts
@@ -6,7 +6,7 @@ import { createNicoScripts, ImageCacheContext } from "@/contexts";
 import { defaultConfig, defaultOptions } from "@/definition/config";
 import { initConfig } from "@/definition/initConfig";
 import { EventHandler } from "@/eventHandler";
-import NiconiComments from "@/main";
+import NiconiComments, { BAN_FRAME_POSITION_RESOLUTION_BUDGET } from "@/main";
 import {
   DEFAULT_COMMENT_LONG,
   DEFAULT_NICOSCRIPT_LONG,
@@ -23,7 +23,6 @@ class HTMLCanvasElementMock {}
 
 const HUGE_DURATION = "@9999";
 const OVERFLOW_DURATION = `@${"9".repeat(400)}`;
-const BAN_FRAME_POSITION_RESOLUTION_BUDGET = 256;
 
 const emptyTextMetrics = (width: number): TextMetrics =>
   ({

--- a/tests/unit/duration-lazy.spec.ts
+++ b/tests/unit/duration-lazy.spec.ts
@@ -5,11 +5,13 @@ import type { CommentInstanceContext } from "@/contexts";
 import { createNicoScripts, ImageCacheContext } from "@/contexts";
 import { defaultConfig, defaultOptions } from "@/definition/config";
 import { initConfig } from "@/definition/initConfig";
+import { EventHandler } from "@/eventHandler";
 import NiconiComments from "@/main";
 import {
   DEFAULT_COMMENT_LONG,
   DEFAULT_NICOSCRIPT_LONG,
   getLazyCommentLookahead,
+  isReverseActive,
   MAX_COMMENT_LONG,
   MAX_LAZY_COMMENT_LOOKAHEAD,
   MAX_NICOSCRIPT_LONG,
@@ -21,6 +23,7 @@ class HTMLCanvasElementMock {}
 
 const HUGE_DURATION = "@9999";
 const OVERFLOW_DURATION = `@${"9".repeat(400)}`;
+const BAN_FRAME_POSITION_RESOLUTION_BUDGET = 256;
 
 const emptyTextMetrics = (width: number): TextMetrics =>
   ({
@@ -399,5 +402,187 @@ describe("duration bounds and lazy timeline expansion", () => {
     expect(Object.keys(state.timeline).length).toBeLessThan(
       MAX_COMMENT_LONG * 3,
     );
+  });
+
+  test("ban frames skip reverse state and keep lazy resolution inside the frame budget", () => {
+    const invisibleComments = Array.from({ length: 1024 }, (_, index) =>
+      createComment({
+        id: index + 3,
+        vpos: 1,
+        content: `/hidden ${index}`,
+      }),
+    );
+    const heavyComments = Array.from({ length: 1024 }, (_, index) =>
+      createComment({
+        id: index + 2000,
+        vpos: 1,
+        content: `visible ${index}`,
+        mail: ["ue"],
+      }),
+    );
+    const instance = new NiconiComments(
+      new FakeRenderer(),
+      [
+        createComment({
+          id: 1,
+          owner: true,
+          vpos: 0,
+          content: "@コメント禁止",
+        }),
+        createComment({
+          id: 2,
+          owner: true,
+          vpos: 0,
+          content: "@逆 全",
+        }),
+        ...invisibleComments,
+        ...heavyComments,
+      ],
+      {
+        format: "formatted",
+        lazy: true,
+        mode: "html5",
+        config: { commentLimit: undefined },
+      },
+    );
+    const state = instance as unknown as {
+      comments: IComment[];
+      ctx: CommentInstanceContext;
+      nextUnprocessedCommentIndex: number;
+      processedCommentIndex: number;
+    };
+    const firstDrawableIndex = state.comments.findIndex(
+      (comment) => !comment.invisible,
+    );
+
+    instance.drawCanvas(1, true);
+
+    expect(firstDrawableIndex).toBeGreaterThanOrEqual(0);
+    expect(state.nextUnprocessedCommentIndex).toBeLessThanOrEqual(
+      BAN_FRAME_POSITION_RESOLUTION_BUDGET,
+    );
+    expect(state.processedCommentIndex).toBeLessThanOrEqual(
+      firstDrawableIndex + BAN_FRAME_POSITION_RESOLUTION_BUDGET - 1,
+    );
+    expect(state.processedCommentIndex).toBeLessThan(state.comments.length - 1);
+    expect(state.ctx.rangeCache.reverseActiveOwner.size).toBe(0);
+    expect(state.ctx.rangeCache.reverseActiveViewer.size).toBe(0);
+  });
+
+  test("reverse active range cache prunes expired ranges after the first scan", () => {
+    const ctx = createContext();
+    let expiredEndReads = 0;
+    for (let i = 0; i < 512; i++) {
+      ctx.nicoScripts.reverse.push({
+        target: "全",
+        start: 0,
+        get end() {
+          expiredEndReads++;
+          return 5;
+        },
+      });
+    }
+    ctx.nicoScripts.reverse.push({
+      target: "全",
+      start: 0,
+      end: 100,
+    });
+
+    expect(isReverseActive(4, false, ctx.nicoScripts, ctx.rangeCache)).toBe(
+      true,
+    );
+    expect(isReverseActive(6, false, ctx.nicoScripts, ctx.rangeCache)).toBe(
+      true,
+    );
+
+    expiredEndReads = 0;
+    expect(isReverseActive(7, false, ctx.nicoScripts, ctx.rangeCache)).toBe(
+      true,
+    );
+    expect(expiredEndReads).toBeLessThan(64);
+  });
+
+  test("reverse active range cache does not rescan long-lived active ranges each frame", () => {
+    const ctx = createContext();
+    let targetReads = 0;
+    for (let i = 0; i < 512; i++) {
+      ctx.nicoScripts.reverse.push({
+        get target() {
+          targetReads++;
+          return "全";
+        },
+        start: 0,
+        end: 10_000,
+      });
+    }
+
+    expect(isReverseActive(4, false, ctx.nicoScripts, ctx.rangeCache)).toBe(
+      true,
+    );
+
+    targetReads = 0;
+    expect(isReverseActive(5, false, ctx.nicoScripts, ctx.rangeCache)).toBe(
+      true,
+    );
+    expect(targetReads).toBe(0);
+  });
+
+  test("event range scan cache prunes expired ban ranges after transition checks", () => {
+    const eventHandler = new EventHandler();
+    const ctx = createContext();
+    let expiredEndReads = 0;
+    let disabled = 0;
+    eventHandler.register("commentDisable", () => {
+      disabled++;
+    });
+    for (let i = 0; i < 512; i++) {
+      ctx.nicoScripts.ban.push({
+        start: 0,
+        get end() {
+          expiredEndReads++;
+          return 5;
+        },
+      });
+    }
+    ctx.nicoScripts.ban.push({
+      start: 0,
+      end: 100,
+    });
+
+    eventHandler.trigger(4, 3, ctx.nicoScripts);
+    eventHandler.trigger(6, 4, ctx.nicoScripts);
+
+    expiredEndReads = 0;
+    eventHandler.trigger(7, 6, ctx.nicoScripts);
+
+    expect(expiredEndReads).toBeLessThan(64);
+    expect(disabled).toBe(0);
+  });
+
+  test("event range scan cache does not rescan long-lived active ranges each frame", () => {
+    const eventHandler = new EventHandler();
+    const ctx = createContext();
+    let startReads = 0;
+    let disabled = 0;
+    eventHandler.register("commentDisable", () => {
+      disabled++;
+    });
+    for (let i = 0; i < 512; i++) {
+      ctx.nicoScripts.ban.push({
+        get start() {
+          startReads++;
+          return 0;
+        },
+        end: 10_000,
+      });
+    }
+
+    eventHandler.trigger(4, 3, ctx.nicoScripts);
+
+    startReads = 0;
+    eventHandler.trigger(5, 4, ctx.nicoScripts);
+
+    expect(startReads).toBeLessThan(64);
+    expect(disabled).toBe(0);
   });
 });

--- a/tests/unit/duration-lazy.spec.ts
+++ b/tests/unit/duration-lazy.spec.ts
@@ -44,6 +44,7 @@ const emptyTextMetrics = (width: number): TextMetrics =>
 class FakeRenderer implements IRenderer {
   public readonly rendererName = "FakeRenderer";
   public readonly canvas = {} as HTMLCanvasElement;
+  public clearRectCalls = 0;
   private font = "";
   private size = { width: 1920, height: 1080 };
 
@@ -61,7 +62,9 @@ class FakeRenderer implements IRenderer {
   fillText() {}
   strokeText() {}
   quadraticCurveTo() {}
-  clearRect() {}
+  clearRect() {
+    this.clearRectCalls++;
+  }
   setFont(font: string) {
     this.font = font;
   }
@@ -467,6 +470,29 @@ describe("duration bounds and lazy timeline expansion", () => {
     expect(state.processedCommentIndex).toBeLessThan(state.comments.length - 1);
     expect(state.ctx.rangeCache.reverseActiveOwner.size).toBe(0);
     expect(state.ctx.rangeCache.reverseActiveViewer.size).toBe(0);
+  });
+
+  test("redraws when ban state changes across identical timeline ranges", () => {
+    const renderer = new FakeRenderer();
+    const instance = new NiconiComments(renderer, [], {
+      format: "formatted",
+      mode: "html5",
+    });
+    const state = instance as unknown as {
+      ctx: CommentInstanceContext;
+    };
+
+    state.ctx.nicoScripts.ban.push({ start: 0, end: 10 });
+    state.ctx.rangeCache.reset();
+
+    expect(instance.drawCanvas(1)).toBe(true);
+    expect(renderer.clearRectCalls).toBe(1);
+
+    state.ctx.nicoScripts.ban.length = 0;
+    state.ctx.rangeCache.reset();
+
+    expect(instance.drawCanvas(2)).toBe(true);
+    expect(renderer.clearRectCalls).toBe(2);
   });
 
   test("reverse active range cache prunes expired ranges after the first scan", () => {

--- a/tests/unit/duration-lazy.spec.ts
+++ b/tests/unit/duration-lazy.spec.ts
@@ -6,7 +6,7 @@ import { createNicoScripts, ImageCacheContext } from "@/contexts";
 import { defaultConfig, defaultOptions } from "@/definition/config";
 import { initConfig } from "@/definition/initConfig";
 import { EventHandler } from "@/eventHandler";
-import NiconiComments, { BAN_FRAME_POSITION_RESOLUTION_BUDGET } from "@/main";
+import NiconiComments from "@/main";
 import {
   DEFAULT_COMMENT_LONG,
   DEFAULT_NICOSCRIPT_LONG,
@@ -23,6 +23,7 @@ class HTMLCanvasElementMock {}
 
 const HUGE_DURATION = "@9999";
 const OVERFLOW_DURATION = `@${"9".repeat(400)}`;
+const { BAN_FRAME_POSITION_RESOLUTION_BUDGET } = NiconiComments;
 
 const emptyTextMetrics = (width: number): TextMetrics =>
   ({


### PR DESCRIPTION
## チケットへのリンク

- Task SEC-03: P0: ban/reverse/lazy draw path DoS guard

## やったこと

- ban中の描画フレームでは `_drawComments()` が banActive だけを先に判定し、reverse state を計算せず即 return するようにしました。
- lazy position resolution を ban frame では `BAN_FRAME_POSITION_RESOLUTION_BUDGET` 内に制限し、leading invisible comment でも unbounded scan しないようにしました。
- `isReverseActive()` / event range scan を range boundary cache ベースにし、大量 range で毎フレーム active range 全体を走査し続けないようにしました。
- ban/reverse/lazy DoS guard の focused unit tests を追加しました。

## やらないこと

- renderer 実装、Flash/HTML5 comment 実装、docs/workflows/package/lockfile は変更しません。
- renderer robustness や Flash button/spacer は別タスクのため扱いません。

## できるようになること（ユーザ目線）

- 悪意ある大量コメントや大量 NicoScript range がある動画でも、ban中フレームの描画処理が入力コメント数に比例して伸び続けにくくなります。

## できなくなること（ユーザ目線）

- 無し。

## 動作確認

- `npm run check-types` passed
- `npm run test:unit -- tests/unit/duration-lazy.spec.ts` passed（12 tests）
- `npm run test:unit` passed（45 tests）
- `npm run lint` exit 0（既存の src/typeGuard.ts warnings 2件のみ）
- `git diff --check` passed
- deep-review self-review 実施、独立 reviewer follow-up で actionable findings なし

## その他

- 初回の大量 range sort や、多数の境界を跨ぐ seek は対象 boundary 数に比例します。通常の連続フレームでは active range 全体を毎回 prune しません。

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the per-frame O(n) linear scans for ban/reverse/jump event ranges with a sweep-line cache keyed on `RangeCacheContext`, and caps lazy position resolution during ban frames at `BAN_FRAME_POSITION_RESOLUTION_BUDGET` (256) entries. The `_drawComments` ban early-return is hoisted to the top of the function before any expensive state computation, and `frameBanActive` is threaded from `drawCanvas` into `_drawComments` so `isBanActive` is only called once per frame.

- **Sweep-line in `comment.ts`** (`getActiveRangeState`): a shared sorted-arrays + cursor state replaces O(n) scans in `isBanActive` and `isReverseActive`; the cursor resets on backward seek and O(1)-amortises forward playback.
- **Transition-ranges in `eventHandler.ts`** (`getTransitionRanges`): binary-search on sorted-by-start / sorted-by-end arrays replaces the O(n) per-frame loop for ban, seekDisable, and jump event triggers.
- **Ban-frame DoS guard in `main.ts`**: lazy resolution is budget-capped when a ban range is active, `_drawComments` returns 0 immediately, and a new `lastFrameBanActive` field forces a redraw when ban state flips across otherwise-identical timeline slices.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the sweep-line preserves the exact boundary semantics of the old O(n) scans, the ban early-return is moved before all expensive state computation, and the lazy-budget cap is correctly threaded through both the resolution window and getCommentPos.

All three changed algorithm paths (getTransitionRanges, getActiveRangeState sweep-line, and the ban-frame draw guard) were verified against the old code's strict-inequality boundary conditions and produce identical results. The backward-seek reset, the targetCounts/activeCount split between reverse and ban caches, the frameBanActive threading, and the resolveLazyCommentWindow budget cap are all logically consistent. Six new unit tests cover the key invariants with property-based getter probes. No changed public API surface.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/eventHandler.ts | Adds generic EventRange sweep-line helpers (lowerBoundStart, upperBoundEnd, getTransitionRanges) and replaces per-range O(n) loops for ban/seekDisable/jump with O(log n) binary-search transition detection. Boundary semantics match the old strict-inequality checks. |
| src/utils/comment.ts | Introduces getActiveRangeState sweep-line for isBanActive and isReverseActive; correctly filters degenerate ranges (start >= end), resets on backward seek, and uses separate WeakMap caches per domain (ban vs reverse) keyed on RangeCacheContext. |
| src/main.ts | Hoists ban detection before _drawComments, caps resolveLazyCommentWindow to BAN_FRAME_POSITION_RESOLUTION_BUDGET during ban frames, adds lastFrameBanActive to force redraw on ban-state transitions, and skips _advanceNextUnprocessedCommentIndex in the constructor for sorted-lazy mode. |
| tests/unit/duration-lazy.spec.ts | Adds six focused unit tests covering ban-frame lazy budget, redraw on ban-state flip, sweep-line cache pruning for expired/long-lived reverse ranges, and event-handler scan efficiency. BAN_FRAME_POSITION_RESOLUTION_BUDGET imported from NiconiComments.BAN_FRAME_POSITION_RESOLUTION_BUDGET (not redefined). |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[drawCanvas vpos] --> B[isBanActive sweep-line\nO log n amortised]
    B --> C{frameBanActive?}
    C -- yes --> D[resolveLazyCommentWindow\nbudget = BAN_FRAME_POSITION_RESOLUTION_BUDGET]
    C -- no --> E[resolveLazyCommentWindow\nno budget]
    D --> F{frameBanActive\n=== lastFrameBanActive\nAND timeline equal?}
    E --> F
    F -- yes --> G[return false\nearly exit]
    F -- no --> H[clearRect / drawVideo]
    H --> I[_drawComments\nframeBanActive passed in]
    I --> J{banActive?}
    J -- yes --> K[return 0 immediately\nskip isReverseActive\nskip comment loop]
    J -- no --> L[compute isReverseActive\nO log n via sweep-line]
    L --> M[render comments]
    M --> N[lastFrameBanActive = frameBanActive]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["Redraw on ban state changes"](https://github.com/xpadev-net/niconicomments/commit/c23840c48e9f26d412fed9377b6d93c676405046) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35586693)</sub>

<!-- /greptile_comment -->