### PR TITLE
SEC-06: tighten sample script policy and render loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,22 @@ npm： https://www.npmjs.com/package/@xpadev-net/niconicomments
 
 ## Installation
 
+CDN から読み込む場合は、可変エイリアスではなく固定バージョンを指定してください。
+
 ```html
 <script src="https://cdn.jsdelivr.net/npm/@xpadev-net/niconicomments@0.2.78/dist/bundle.min.js"></script>
 ```
 
 or
 
-```
+```shell
 npm i @xpadev-net/niconicomments
+```
+
+npm で読み込む場合:
+
+```javascript
+import NiconiComments from "@xpadev-net/niconicomments";
 ```
 
 ## Examples
@@ -34,10 +42,40 @@ const req = await fetch("sample.json");
 const res = await req.json();
 const niconiComments = new NiconiComments(canvas, res);
 //video.ontimeupdateを使用すると、呼び出し回数の関係でコメントカクつく
-setInterval(
-  () => niconiComments.drawCanvas(video.currentTime * 100),
-  10
-);
+let animationFrameId = null;
+
+const stopDrawing = () => {
+  if (animationFrameId === null) return;
+  cancelAnimationFrame(animationFrameId);
+  animationFrameId = null;
+};
+
+const draw = () => {
+  animationFrameId = null;
+  niconiComments.drawCanvas(video.currentTime * 100);
+  if (!video.paused && document.visibilityState !== "hidden") {
+    animationFrameId = requestAnimationFrame(draw);
+  }
+};
+
+const startDrawing = () => {
+  if (animationFrameId === null && document.visibilityState !== "hidden") {
+    animationFrameId = requestAnimationFrame(draw);
+  }
+};
+
+video.addEventListener("play", startDrawing);
+video.addEventListener("pause", () => {
+  stopDrawing();
+  niconiComments.drawCanvas(video.currentTime * 100);
+});
+document.addEventListener("visibilitychange", () => {
+  if (document.visibilityState === "hidden" || video.paused) {
+    stopDrawing();
+  } else {
+    startDrawing();
+  }
+});
 ```
 
 ## Sample

--- a/docs/sample/index.html
+++ b/docs/sample/index.html
@@ -86,19 +86,19 @@
     <label>
       <span data-i18n="ncVersion"></span>
       <select name="nc-version" id="nc-version" autocomplete="off">
-        <option value="dev" data-i18n="devBuild"></option>
+        <option value="0.2.78">0.2.78</option>
       </select>
     </label>
     <label>
       <span data-i18n="pluginVersion"></span>
       <select name="plugin-version" id="plugin-version" autocomplete="off">
-        <option value="latest">latest</option>
+        <option value="0.0.13">0.0.13</option>
       </select>
     </label>
     <label>
       <span data-i18n="niwangoVersion"></span>
       <select name="niwango-version" id="niwango-version" autocomplete="off">
-        <option value="dev-build" data-i18n="devBuild"></option>
+        <option value="0.0.1-canary.20231002-1">0.0.1-canary.20231002-1</option>
       </select>
     </label>
     <div id="toggle"><p>&lt;</p></div>

--- a/docs/sample/sample.js
+++ b/docs/sample/sample.js
@@ -1,22 +1,18 @@
-const NC_DEV_URL =
-  "https://cdn.jsdelivr.net/gh/xpadev-net/niconicomments@dev-build/dist/bundle.js";
-const NIWANGO_DEV_URL =
-  "https://cdn.jsdelivr.net/gh/xpadev-net/niwango.js@dev-build/dist/bundle.js";
-const DEFAULT_NC_VERSION = "dev";
-const DEFAULT_PLUGIN_VERSION = "latest";
-const DEFAULT_NIWANGO_VERSION = "dev-build";
+const DEFAULT_NC_VERSION = "0.2.78";
+const DEFAULT_PLUGIN_VERSION = "0.0.13";
+const DEFAULT_NIWANGO_VERSION = "0.0.1-canary.20231002-1";
 const MAX_VERSION_LENGTH = 64;
 const VERSION_PARAM_CONFIG = {
   ncVersion: {
-    aliases: new Set([DEFAULT_NC_VERSION]),
+    aliases: new Set(),
     defaultValue: DEFAULT_NC_VERSION,
   },
   pluginVersion: {
-    aliases: new Set([DEFAULT_PLUGIN_VERSION]),
+    aliases: new Set(),
     defaultValue: DEFAULT_PLUGIN_VERSION,
   },
   niwangoVersion: {
-    aliases: new Set([DEFAULT_NIWANGO_VERSION]),
+    aliases: new Set(),
     defaultValue: DEFAULT_NIWANGO_VERSION,
   },
 };
@@ -117,15 +113,11 @@ const loadScript = (src) =>
 
 const encodeVersionForUrl = (value) => encodeURIComponent(value);
 const getNCUrl = (v) =>
-  v === "dev"
-    ? NC_DEV_URL
-    : `https://cdn.jsdelivr.net/npm/@xpadev-net/niconicomments@${encodeVersionForUrl(v)}/dist/bundle.min.js`;
+  `https://cdn.jsdelivr.net/npm/@xpadev-net/niconicomments@${encodeVersionForUrl(v)}/dist/bundle.min.js`;
 const getPluginUrl = (v) =>
   `https://cdn.jsdelivr.net/npm/@xpadev-net/niconicomments-plugin-niwango@${encodeVersionForUrl(v)}/dist/bundle.min.js`;
 const getNiwangoUrl = (v) =>
-  v === "dev-build"
-    ? NIWANGO_DEV_URL
-    : `https://cdn.jsdelivr.net/npm/@xpadev-net/niwango@${encodeVersionForUrl(v)}/dist/bundle.js`;
+  `https://cdn.jsdelivr.net/npm/@xpadev-net/niwango@${encodeVersionForUrl(v)}/dist/bundle.js`;
 
 let resolveScripts;
 let scriptsLoadError = null;
@@ -382,7 +374,7 @@ let player,
   isPaused = true,
   duration = 0,
   seekDragging = false,
-  interval = null,
+  animationFrameId = null,
   loadGeneration = 0,
   nicoLoadId = 0,
   videoChangeGeneration = 0;
@@ -577,6 +569,34 @@ const updateTime = (currentTime_, paused) => {
   }
 };
 
+const shouldRunRenderLoop = () =>
+  Boolean(nico && !isPaused && document.visibilityState !== "hidden");
+
+const stopRenderLoop = () => {
+  if (animationFrameId === null) return;
+  cancelAnimationFrame(animationFrameId);
+  animationFrameId = null;
+};
+
+const scheduleRenderLoop = () => {
+  if (animationFrameId !== null || !shouldRunRenderLoop()) return;
+  animationFrameId = requestAnimationFrame(renderFrame);
+};
+
+const updateRenderLoop = () => {
+  if (shouldRunRenderLoop()) {
+    scheduleRenderLoop();
+  } else {
+    stopRenderLoop();
+  }
+};
+
+const renderFrame = () => {
+  animationFrameId = null;
+  updateCanvas();
+  scheduleRenderLoop();
+};
+
 const updateCanvas = () => {
   if (!nico) return;
   let vpos;
@@ -632,13 +652,16 @@ const loadComments = async () => {
   document.body.appendChild(elem);
   const background = getById(videos, video).bg;
   backgroundElement.style.background = background || "none";
+  let didSeek = false;
   if (time >= 0) {
     seekTo(time);
     time = -1;
+    didSeek = true;
   }
-  if (!interval) {
-    interval = setInterval(updateCanvas, 1);
+  if (!didSeek) {
+    updateCanvas();
   }
+  updateRenderLoop();
   if (debug) {
     const handler = (e) => {
       console.log(e);
@@ -668,8 +691,7 @@ const loadVideo = async () => {
   isPaused = true;
   videoMicroSec = false;
   nico = undefined;
-  clearInterval(interval);
-  interval = null;
+  stopRenderLoop();
   resetVideoControls();
   if (videoItem.yt) {
     await loadYTVideo(videoItem.yt);
@@ -749,6 +771,7 @@ const loadYTVideo = (ytId) => {
           isPaused = e.data !== YT.PlayerState.PLAYING;
           updateTime(currentTime, isPaused);
           updatePlayPauseButton();
+          updateRenderLoop();
           const d = player.getDuration();
           if (d > 0 && duration !== d) {
             duration = d;
@@ -766,6 +789,7 @@ const loadYTVideo = (ytId) => {
 
 const seekTo = (time_) => {
   currentTime = time_;
+  updateTime(currentTime, isPaused);
   if (player) {
     player.seekTo(time_, true);
   } else {
@@ -781,6 +805,8 @@ const seekTo = (time_) => {
       "https://embed.nicovideo.jp",
     );
   }
+  updateCanvas();
+  updateRenderLoop();
 };
 
 const togglePlayback = () => {
@@ -891,12 +917,17 @@ window.addEventListener("message", (e) => {
       vcSeekElement.disabled = false;
     }
     updateTime(currentTime, isPaused);
+    updateRenderLoop();
   } else if (e.data.eventName === "playerStatusChange") {
     isPaused = e.data.data.playerStatus !== 2;
     updateTime(currentTime, isPaused);
     updatePlayPauseButton();
+    updateRenderLoop();
   }
 });
+
+document.addEventListener("visibilitychange", updateRenderLoop);
+window.addEventListener("pagehide", stopRenderLoop);
 
 // --- Main initialization ---
 const onYouTubeIframeAPIReady = async () => {


### PR DESCRIPTION
## Summary
- Replace sample plugin/CDN defaults with fixed published versions and remove mutable dev-build/latest loader paths from the public sample.
- Move the sample render loop from a 1ms setInterval to requestAnimationFrame with pause, visibility, pagehide, seek, and load lifecycle handling.
- Update README guidance to recommend fixed CDN versions and show a requestAnimationFrame drawing example.

## Validation
- git diff --check
- node --check docs/sample/sample.js
- python3 HTMLParser parse of docs/sample/index.html
- rg confirmed no setInterval(updateCanvas, 1), clearInterval timer loop, or mutable CDN branch/latest URLs in README/docs sample/typedoc workflow scope
- npm exec --package=@biomejs/biome@2.4.16 -- biome check src docs/sample/sample.js (exit 0; reported existing warnings in src/typeGuard.ts outside this task scope)

## Review
- deep-review self-review focused on docs/sample security, render-loop lifecycle, and CDN policy
- independent subagent review found duplicate initial paused draw for ?time=; fixed before PR

## Notes
- npm run lint was attempted first but local node_modules are not installed in this worktree, so biome was not on PATH; the pinned npm exec Biome command above was used instead.
- npm run check-types was not run because src/** was not modified and this is a docs/sample-only change.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR tightens the sample page's CDN and render-loop policies: it replaces mutable `dev`/`latest`/`dev-build` version aliases with pinned semver strings in both `index.html` and `sample.js`, and swaps the 1 ms `setInterval` render loop for a `requestAnimationFrame` loop with proper lifecycle guards (`visibilitychange`, `pagehide`, seek, load).

- **CDN policy**: mutable GitHub branch URL constants and their special-case branches in `getNCUrl`/`getNiwangoUrl` are removed; all scripts now always go through the versioned jsDelivr/npm path, and the `aliases` Sets that previously allowed `dev`/`latest`/`dev-build` query-param overrides are now empty, so those values are rejected and the URL is sanitised to the pinned default.
- **Render loop**: `setInterval(updateCanvas, 1)` is replaced by a `requestAnimationFrame` chain driven by `shouldRunRenderLoop` (`nico && !isPaused && visibilityState !== \"hidden\"`); `stopRenderLoop`/`scheduleRenderLoop`/`updateRenderLoop` are wired into every state-change site (YouTube `onStateChange`, NicoNico `playerStatusChange`/`playerMetadataChange`, `visibilitychange`, `pagehide`, `seekTo`, and `loadComments`).
- **README**: updates the install snippet to recommend fixed CDN versions and replaces the `setInterval` usage example with the `requestAnimationFrame` pattern.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; changes are confined to the docs sample page and README, with no modifications to the library source. The render-loop rewrite is well-structured and handles all relevant lifecycle events.

The CDN-policy hardening and render-loop replacement are correct and complete. The one gap is in the README documentation example, which does not include a `seeked` handler: a developer copying the snippet verbatim would find the comment overlay frozen whenever they seek while paused. The `sample.js` itself handles this correctly inside `seekTo`, so the live sample page is unaffected.

README.md — the `requestAnimationFrame` code example omits a `seeked` listener, leaving the canvas stale on pause+seek for anyone following the snippet.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Updated CDN install guidance to recommend fixed versions and replaced the setInterval example with a requestAnimationFrame loop; the example is mostly correct but lacks a `seeked` handler so the canvas goes stale when paused and the user scrubs. |
| docs/sample/index.html | Replaced mutable `dev`/`latest`/`dev-build` dropdown defaults with pinned semver strings (nc 0.2.78, plugin 0.0.13, niwango 0.0.1-canary.20231002-1); straightforward and correct change. |
| docs/sample/sample.js | Removed mutable dev-build URL constants and special-case branches; replaced setInterval render loop with a requestAnimationFrame pattern guarded by `shouldRunRenderLoop`; added `visibilitychange` and `pagehide` listeners; lifecycle handling across YouTube and NicoNico embed paths looks complete and correct. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[State change event\ne.g. play / pause / seek /\nvisibilitychange / load] --> B[updateRenderLoop]
    B --> C{shouldRunRenderLoop?\nico && !isPaused &&\nvisibility !== hidden}
    C -- yes --> D[scheduleRenderLoop]
    C -- no --> E[stopRenderLoop\ncancelAnimationFrame]
    D --> F{animationFrameId\nalready set?}
    F -- yes --> G[no-op\nloop already running]
    F -- no --> H[requestAnimationFrame\nrenderFrame]
    H --> I[renderFrame fires]
    I --> J[animationFrameId = null]
    J --> K[updateCanvas\ndrawCanvas at current vpos]
    K --> L[scheduleRenderLoop\nre-enter loop?]
    L --> C
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0AREADME.md%3A56-74%0A**Missing%20%60seeked%60%20handler%20leaves%20canvas%20stale%20when%20paused%2Bseeked**%0A%0AThe%20README%20example%20stops%20the%20draw%20loop%20on%20%60pause%60%20and%20on%20%60visibilitychange%60%20%28when%20paused%29%2C%20but%20there%20is%20no%20%60seeked%60%20listener.%20If%20the%20user%20pauses%20the%20video%20and%20then%20scrubs%20to%20a%20new%20position%2C%20%60video.currentTime%60%20changes%20but%20no%20%60draw%28%29%60%20call%20is%20triggered%2C%20so%20the%20comment%20overlay%20freezes%20on%20the%20frame%20where%20playback%20was%20paused.%20The%20%60sample.js%60%20avoids%20this%20by%20calling%20%60updateCanvas%28%29%60%20explicitly%20inside%20its%20%60seekTo%28%29%60%20wrapper%2C%20but%20a%20developer%20copying%20the%20README%20snippet%20would%20miss%20this%20case.%0A%0A&repo=xpadev-net%2Fniconicomments&pr=303&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
README.md:56-74
**Missing `seeked` handler leaves canvas stale when paused+seeked**

The README example stops the draw loop on `pause` and on `visibilitychange` (when paused), but there is no `seeked` listener. If the user pauses the video and then scrubs to a new position, `video.currentTime` changes but no `draw()` call is triggered, so the comment overlay freezes on the frame where playback was paused. The `sample.js` avoids this by calling `updateCanvas()` explicitly inside its `seekTo()` wrapper, but a developer copying the README snippet would miss this case.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: tighten sample script policy and r..."](https://github.com/xpadev-net/niconicomments/commit/14fb06ddc7f4be33e367412c61070124fdb6615c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35588778)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->