### PR TITLE
Rewrite Flash spacer parsing iteratively

### DIFF
--- a/src/comments/FlashComment.ts
+++ b/src/comments/FlashComment.ts
@@ -336,14 +336,15 @@ class FlashComment extends BaseComment {
   }
 
   private _measureContent(comment: MeasureTextInput) {
-    const widthArr: number[] = [];
-    const spacedWidthArr: number[] = [];
     let currentWidth = 0;
     let spacedWidth = 0;
+    let leadLineWidth = 1;
+    let leadLineSpacedWidth = 0;
     const recordLineWidth = () => {
-      if (widthArr.length >= MAX_FLASH_CONTENT_ITEMS) return;
-      widthArr.push(currentWidth);
-      spacedWidthArr.push(spacedWidth);
+      if (leadLineSpacedWidth < spacedWidth) {
+        leadLineWidth = currentWidth || 1;
+        leadLineSpacedWidth = spacedWidth;
+      }
     };
     for (const item of comment.content) {
       if (item.type === "spacer") {
@@ -378,19 +379,8 @@ class FlashComment extends BaseComment {
       recordLineWidth();
       item.width = widths;
     }
-    const leadLine = (() => {
-      let max = 0;
-      let index = -1;
-      spacedWidthArr.forEach((val, i) => {
-        if (max < val) {
-          max = val;
-          index = i;
-        }
-      });
-      return { max, index };
-    })();
-    const scaleX = leadLine.max / (widthArr[leadLine.index] ?? 1);
-    const width = leadLine.max * comment.scale;
+    const scaleX = leadLineSpacedWidth / leadLineWidth;
+    const width = leadLineSpacedWidth * comment.scale;
     const height =
       (comment.fontSize * (comment.lineHeight ?? 0) * comment.lineCount +
         this.config.flashCommentYPaddingTop[

--- a/src/comments/FlashComment.ts
+++ b/src/comments/FlashComment.ts
@@ -340,14 +340,18 @@ class FlashComment extends BaseComment {
     const spacedWidthArr: number[] = [];
     let currentWidth = 0;
     let spacedWidth = 0;
+    const recordLineWidth = () => {
+      if (widthArr.length >= MAX_FLASH_CONTENT_ITEMS) return;
+      widthArr.push(currentWidth);
+      spacedWidthArr.push(spacedWidth);
+    };
     for (const item of comment.content) {
       if (item.type === "spacer") {
         spacedWidth +=
           item.count * item.charWidth * comment.fontSize +
           Math.max(item.count - 1, 0) * this.config.flashLetterSpacing;
         currentWidth += item.count * item.charWidth * comment.fontSize;
-        widthArr.push(currentWidth);
-        spacedWidthArr.push(spacedWidth);
+        recordLineWidth();
         continue;
       }
       const lines = item.content.split("\n");
@@ -366,14 +370,12 @@ class FlashComment extends BaseComment {
           Math.max(value.length - 1, 0) * this.config.flashLetterSpacing;
         widths.push(meas.width);
         if (i < lines.length - 1) {
-          widthArr.push(currentWidth);
-          spacedWidthArr.push(spacedWidth);
+          recordLineWidth();
           spacedWidth = 0;
           currentWidth = 0;
         }
       }
-      widthArr.push(currentWidth);
-      spacedWidthArr.push(spacedWidth);
+      recordLineWidth();
       item.width = widths;
     }
     const leadLine = (() => {

--- a/src/utils/flash.ts
+++ b/src/utils/flash.ts
@@ -198,8 +198,7 @@ const addPartToResult = (
   const spacerKeys = getFlashSpacerKeys(config);
   const fontName = font ?? "defont";
   while (tasks.length > 0 && lineContent.length < maxItems) {
-    const task = tasks.pop();
-    if (!task) continue;
+    const task = tasks.pop() as AddPartTask;
     if (task.type === "spacer") {
       lineContent.push({
         type: "spacer",

--- a/src/utils/flash.ts
+++ b/src/utils/flash.ts
@@ -20,6 +20,7 @@ const flashCharRegexCache = new WeakMap<
   BaseConfig,
   { simsunStrong: RegExp; simsunWeak: RegExp; gulim: RegExp; gothic: RegExp }
 >();
+const flashSpacerKeysCache = new WeakMap<BaseConfig, string[]>();
 
 const getFlashCharRegex = (config: BaseConfig) => {
   let cached = flashCharRegexCache.get(config);
@@ -31,6 +32,17 @@ const getFlashCharRegex = (config: BaseConfig) => {
       gothic: new RegExp(config.flashChar.gothic),
     };
     flashCharRegexCache.set(config, cached);
+  }
+  return cached;
+};
+
+const getFlashSpacerKeys = (config: BaseConfig) => {
+  let cached = flashSpacerKeysCache.get(config);
+  if (!cached) {
+    cached = Object.keys(config.compatSpacer.flash).filter(
+      (key) => key.length > 0,
+    );
+    flashSpacerKeysCache.set(config, cached);
   }
   return cached;
 };
@@ -105,14 +117,14 @@ const parseContent = (content: string, config: BaseConfig) => {
   const clamped = clampFlashContent(content);
   const lines = Array.from(clamped.content.match(/\n|[^\n]+/g) ?? []);
   for (const line of lines) {
-    const lineContent = parseLine(line, config);
-    const firstContent = lineContent[0];
     const remainingItems = MAX_FLASH_CONTENT_ITEMS - results.length;
     if (remainingItems <= 0) break;
+    const lineContent = parseLine(line, config, remainingItems);
+    const firstContent = lineContent[0];
     const defaultFont = firstContent?.font;
     if (defaultFont) {
       results.push(
-        ...lineContent.slice(0, remainingItems).map((val) => {
+        ...lineContent.map((val) => {
           val.font ??= defaultFont;
           if (val.type === "spacer") {
             const spacer = config.compatSpacer.flash[val.char];
@@ -125,7 +137,7 @@ const parseContent = (content: string, config: BaseConfig) => {
         }),
       );
     } else {
-      results.push(...lineContent.slice(0, remainingItems));
+      results.push(...lineContent);
     }
   }
   return results;
@@ -137,18 +149,35 @@ const parseContent = (content: string, config: BaseConfig) => {
  * @param config インスタンス設定
  * @returns パースしたコメントの内容
  */
-const parseLine = (line: string, config: BaseConfig) => {
+const parseLine = (
+  line: string,
+  config: BaseConfig,
+  maxItems = MAX_FLASH_CONTENT_ITEMS,
+) => {
   const parts = Array.from(line.match(/[ -~｡-ﾟ]+|[^ -~｡-ﾟ]+/g) ?? []);
   const lineContent: CommentContentItem[] = [];
   for (const part of parts) {
+    if (lineContent.length >= maxItems) break;
     if (part.match(/[ -~｡-ﾟ]+/g) !== null) {
-      addPartToResult(lineContent, part, config, "defont");
+      addPartToResult(lineContent, part, config, "defont", maxItems);
       continue;
     }
-    parseFullWidthPart(part, lineContent, config);
+    parseFullWidthPart(part, lineContent, config, maxItems);
   }
   return lineContent;
 };
+
+type AddPartTask =
+  | {
+      type: "segment";
+      value: string;
+    }
+  | {
+      type: "spacer";
+      char: string;
+      charWidth: number;
+      count: number;
+    };
 
 /**
  * スペースの補正を行った上で結果を追加する
@@ -162,35 +191,69 @@ const addPartToResult = (
   part: string,
   config: BaseConfig,
   font?: CommentFlashFont,
+  maxItems = MAX_FLASH_CONTENT_ITEMS,
 ) => {
-  if (part === "" || lineContent.length >= MAX_FLASH_CONTENT_ITEMS) return;
-  for (const key of Object.keys(config.compatSpacer.flash)) {
-    const spacerWidth = config.compatSpacer.flash[key]?.[font ?? "defont"];
-    if (!spacerWidth) continue;
-    const compatIndex = part.indexOf(key);
-    if (compatIndex >= 0) {
-      addPartToResult(lineContent, part.slice(0, compatIndex), config, font);
-      let i = compatIndex;
-      for (; i < part.length && part[i] === key; i++) {
-        /* empty */
-      }
+  if (part === "" || lineContent.length >= maxItems) return;
+  const tasks: AddPartTask[] = [{ type: "segment", value: part }];
+  const spacerKeys = getFlashSpacerKeys(config);
+  const fontName = font ?? "defont";
+  while (tasks.length > 0 && lineContent.length < maxItems) {
+    const task = tasks.pop();
+    if (!task) continue;
+    if (task.type === "spacer") {
       lineContent.push({
         type: "spacer",
-        char: key,
-        charWidth: spacerWidth,
+        char: task.char,
+        charWidth: task.charWidth,
         font,
-        count: i - compatIndex,
+        count: task.count,
       });
-      addPartToResult(lineContent, part.slice(i), config, font);
-      return;
+      continue;
     }
+    if (task.value === "") continue;
+    let match:
+      | {
+          key: string;
+          index: number;
+          width: number;
+          count: number;
+          end: number;
+        }
+      | undefined;
+    for (const key of spacerKeys) {
+      const spacerWidth = config.compatSpacer.flash[key]?.[fontName];
+      if (!spacerWidth) continue;
+      const compatIndex = task.value.indexOf(key);
+      if (compatIndex < 0) continue;
+      let count = 0;
+      let end = compatIndex;
+      while (task.value.startsWith(key, end)) {
+        count++;
+        end += key.length;
+      }
+      match = { key, index: compatIndex, width: spacerWidth, count, end };
+      break;
+    }
+    if (!match) {
+      lineContent.push({
+        type: "text",
+        content: task.value,
+        slicedContent: task.value.split("\n"),
+        font,
+      });
+      continue;
+    }
+    const after = task.value.slice(match.end);
+    if (after !== "") tasks.push({ type: "segment", value: after });
+    tasks.push({
+      type: "spacer",
+      char: match.key,
+      charWidth: match.width,
+      count: match.count,
+    });
+    const before = task.value.slice(0, match.index);
+    if (before !== "") tasks.push({ type: "segment", value: before });
   }
-  lineContent.push({
-    type: "text",
-    content: part,
-    slicedContent: part.split("\n"),
-    font,
-  });
 };
 
 /**
@@ -203,14 +266,22 @@ const parseFullWidthPart = (
   part: string,
   lineContent: CommentContentItem[],
   config: BaseConfig,
+  maxItems = MAX_FLASH_CONTENT_ITEMS,
 ) => {
+  if (lineContent.length >= maxItems) return;
   const index = getFlashFontIndex(part, config);
   if (index.length === 0) {
-    addPartToResult(lineContent, part, config);
+    addPartToResult(lineContent, part, config, undefined, maxItems);
   } else if (index.length === 1 && index[0]) {
-    addPartToResult(lineContent, part, config, getFlashFontName(index[0].font));
+    addPartToResult(
+      lineContent,
+      part,
+      config,
+      getFlashFontName(index[0].font),
+      maxItems,
+    );
   } else {
-    parseMultiFontFullWidthPart(part, index, lineContent, config);
+    parseMultiFontFullWidthPart(part, index, lineContent, config, maxItems);
   }
 };
 
@@ -226,11 +297,13 @@ const parseMultiFontFullWidthPart = (
   index: CommentContentIndex[],
   lineContent: CommentContentItem[],
   config: BaseConfig,
+  maxItems = MAX_FLASH_CONTENT_ITEMS,
 ) => {
   index.sort(nativeSort((val) => val.index));
   if (config.flashMode === "xp") {
     let offset = 0;
     for (let i = 1, n = index.length; i < n; i++) {
+      if (lineContent.length >= maxItems) return;
       const currentVal = index[i];
       const lastVal = index[i - 1];
       if (currentVal === undefined || lastVal === undefined) continue;
@@ -240,24 +313,37 @@ const parseMultiFontFullWidthPart = (
         content,
         config,
         getFlashFontName(lastVal.font),
+        maxItems,
       );
       offset = currentVal.index;
     }
     const val = index[index.length - 1];
     if (val) {
       const content = part.slice(offset);
-      addPartToResult(lineContent, content, config, getFlashFontName(val.font));
+      addPartToResult(
+        lineContent,
+        content,
+        config,
+        getFlashFontName(val.font),
+        maxItems,
+      );
     }
     return;
   }
   const firstVal = index[0];
   const secondVal = index[1];
   if (!firstVal || !secondVal) {
-    addPartToResult(lineContent, part, config);
+    addPartToResult(lineContent, part, config, undefined, maxItems);
     return;
   }
   if (firstVal.font !== "gothic") {
-    addPartToResult(lineContent, part, config, getFlashFontName(firstVal.font));
+    addPartToResult(
+      lineContent,
+      part,
+      config,
+      getFlashFontName(firstVal.font),
+      maxItems,
+    );
     return;
   }
   const firstContent = part.slice(0, secondVal.index);
@@ -267,12 +353,14 @@ const parseMultiFontFullWidthPart = (
     firstContent,
     config,
     getFlashFontName(firstVal.font),
+    maxItems,
   );
   addPartToResult(
     lineContent,
     secondContent,
     config,
     getFlashFontName(secondVal.font),
+    maxItems,
   );
 };
 

--- a/tests/unit/flash-resource-bounds.spec.ts
+++ b/tests/unit/flash-resource-bounds.spec.ts
@@ -15,6 +15,7 @@ import {
   MAX_AT_BUTTON_MAIL_ENTRIES,
   MAX_AT_BUTTON_TEXT_CHARS,
   MAX_FLASH_COMMENT_LINES,
+  MAX_FLASH_CONTENT_ITEMS,
   MAX_NICOSCRIPT_COMMAND_CHARS,
   MAX_NICOSCRIPT_TEXT_CHARS,
   MAX_PARSED_COMMAND_MAIL_ENTRIES,
@@ -241,6 +242,26 @@ describe("Flash and at-button resource bounds", () => {
 
     expect(comment.exposeTextImage()).toBeNull();
     expect(renderer.children).toHaveLength(initialCanvasCount);
+  });
+
+  test("parses long spacer-heavy Flash comments iteratively within item bounds", () => {
+    const renderer = new RecordingRenderer();
+    const budgetFiller = "x ".repeat(MAX_FLASH_CONTENT_ITEMS / 2);
+    const skippedTail = `\n${"tail ".repeat(3000)}`;
+    const comment = new TestFlashComment(
+      formattedComment(`${budgetFiller}${skippedTail}`),
+      renderer,
+      0,
+      createContext(),
+    );
+
+    expect(comment.comment.content).toHaveLength(MAX_FLASH_CONTENT_ITEMS);
+    expect(
+      comment.comment.content.some(
+        (item) => item.type === "text" && item.content.includes("tail"),
+      ),
+    ).toBe(false);
+    expect(renderer.measureCalls).toBeLessThanOrEqual(MAX_FLASH_CONTENT_ITEMS);
   });
 
   test("does not allocate button canvases for many normal Flash comments", () => {


### PR DESCRIPTION
## Summary
- replace recursive Flash spacer splitting with an iterative task stack
- cache Flash spacer keys per config and stop parsing when MAX_FLASH_CONTENT_ITEMS is reached
- cap Flash measurement line-width arrays and add a long spacer-heavy regression test

## Validation
- npm run test:unit -- tests/unit/flash-resource-bounds.spec.ts
- npm run check-types
- npm run lint (exit 0; existing warnings in src/typeGuard.ts)
- git diff --check

## Review
- deep-review self-review: no remaining actionable findings
- independent subagent review: one test-strength finding fixed, second pass no findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR rewrites the recursive Flash spacer-splitting logic in `addPartToResult` as an explicit LIFO task-stack loop, eliminating potential call-stack overflows on spacer-dense comments, while also replacing the `widthArr`/`spacedWidthArr` accumulator arrays in `_measureContent` with a single pair of running scalar maximums.

- **`src/utils/flash.ts`**: `addPartToResult` is converted from recursion to an iterative stack; `parseLine`, `parseFullWidthPart`, and `parseMultiFontFullWidthPart` receive a `maxItems` parameter so the budget is enforced during parsing rather than by post-parse slicing; `getFlashSpacerKeys` caches per-config spacer key arrays (filtering empty keys).
- **`src/comments/FlashComment.ts`**: `_measureContent` removes the two push-per-item width arrays and replaces them with a closure `recordLineWidth()` that updates a pair of scalar maximums inline, eliminating an earlier cap-drop concern entirely.
- **`tests/unit/flash-resource-bounds.spec.ts`**: A new test verifies that a 2048-spacer-unit budget filler plus a 3000-item tail produces exactly `MAX_FLASH_CONTENT_ITEMS` content items with no "tail" items leaking through.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — pure internal rewrite with no public API changes; stack ordering, budget enforcement, and width tracking are all semantically equivalent to the original.

The LIFO push order correctly mirrors the old recursive sequence; recordLineWidth() updates running maximums at the identical call sites as the old array pushes; and maxItems is threaded through all parse helpers so the budget is respected during parsing rather than by slicing output after the fact.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/utils/flash.ts | Recursive addPartToResult replaced with correct LIFO-stack iterative version; maxItems budget propagated through all parse helpers; spacer key list cached per config with empty-key guard. |
| src/comments/FlashComment.ts | widthArr/spacedWidthArr arrays removed; scalar leadLineWidth/leadLineSpacedWidth updated by recordLineWidth() closure at the same call sites as the old array pushes — semantically equivalent and cap-drop-free. |
| tests/unit/flash-resource-bounds.spec.ts | New regression test verifies the 2048-item budget is fully consumed by the filler, no tail content leaks through, and measureText calls stay within the item bound. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["addPartToResult(part, maxItems)"] --> B{part == '' or\nlength >= maxItems?}
    B -- yes --> Z[return]
    B -- no --> C["tasks = [segment(part)]"]
    C --> D{tasks.length > 0\nAND length < maxItems?}
    D -- no --> Z
    D -- yes --> E["task = tasks.pop()"]
    E --> F{task.type?}
    F -- spacer --> G["lineContent.push(spacer item)"]
    G --> D
    F -- segment --> H{value == ''?}
    H -- yes --> D
    H -- no --> I[Scan spacerKeys for first match in value]
    I --> J{match found?}
    J -- no --> K["lineContent.push(text item)"]
    K --> D
    J -- yes --> L["push segment(after) if non-empty"]
    L --> M["push spacer task"]
    M --> N["push segment(before) if non-empty"]
    N --> D
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/dev..."](https://github.com/xpadev-net/niconicomments/commit/b2b0536d9f1f5aed31478f6adfebc3217b0a6b51) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35587557)</sub>

<!-- /greptile_comment -->