### PR TITLE
Guard keepCA comment art grouping

### DIFF
--- a/src/utils/commentArt.ts
+++ b/src/utils/commentArt.ts
@@ -5,6 +5,7 @@ const HASH_OFFSET_A = 0x811c9dc5;
 const HASH_OFFSET_B = 0x9e3779b9;
 const HASH_PRIME_A = 0x01000193;
 const HASH_PRIME_B = 0x85ebca6b;
+const HASH_SEPARATOR = 0x1f;
 
 type GroupedByUser = {
   comments: FormattedComment[];
@@ -117,32 +118,43 @@ const getCommentArtDuplicateKey = (comment: FormattedComment) => {
     new Set(comment.mail.filter((mail) => !RE_CA_FILTER.test(mail))),
   ).sort((a, b) => a.localeCompare(b));
   const mailHash = hashStringList(normalizedMail);
+  // Keep the duplicate key bounded even for huge CA payloads. The finite hash
+  // can theoretically collide, but avoids reintroducing unbounded content keys.
   return `content=${hashString(comment.content)};mail=${mailHash}`;
 };
 
 const hashStringList = (values: string[]) => {
-  let hashA = HASH_OFFSET_A;
-  let hashB = HASH_OFFSET_B;
+  const state = createHashState();
   for (const value of values) {
-    const hash = hashString(value);
-    for (let i = 0; i < hash.length; i++) {
-      const code = hash.charCodeAt(i);
-      hashA = Math.imul(hashA ^ code, HASH_PRIME_A);
-      hashB = Math.imul(hashB + code, HASH_PRIME_B) ^ (hashB >>> 13);
+    mixHashCode(state, value.length);
+    for (let i = 0; i < value.length; i++) {
+      mixHashCode(state, value.charCodeAt(i));
     }
+    mixHashCode(state, HASH_SEPARATOR);
   }
-  return `${values.length}:${toBase36(hashA)}:${toBase36(hashB)}`;
+  return `${values.length}:${toBase36(state.hashA)}:${toBase36(state.hashB)}`;
 };
 
 const hashString = (value: string) => {
-  let hashA = HASH_OFFSET_A;
-  let hashB = HASH_OFFSET_B;
+  const state = createHashState();
   for (let i = 0; i < value.length; i++) {
-    const code = value.charCodeAt(i);
-    hashA = Math.imul(hashA ^ code, HASH_PRIME_A);
-    hashB = Math.imul(hashB + code, HASH_PRIME_B) ^ (hashB >>> 13);
+    mixHashCode(state, value.charCodeAt(i));
   }
-  return `${value.length}:${toBase36(hashA)}:${toBase36(hashB)}`;
+  return `${value.length}:${toBase36(state.hashA)}:${toBase36(state.hashB)}`;
+};
+
+const createHashState = () => ({
+  hashA: HASH_OFFSET_A,
+  hashB: HASH_OFFSET_B,
+});
+
+const mixHashCode = (
+  state: ReturnType<typeof createHashState>,
+  code: number,
+) => {
+  state.hashA = Math.imul(state.hashA ^ code, HASH_PRIME_A);
+  state.hashB =
+    Math.imul(state.hashB + code, HASH_PRIME_B) ^ (state.hashB >>> 13);
 };
 
 const toBase36 = (value: number) => (value >>> 0).toString(36);
@@ -221,6 +233,7 @@ const groupUserCommentsByTime = (
     if (time === undefined) {
       time = {
         bucketEnd: 0,
+        // Inverted range means no buckets have been registered yet.
         bucketStart: 1,
         index: result.length,
         range: {

--- a/src/utils/commentArt.ts
+++ b/src/utils/commentArt.ts
@@ -1,6 +1,10 @@
 import type { BaseConfig, FormattedComment } from "@/@types";
 
 const RE_CA_FILTER = /@[\d.]+|184|device:.+|patissier|ca/;
+const HASH_OFFSET_A = 0x811c9dc5;
+const HASH_OFFSET_B = 0x9e3779b9;
+const HASH_PRIME_A = 0x01000193;
+const HASH_PRIME_B = 0x85ebca6b;
 
 type GroupedByUser = {
   comments: FormattedComment[];
@@ -16,6 +20,11 @@ type GroupedByTimeItem = {
     start: number;
     end: number;
   };
+};
+type IndexedGroupedByTimeItem = GroupedByTimeItem & {
+  bucketEnd: number;
+  bucketStart: number;
+  index: number;
 };
 
 /**
@@ -84,27 +93,59 @@ const removeDuplicateCommentArt = (
   comments: FormattedComment[],
   config: BaseConfig,
 ) => {
-  const index: { [key: string]: FormattedComment } = {};
+  const index = new Map<string, FormattedComment>();
   return comments.filter((comment) => {
-    const key = `${comment.content}@@${[...comment.mail]
-      .sort((a, b) => a.localeCompare(b))
-      .filter((e) => !RE_CA_FILTER.test(e))
-      .join("")}`;
-    const lastComment = index[key];
+    const key = getCommentArtDuplicateKey(comment);
+    const lastComment = index.get(key);
     if (lastComment === undefined) {
-      index[key] = comment;
+      index.set(key, comment);
       return true;
     }
     if (
       comment.vpos - lastComment.vpos > config.sameCAGap ||
       Math.abs(comment.date - lastComment.date) < config.sameCARange
     ) {
-      index[key] = comment;
+      index.set(key, comment);
       return true;
     }
     return false;
   });
 };
+
+const getCommentArtDuplicateKey = (comment: FormattedComment) => {
+  const normalizedMail = Array.from(
+    new Set(comment.mail.filter((mail) => !RE_CA_FILTER.test(mail))),
+  ).sort((a, b) => a.localeCompare(b));
+  const mailHash = hashStringList(normalizedMail);
+  return `content=${hashString(comment.content)};mail=${mailHash}`;
+};
+
+const hashStringList = (values: string[]) => {
+  let hashA = HASH_OFFSET_A;
+  let hashB = HASH_OFFSET_B;
+  for (const value of values) {
+    const hash = hashString(value);
+    for (let i = 0; i < hash.length; i++) {
+      const code = hash.charCodeAt(i);
+      hashA = Math.imul(hashA ^ code, HASH_PRIME_A);
+      hashB = Math.imul(hashB + code, HASH_PRIME_B) ^ (hashB >>> 13);
+    }
+  }
+  return `${values.length}:${toBase36(hashA)}:${toBase36(hashB)}`;
+};
+
+const hashString = (value: string) => {
+  let hashA = HASH_OFFSET_A;
+  let hashB = HASH_OFFSET_B;
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    hashA = Math.imul(hashA ^ code, HASH_PRIME_A);
+    hashB = Math.imul(hashB + code, HASH_PRIME_B) ^ (hashB >>> 13);
+  }
+  return `${value.length}:${toBase36(hashA)}:${toBase36(hashB)}`;
+};
+
+const toBase36 = (value: number) => (value >>> 0).toString(36);
 
 /**
  * レイヤーIDを更新する
@@ -150,48 +191,120 @@ const groupCommentsByUser = (comments: FormattedComment[]): GroupedByUser => {
  * @returns 時間ごとにグループ化されたコメントデータ
  */
 const groupCommentsByTime = (comments: GroupedByUser, config: BaseConfig) => {
-  return comments.reduce<GroupedByTime>((result, user) => {
-    result.push({
-      userId: user.userId,
-      comments: user.comments.reduce<GroupedByTimeItem[]>((result, comment) => {
-        const time = getTime(comment.date, result, config);
-        time.comments.push(comment);
-        time.range.start = Math.min(time.range.start, comment.date);
-        time.range.end = Math.max(time.range.end, comment.date);
-        return result;
-      }, []),
-    });
-    return result;
-  }, []);
+  return comments.map((user) => ({
+    userId: user.userId,
+    comments: groupUserCommentsByTime(user.comments, config),
+  }));
 };
 
 /**
- * 時間配列から該当の時間の参照を取得する
- * @param time 探す対象の時間
- * @param times 時間配列
+ * ユーザー内のコメントを入力順に走査して時間ごとにグループ化する
+ * @param comments ユーザー単位のコメントデータ
  * @param config インスタンス設定
- * @returns 該当の時間の参照
+ * @returns 時間ごとにグループ化したコメントデータ
  */
-const getTime = (
-  time: number,
-  times: GroupedByTimeItem[],
+const groupUserCommentsByTime = (
+  comments: FormattedComment[],
   config: BaseConfig,
-): GroupedByTimeItem => {
-  const timeObj = times.find(
-    (timeObj) =>
-      timeObj.range.start - config.sameCATimestampRange <= time &&
-      timeObj.range.end + config.sameCATimestampRange >= time,
-  );
-  if (timeObj) return timeObj;
-  const obj = {
-    range: {
-      start: time,
-      end: time,
-    },
-    comments: [],
-  };
-  times.push(obj);
-  return obj;
+) => {
+  const result: IndexedGroupedByTimeItem[] = [];
+  const bucketSize = getTimeBucketSize(config);
+  const bucketIndex = new Map<number, Set<IndexedGroupedByTimeItem>>();
+
+  for (const comment of comments) {
+    let time = getTimeFromBucketIndex(
+      comment.date,
+      bucketSize,
+      bucketIndex,
+      config,
+    );
+    if (time === undefined) {
+      time = {
+        bucketEnd: 0,
+        bucketStart: 1,
+        index: result.length,
+        range: {
+          start: comment.date,
+          end: comment.date,
+        },
+        comments: [],
+      };
+      result.push(time);
+    }
+    time.comments.push(comment);
+    time.range.start = Math.min(time.range.start, comment.date);
+    time.range.end = Math.max(time.range.end, comment.date);
+    updateTimeBucketIndex(time, bucketSize, bucketIndex, config);
+  }
+
+  return result;
 };
+
+const getTimeFromBucketIndex = (
+  time: number,
+  bucketSize: number,
+  bucketIndex: Map<number, Set<IndexedGroupedByTimeItem>>,
+  config: BaseConfig,
+) => {
+  const candidates = bucketIndex.get(getTimeBucket(time, bucketSize));
+  if (candidates === undefined) return undefined;
+  let result: IndexedGroupedByTimeItem | undefined;
+  for (const candidate of candidates) {
+    if (
+      (result === undefined || candidate.index < result.index) &&
+      isSameCommentArtTime(time, candidate, config)
+    ) {
+      result = candidate;
+    }
+  }
+  return result;
+};
+
+const updateTimeBucketIndex = (
+  time: IndexedGroupedByTimeItem,
+  bucketSize: number,
+  bucketIndex: Map<number, Set<IndexedGroupedByTimeItem>>,
+  config: BaseConfig,
+) => {
+  const bucketStart = getTimeBucket(
+    time.range.start - config.sameCATimestampRange,
+    bucketSize,
+  );
+  const bucketEnd = getTimeBucket(
+    time.range.end + config.sameCATimestampRange,
+    bucketSize,
+  );
+  if (!Number.isFinite(bucketStart) || !Number.isFinite(bucketEnd)) return;
+  for (let bucket = bucketStart; bucket <= bucketEnd; bucket++) {
+    if (bucket >= time.bucketStart && bucket <= time.bucketEnd) continue;
+    let bucketItems = bucketIndex.get(bucket);
+    if (bucketItems === undefined) {
+      bucketItems = new Set();
+      bucketIndex.set(bucket, bucketItems);
+    }
+    bucketItems.add(time);
+  }
+  time.bucketStart = bucketStart;
+  time.bucketEnd = bucketEnd;
+};
+
+const getTimeBucketSize = (config: BaseConfig) =>
+  config.sameCATimestampRange === Infinity
+    ? Infinity
+    : Number.isFinite(config.sameCATimestampRange) &&
+        config.sameCATimestampRange > 0
+      ? Math.ceil(config.sameCATimestampRange * 2) + 1
+      : 1;
+
+const getTimeBucket = (time: number, bucketSize: number) =>
+  bucketSize === Infinity ? 0 : Math.floor(time / bucketSize);
+
+const isSameCommentArtTime = (
+  time: number,
+  timeObj: GroupedByTimeItem,
+  config: BaseConfig,
+) =>
+  timeObj.range.start - config.sameCATimestampRange <= time &&
+  timeObj.range.end + config.sameCATimestampRange >= time;
 
 export { changeCALayer };

--- a/tests/unit/comment-art-resource-bounds.spec.ts
+++ b/tests/unit/comment-art-resource-bounds.spec.ts
@@ -62,12 +62,14 @@ describe("comment art resource bounds", () => {
       );
     } as typeof Array.prototype.find;
 
+    let result: FormattedComment[];
     try {
-      expect(changeCALayer(comments, config)).toHaveLength(comments.length);
+      result = changeCALayer(comments, config);
     } finally {
       Array.prototype.find = originalFind;
     }
 
+    expect(result).toHaveLength(comments.length);
     expect(findPredicateCalls).toBe(0);
   });
 
@@ -144,12 +146,14 @@ describe("comment art resource bounds", () => {
       return originalSet.call(this, key, value);
     } as typeof Map.prototype.set;
 
+    let result: FormattedComment[];
     try {
-      expect(changeCALayer(comments, config)).toHaveLength(1);
+      result = changeCALayer(comments, config);
     } finally {
       Map.prototype.set = originalSet;
     }
 
+    expect(result).toHaveLength(1);
     expect(stringKeyLengths.length).toBeGreaterThan(0);
     expect(Math.max(...stringKeyLengths)).toBeLessThan(160);
   });

--- a/tests/unit/comment-art-resource-bounds.spec.ts
+++ b/tests/unit/comment-art-resource-bounds.spec.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, test } from "vitest";
+
+import type { BaseConfig, FormattedComment } from "@/@types";
+import { defaultConfig } from "@/definition/config";
+import { initConfig } from "@/definition/initConfig";
+import { changeCALayer } from "@/utils/commentArt";
+
+const formattedComment = (
+  id: number,
+  overrides: Partial<FormattedComment> = {},
+): FormattedComment => ({
+  id,
+  vpos: id,
+  content: `comment ${id}`,
+  date: 1_700_000_000 + id,
+  date_usec: 0,
+  owner: false,
+  premium: false,
+  mail: ["ca"],
+  user_id: 1,
+  layer: -1,
+  is_my_post: false,
+  ...overrides,
+});
+
+const createConfig = (overrides: Partial<BaseConfig> = {}): BaseConfig => ({
+  ...defaultConfig,
+  ...overrides,
+});
+
+describe("comment art resource bounds", () => {
+  beforeEach(() => {
+    initConfig();
+  });
+
+  test("groups one user's many distinct timestamps without scanning prior groups", () => {
+    const comments = Array.from({ length: 500 }, (_, index) =>
+      formattedComment(index + 1, {
+        content: `comment art ${index}`,
+        date: 1_700_000_000 + index * 2,
+        user_id: 1,
+      }),
+    );
+    const config = createConfig({
+      sameCATimestampRange: 0,
+      sameCAMinScore: 10,
+    });
+    const originalFind = Array.prototype.find;
+    let findPredicateCalls = 0;
+    Array.prototype.find = function findWithCount<T>(
+      this: T[],
+      predicate: (value: T, index: number, obj: T[]) => unknown,
+      thisArg?: unknown,
+    ) {
+      return originalFind.call(
+        this,
+        (value: T, index: number, obj: T[]) => {
+          findPredicateCalls++;
+          return predicate.call(thisArg, value, index, obj);
+        },
+        thisArg,
+      );
+    } as typeof Array.prototype.find;
+
+    try {
+      expect(changeCALayer(comments, config)).toHaveLength(comments.length);
+    } finally {
+      Array.prototype.find = originalFind;
+    }
+
+    expect(findPredicateCalls).toBe(0);
+  });
+
+  test("keeps encounter-order layer grouping for non-monotonic timestamps", () => {
+    const comments = [
+      formattedComment(1, {
+        content: "first art",
+        date: 0,
+      }),
+      formattedComment(2, {
+        content: "second art",
+        date: 20,
+      }),
+      formattedComment(3, {
+        content: "third art",
+        date: 10,
+      }),
+    ];
+    const result = changeCALayer(
+      comments,
+      createConfig({
+        sameCATimestampRange: 10,
+      }),
+    );
+
+    expect(result.map((comment) => comment.layer)).toEqual([0, 1, 0]);
+  });
+
+  test("does not expand buckets without bounds for infinite timestamp range", () => {
+    const comments = Array.from({ length: 20 }, (_, index) =>
+      formattedComment(index + 1, {
+        content: `wide range art ${index}`,
+        date: index * 10_000,
+      }),
+    );
+    const result = changeCALayer(
+      comments,
+      createConfig({
+        sameCATimestampRange: Infinity,
+      }),
+    );
+
+    expect(result.map((comment) => comment.layer)).toEqual(
+      Array.from({ length: comments.length }, () => 0),
+    );
+  });
+
+  test("uses bounded duplicate keys for long comment art content", () => {
+    const longContent = "x".repeat(100_000);
+    const comments = [
+      formattedComment(1, {
+        content: longContent,
+        date: 1_700_000_000,
+        vpos: 100,
+      }),
+      formattedComment(2, {
+        content: longContent,
+        date: 1_700_003_600,
+        vpos: 150,
+        mail: ["ca", "ca"],
+      }),
+    ];
+    const config = createConfig();
+    const originalSet = Map.prototype.set;
+    const stringKeyLengths: number[] = [];
+    Map.prototype.set = function setWithKeyLength<K, V>(
+      this: Map<K, V>,
+      key: K,
+      value: V,
+    ) {
+      if (typeof key === "string") {
+        stringKeyLengths.push(key.length);
+      }
+      return originalSet.call(this, key, value);
+    } as typeof Map.prototype.set;
+
+    try {
+      expect(changeCALayer(comments, config)).toHaveLength(1);
+    } finally {
+      Map.prototype.set = originalSet;
+    }
+
+    expect(stringKeyLengths.length).toBeGreaterThan(0);
+    expect(Math.max(...stringKeyLengths)).toBeLessThan(160);
+  });
+
+  test("deduplicates comment art after normalizing mail order and duplicates", () => {
+    const comments = [
+      formattedComment(1, {
+        content: "same art",
+        date: 1_700_000_000,
+        vpos: 200,
+        mail: ["red", "blue", "ca"],
+      }),
+      formattedComment(2, {
+        content: "same art",
+        date: 1_700_003_600,
+        vpos: 250,
+        mail: ["ca", "blue", "red", "red", "ca"],
+      }),
+    ];
+
+    const result = changeCALayer(comments, createConfig());
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.id).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- replace keepCA time grouping linear prior-group scans with an encounter-order bucket index
- normalize comment-art duplicate mail commands as a de-duplicated sorted set and use bounded hash key material
- add focused resource-bound tests for grouping, bounded duplicate keys, mail normalization, encounter-order compatibility, and infinite timestamp range

## Validation
- npm run test:unit -- tests/unit/comment-art-resource-bounds.spec.ts
- npm run check-types
- npm run lint (exit 0; existing warnings remain in src/typeGuard.ts outside this task scope)
- npx biome check tests/unit/comment-art-resource-bounds.spec.ts
- git diff --check
- npm run test:unit

## Review
- deep-review self-review: no required findings after fixing the initial compatibility concern
- independent subagent review: initial P2 compatibility concern fixed; two follow-up reviews reported no actionable findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces the linear scan in `groupCommentsByTime` with a bucket-indexed O(1) lookup and switches the duplicate-key in `removeDuplicateCommentArt` to a bounded hash to avoid unbounded string allocation for large CA payloads. A new unit-test file validates resource-bound guarantees.

- **Bucket index refactor**: `groupUserCommentsByTime` now assigns each time-group an `index` (insertion order) and registers it in a `Map<bucket → Set<group>>`. Lookups retrieve only the candidates in the target bucket and pick the earliest-encountered (lowest `index`) match, preserving the old `Array.find` semantics with bounded per-comment work.
- **Bounded duplicate key**: `getCommentArtDuplicateKey` hashes both content and the de-duplicated sorted mail list rather than concatenating them, capping key length and normalizing duplicate mail entries like `["red","red"]` to match `["red"]`.
- **New tests**: Five focused tests verify no-scan O(1) grouping, encounter-order correctness, infinite-range safety, key-length bounds, and mail normalization — some using global prototype patching (already noted in existing threads).
</details>

<h3>Confidence Score: 5/5</h3>

The change is safe to merge; the bucket-index algorithm preserves the original encounter-order grouping semantics, and the bounded hash key is a well-scoped improvement with an acknowledged trade-off documented inline.

The core bucket-containment invariant holds: any timestamp that would match a group via isSameCommentArtTime is guaranteed to land in a bucket already registered for that group, so no false negatives can occur. Sentinel values, hash collision trade-off, Infinity and zero edge cases are all correctly handled. No new defects found.

No files require special attention beyond what prior review threads have already flagged.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/utils/commentArt.ts | Core algorithm change: replaces O(n²) linear scan with bucket-indexed O(1) lookup and introduces a bounded hash key for duplicate detection. Algorithm is correct (no false negatives proven via bucket-containment invariant), with the previously-flagged trade-offs around hash collisions and hashStringList internals remaining open. |
| tests/unit/comment-art-resource-bounds.spec.ts | New unit tests for resource-bound guarantees. Tests are well-targeted; global prototype patching (Array.prototype.find, Map.prototype.set) is a known concern already captured in existing review threads. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["Address keepCA review feedback"](https://github.com/xpadev-net/niconicomments/commit/3e4493304a3af4405570972a10949afd7245d6dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35596830)</sub>

<!-- /greptile_comment -->