### PR TITLE
Validate init option and config bounds

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -662,7 +662,9 @@ class NiconiComments {
     let startIndex = 0;
     let endIndex = timelineRange.length;
     if (config.commentLimit !== undefined) {
-      if (config.hideCommentOrder === "asc") {
+      if (config.commentLimit === 0) {
+        endIndex = 0;
+      } else if (config.hideCommentOrder === "asc") {
         ({ startIndex, endIndex } = getSliceBounds(
           timelineRange.length,
           -config.commentLimit,

--- a/src/main.ts
+++ b/src/main.ts
@@ -89,6 +89,13 @@ const hasNakaComment = (items: readonly IComment[]) => {
   return hasNaka;
 };
 
+const removeUndefinedConfigValues = (
+  config: NonNullable<Options["config"]>,
+): NonNullable<Options["config"]> =>
+  Object.fromEntries(
+    Object.entries(config).filter(([, value]) => value !== undefined),
+  ) as NonNullable<Options["config"]>;
+
 type DrawCanvasProfile = {
   triggerHandler: number;
   drawVideo: number;
@@ -153,7 +160,11 @@ class NiconiComments {
       throw new InvalidOptionError();
 
     const options = Object.assign({}, defaultOptions, initOptions);
-    const config = Object.assign({}, defaultConfig, options.config);
+    const config = Object.assign(
+      {},
+      defaultConfig,
+      removeUndefinedConfigValues(options.config ?? {}),
+    );
 
     const nicoScripts = createNicoScripts();
     const imageCache = new ImageCacheContext();

--- a/src/typeGuard.ts
+++ b/src/typeGuard.ts
@@ -351,7 +351,7 @@ const isValidConfig = (item: unknown): boolean => {
   };
 
   for (const [key, validator] of Object.entries(validators)) {
-    if (Object.hasOwn(item, key) && !validator(item[key])) {
+    if (item[key] !== undefined && !validator(item[key])) {
       console.warn(
         `[Incorrect input] var: initOptions.config, key: ${key}, value: ${item[key]}`,
       );
@@ -360,6 +360,8 @@ const isValidConfig = (item: unknown): boolean => {
   }
   const width = item.canvasWidth;
   const height = item.canvasHeight;
+  // Single-axis overrides remain within MAX_CANVAS_AREA with today's
+  // 1920x1080 defaults. Revisit this guard if the defaults grow.
   if (
     typeof width === "number" &&
     typeof height === "number" &&
@@ -396,11 +398,11 @@ const typeGuard = {
     apiThread: (i: unknown): i is ApiThread => is(ZApiThread, i),
   },
   xmlDocument: (i: unknown): i is XMLDocument => {
-    if ((i as XMLDocument).documentElement?.nodeName !== "packet") return false;
-    if (!(i as XMLDocument).documentElement.children) return false;
-    for (const element of Array.from(
-      (i as XMLDocument).documentElement.children,
-    )) {
+    if (!isRecord(i)) return false;
+    const document = i as unknown as XMLDocument;
+    if (document.documentElement?.nodeName !== "packet") return false;
+    if (!document.documentElement.children) return false;
+    for (const element of Array.from(document.documentElement.children)) {
       if (element?.nodeName !== "chat") continue;
       if (!typeAttributeVerify(element, ["vpos", "date"])) return false;
     }

--- a/src/typeGuard.ts
+++ b/src/typeGuard.ts
@@ -68,6 +68,20 @@ import {
 } from "@/@types/";
 import { colors } from "@/definition/colors";
 
+const MAX_OPTION_SCALE = 8;
+const MAX_CANVAS_DIMENSION = 8192;
+const MAX_CANVAS_AREA = 16_777_216;
+const MAX_FONT_SIZE = 512;
+const MAX_LINE_HEIGHT = 16;
+const MAX_COMMENT_LIMIT = 10_000;
+const MAX_COMMENT_LINE_COUNT = 256;
+const MAX_COMMENT_RANGE = 86_400_000;
+const MAX_UNIX_TIME_SECONDS = 4_102_444_800;
+const MAX_CONFIG_RATIO = 64;
+const MAX_CONFIG_SPACING = 1024;
+const COMMENT_SIZES = ["big", "medium", "small"] as const;
+const RESIZED_KEYS = ["default", "resized"] as const;
+
 /**
  * 入力がBooleanかどうかを返す
  * @param i 入力
@@ -75,19 +89,291 @@ import { colors } from "@/definition/colors";
  */
 const isBoolean = (i: unknown): i is boolean => typeof i === "boolean";
 
-/**
- * 入力がNumberかどうかを返す
- * @param i 入力
- * @returns 入力がNumberかどうか
- */
-const isNumber = (i: unknown): i is number => typeof i === "number";
+const isRecord = (i: unknown): i is Record<string, unknown> =>
+  typeof i === "object" && i !== null;
 
-/**
- * 入力がObjectかどうかを返す
- * @param i 入力
- * @returns 入力がObjectかどうか
- */
-const isObject = (i: unknown): i is object => typeof i === "object";
+const isFiniteNumberInRange = (
+  i: unknown,
+  {
+    min = 0,
+    max,
+    integer = false,
+  }: { min?: number; max: number; integer?: boolean },
+) =>
+  typeof i === "number" &&
+  Number.isFinite(i) &&
+  i >= min &&
+  i <= max &&
+  (!integer || Number.isInteger(i));
+
+const isValidOptionScale = (i: unknown): i is number =>
+  isFiniteNumberInRange(i, { min: Number.MIN_VALUE, max: MAX_OPTION_SCALE });
+
+const isMode = (i: unknown): boolean =>
+  i === "default" || i === "html5" || i === "flash";
+
+const isHideCommentOrder = (i: unknown): boolean => i === "asc" || i === "desc";
+
+const isBoundedSpacing = (i: unknown): boolean =>
+  isFiniteNumberInRange(i, { max: MAX_CONFIG_SPACING });
+
+const isBoundedOffset = (i: unknown): boolean =>
+  isFiniteNumberInRange(i, {
+    min: -MAX_CONFIG_SPACING,
+    max: MAX_CONFIG_SPACING,
+  });
+
+const hasConfigKeys = (
+  item: Record<string, unknown>,
+  keys: readonly string[],
+): boolean => keys.every((key) => Object.hasOwn(item, key));
+
+const isBoundedNumberConfigItem = (
+  item: unknown,
+  validate: (i: unknown) => boolean,
+): boolean => {
+  if (validate(item)) return true;
+  if (!isRecord(item) || !hasConfigKeys(item, ["html5", "flash"])) {
+    return false;
+  }
+  return validate(item.html5) && validate(item.flash);
+};
+
+const isBoundedResizedItem = (
+  item: unknown,
+  validate: (i: unknown) => boolean,
+): boolean => {
+  if (!isRecord(item) || !hasConfigKeys(item, RESIZED_KEYS)) return false;
+  return RESIZED_KEYS.every((key) => validate(item[key]));
+};
+
+const isBoundedSizeItem = (
+  item: unknown,
+  validate: (i: unknown) => boolean,
+): boolean => {
+  if (!isRecord(item) || !hasConfigKeys(item, COMMENT_SIZES)) return false;
+  return COMMENT_SIZES.every((size) => validate(item[size]));
+};
+
+const isBoundedFontSizeConfig = (item: unknown): boolean =>
+  isBoundedNumberConfigItem(item, (value) =>
+    isBoundedSizeItem(value, (sizeValue) =>
+      isBoundedResizedItem(sizeValue, (resizedValue) =>
+        isFiniteNumberInRange(resizedValue, {
+          min: Number.MIN_VALUE,
+          max: MAX_FONT_SIZE,
+        }),
+      ),
+    ),
+  );
+
+const isBoundedLineHeightConfig = (item: unknown): boolean =>
+  isBoundedNumberConfigItem(item, (value) =>
+    isBoundedSizeItem(value, (sizeValue) =>
+      isBoundedResizedItem(sizeValue, (resizedValue) =>
+        isFiniteNumberInRange(resizedValue, {
+          min: Number.MIN_VALUE,
+          max: MAX_LINE_HEIGHT,
+        }),
+      ),
+    ),
+  );
+
+const isBoundedLineCountsConfig = (item: unknown): boolean =>
+  isBoundedNumberConfigItem(item, (value) => {
+    if (
+      !isRecord(value) ||
+      !hasConfigKeys(value, ["default", "resized", "doubleResized"])
+    ) {
+      return false;
+    }
+    return ["default", "resized", "doubleResized"].every((key) =>
+      isBoundedSizeItem(value[key], (count) =>
+        isFiniteNumberInRange(count, {
+          min: Number.MIN_VALUE,
+          max: MAX_COMMENT_LINE_COUNT,
+        }),
+      ),
+    );
+  });
+
+const isBoundedCommentStageSizeConfig = (item: unknown): boolean =>
+  isBoundedNumberConfigItem(item, (value) => {
+    if (
+      !isRecord(value) ||
+      !hasConfigKeys(value, ["width", "fullWidth", "height"])
+    ) {
+      return false;
+    }
+    return ["width", "fullWidth", "height"].every((key) =>
+      isFiniteNumberInRange(value[key], {
+        min: Number.MIN_VALUE,
+        max: MAX_CANVAS_DIMENSION,
+      }),
+    );
+  });
+
+const isBoundedCollisionRange = (item: unknown): boolean =>
+  isRecord(item) &&
+  hasConfigKeys(item, ["left", "right"]) &&
+  isFiniteNumberInRange(item.left, { max: MAX_CANVAS_DIMENSION }) &&
+  isFiniteNumberInRange(item.right, { max: MAX_CANVAS_DIMENSION });
+
+const isBoundedLineBreakCount = (item: unknown): boolean =>
+  isBoundedSizeItem(item, (count) =>
+    isFiniteNumberInRange(count, {
+      min: 1,
+      max: MAX_COMMENT_LINE_COUNT,
+      integer: true,
+    }),
+  );
+
+const isBoundedFlashDoubleResizeHeights = (item: unknown): boolean => {
+  if (!isRecord(item)) return false;
+  for (const size of Object.keys(item)) {
+    if (!COMMENT_SIZES.includes(size as (typeof COMMENT_SIZES)[number])) {
+      return false;
+    }
+    const heights = item[size];
+    if (!isRecord(heights)) return false;
+    for (const height of Object.values(heights)) {
+      if (!isFiniteNumberInRange(height, { max: MAX_CANVAS_DIMENSION })) {
+        return false;
+      }
+    }
+  }
+  return true;
+};
+
+const isValidPlugins = (item: unknown): boolean =>
+  Array.isArray(item) &&
+  item.every(
+    (plugin) =>
+      typeof plugin === "function" &&
+      typeof (plugin as { id?: unknown }).id === "string",
+  );
+
+const isValidCommentPlugins = (item: unknown): boolean =>
+  Array.isArray(item) &&
+  item.every(
+    (plugin) =>
+      isRecord(plugin) &&
+      typeof plugin.class === "function" &&
+      typeof plugin.condition === "function",
+  );
+
+const isValidCommentLimit = (item: unknown): boolean =>
+  item === undefined ||
+  isFiniteNumberInRange(item, {
+    max: MAX_COMMENT_LIMIT,
+    integer: true,
+  });
+
+const isValidConfig = (item: unknown): boolean => {
+  if (!isRecord(item)) return false;
+  const validators: Record<string, (i: unknown) => boolean> = {
+    cacheAge: (i) => isFiniteNumberInRange(i, { max: MAX_COMMENT_RANGE }),
+    canvasHeight: (i) =>
+      isFiniteNumberInRange(i, {
+        min: 1,
+        max: MAX_CANVAS_DIMENSION,
+      }),
+    canvasWidth: (i) =>
+      isFiniteNumberInRange(i, {
+        min: 1,
+        max: MAX_CANVAS_DIMENSION,
+      }),
+    atButtonPadding: isBoundedSpacing,
+    atButtonRadius: isBoundedSpacing,
+    collisionPadding: isBoundedSpacing,
+    collisionRange: isBoundedCollisionRange,
+    commentDrawPadding: (i) =>
+      isFiniteNumberInRange(i, { max: MAX_CANVAS_DIMENSION }),
+    commentDrawRange: (i) =>
+      isFiniteNumberInRange(i, { max: MAX_CANVAS_DIMENSION }),
+    commentLimit: isValidCommentLimit,
+    commentPlugins: isValidCommentPlugins,
+    commentScale: (i) =>
+      isBoundedNumberConfigItem(i, (value) =>
+        isFiniteNumberInRange(value, {
+          min: Number.MIN_VALUE,
+          max: MAX_CONFIG_RATIO,
+        }),
+      ),
+    commentStageSize: isBoundedCommentStageSizeConfig,
+    contextLineWidth: (i) =>
+      isBoundedNumberConfigItem(i, (value) =>
+        isFiniteNumberInRange(value, { max: MAX_CONFIG_SPACING }),
+      ),
+    contextStrokeOpacity: (i) => isFiniteNumberInRange(i, { max: 1 }),
+    contextFillLiveOpacity: (i) => isFiniteNumberInRange(i, { max: 1 }),
+    flashLetterSpacing: (i) =>
+      isFiniteNumberInRange(i, { max: MAX_CONFIG_SPACING }),
+    flashCommentYPaddingTop: (i) => isBoundedResizedItem(i, isBoundedSpacing),
+    flashCommentYOffset: (i) =>
+      isBoundedSizeItem(i, (sizeValue) =>
+        isBoundedResizedItem(sizeValue, isBoundedOffset),
+      ),
+    flashDoubleResizeHeights: isBoundedFlashDoubleResizeHeights,
+    flashLineBreakScale: (i) =>
+      isBoundedSizeItem(i, (value) =>
+        isFiniteNumberInRange(value, {
+          min: Number.MIN_VALUE,
+          max: MAX_CONFIG_RATIO,
+        }),
+      ),
+    flashScriptCharOffset: (i) =>
+      isFiniteNumberInRange(i, { max: MAX_CONFIG_RATIO }),
+    flashThreshold: (i) =>
+      isFiniteNumberInRange(i, { max: MAX_UNIX_TIME_SECONDS }),
+    fontSize: isBoundedFontSizeConfig,
+    fpsInterval: (i) => isFiniteNumberInRange(i, { max: MAX_COMMENT_RANGE }),
+    hideCommentOrder: isHideCommentOrder,
+    html5HiResCommentCorrection: (i) =>
+      isFiniteNumberInRange(i, { max: MAX_CONFIG_SPACING }),
+    html5LineCounts: isBoundedLineCountsConfig,
+    html5MinFontSize: (i) =>
+      isFiniteNumberInRange(i, {
+        min: Number.MIN_VALUE,
+        max: MAX_FONT_SIZE,
+      }),
+    lineBreakCount: isBoundedLineBreakCount,
+    lineHeight: isBoundedLineHeightConfig,
+    nakaCommentSpeedOffset: (i) =>
+      isFiniteNumberInRange(i, { max: MAX_CONFIG_RATIO }),
+    plugins: isValidPlugins,
+    sameCAGap: (i) => isFiniteNumberInRange(i, { max: MAX_COMMENT_RANGE }),
+    sameCAMinScore: (i) =>
+      isFiniteNumberInRange(i, { max: MAX_COMMENT_LIMIT, integer: true }),
+    sameCARange: (i) => isFiniteNumberInRange(i, { max: MAX_COMMENT_RANGE }),
+    sameCATimestampRange: (i) =>
+      isFiniteNumberInRange(i, { max: MAX_COMMENT_RANGE }),
+  };
+
+  for (const [key, validator] of Object.entries(validators)) {
+    if (Object.hasOwn(item, key) && !validator(item[key])) {
+      console.warn(
+        `[Incorrect input] var: initOptions.config, key: ${key}, value: ${item[key]}`,
+      );
+      return false;
+    }
+  }
+  const width = item.canvasWidth;
+  const height = item.canvasHeight;
+  if (
+    typeof width === "number" &&
+    typeof height === "number" &&
+    width * height > MAX_CANVAS_AREA
+  ) {
+    console.warn(
+      `[Incorrect input] var: initOptions.config, key: canvasArea, value: ${
+        width * height
+      }`,
+    );
+    return false;
+  }
+  return true;
+};
 
 const typeGuard = {
   formatted: {
@@ -110,16 +396,12 @@ const typeGuard = {
     apiThread: (i: unknown): i is ApiThread => is(ZApiThread, i),
   },
   xmlDocument: (i: unknown): i is XMLDocument => {
-    if (
-      !(i as XMLDocument).documentElement ||
-      (i as XMLDocument).documentElement.nodeName !== "packet"
-    )
-      return false;
+    if ((i as XMLDocument).documentElement?.nodeName !== "packet") return false;
     if (!(i as XMLDocument).documentElement.children) return false;
     for (const element of Array.from(
       (i as XMLDocument).documentElement.children,
     )) {
-      if (!element || element.nodeName !== "chat") continue;
+      if (element?.nodeName !== "chat") continue;
       if (!typeAttributeVerify(element, ["vpos", "date"])) return false;
     }
     return true;
@@ -220,8 +502,10 @@ const typeGuard = {
         debug: isBoolean,
         enableLegacyPiP: isBoolean,
         keepCA: isBoolean,
-        scale: isNumber,
-        config: isObject,
+        lazy: isBoolean,
+        mode: isMode,
+        scale: isValidOptionScale,
+        config: isValidConfig,
         format: (i) => is(ZInputFormatType, i),
         video: (i: unknown) => is(optional(instance(HTMLVideoElement)), i),
       };

--- a/tests/unit/init-option-config-bounds.spec.ts
+++ b/tests/unit/init-option-config-bounds.spec.ts
@@ -1,0 +1,279 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { BaseConfig, FormattedComment, IRenderer } from "@/@types";
+import { defaultConfig } from "@/definition/config";
+import { initConfig } from "@/definition/initConfig";
+import { InvalidOptionError } from "@/errors";
+import NiconiComments from "@/main";
+
+type MultiFontSizeConfig = Extract<BaseConfig["fontSize"], { html5: unknown }>;
+
+const textMetrics = (width: number): TextMetrics =>
+  ({
+    width,
+    actualBoundingBoxLeft: 0,
+    actualBoundingBoxRight: width,
+    actualBoundingBoxAscent: 0,
+    actualBoundingBoxDescent: 0,
+    alphabeticBaseline: 0,
+    hangingBaseline: 0,
+    emHeightAscent: 0,
+    emHeightDescent: 0,
+    fontBoundingBoxAscent: 0,
+    fontBoundingBoxDescent: 0,
+    ideographicBaseline: 0,
+  }) as TextMetrics;
+
+class FakeRenderer implements IRenderer {
+  public readonly rendererName = "FakeRenderer";
+  public readonly canvas = {} as HTMLCanvasElement;
+  public drawImageCalls = 0;
+  private font = "";
+  private size = { width: 1920, height: 1080 };
+
+  destroy() {}
+  drawVideo() {}
+  getFont() {
+    return this.font;
+  }
+  getFillStyle() {
+    return "#000000";
+  }
+  setScale() {}
+  fillRect() {}
+  strokeRect() {}
+  fillText() {}
+  strokeText() {}
+  quadraticCurveTo() {}
+  clearRect() {}
+  setFont(font: string) {
+    this.font = font;
+  }
+  setFillStyle() {}
+  setStrokeStyle() {}
+  setLineWidth() {}
+  setGlobalAlpha() {}
+  setSize(width: number, height: number) {
+    this.size = { width, height };
+  }
+  getSize() {
+    return this.size;
+  }
+  measureText(text: string) {
+    const fontSize = Number(/([0-9.]+)px/.exec(this.font)?.[1] ?? 10);
+    return textMetrics(text.length * fontSize * 0.5);
+  }
+  beginPath() {}
+  closePath() {}
+  moveTo() {}
+  lineTo() {}
+  stroke() {}
+  save() {}
+  restore() {}
+  getCanvas() {
+    return this;
+  }
+  drawImage() {
+    this.drawImageCalls++;
+  }
+  flush() {}
+  invalidateImage() {}
+}
+
+const createComment = (id: number): FormattedComment => ({
+  id,
+  vpos: 0,
+  content: `comment ${id}`,
+  date: id,
+  date_usec: 0,
+  owner: false,
+  premium: false,
+  mail: ["ue"],
+  user_id: id,
+  layer: -1,
+  is_my_post: false,
+});
+
+describe("init option and config bounds", () => {
+  beforeEach(() => {
+    initConfig();
+    if (!("HTMLCanvasElement" in globalThis)) {
+      Object.defineProperty(globalThis, "HTMLCanvasElement", {
+        configurable: true,
+        value: class HTMLCanvasElement {},
+      });
+    }
+    let timeoutId = 0;
+    vi.stubGlobal("window", {
+      setTimeout: vi.fn(() => ++timeoutId),
+    });
+    vi.stubGlobal("clearTimeout", vi.fn());
+  });
+
+  test.each([
+    Infinity,
+    Number.NaN,
+    1e9,
+    0,
+  ])("rejects unsafe scale value %s", (scale) => {
+    expect(
+      () =>
+        new NiconiComments(new FakeRenderer(), [], {
+          format: "formatted",
+          mode: "html5",
+          scale,
+        }),
+    ).toThrow(InvalidOptionError);
+  });
+
+  test("rejects config values that can break allocation or loop bounds", () => {
+    const fontSize = defaultConfig.fontSize as MultiFontSizeConfig;
+    expect(
+      () =>
+        new NiconiComments(new FakeRenderer(), [], {
+          format: "formatted",
+          mode: "html5",
+          config: { canvasWidth: 1e9 },
+        }),
+    ).toThrow(InvalidOptionError);
+    expect(
+      () =>
+        new NiconiComments(new FakeRenderer(), [], {
+          format: "formatted",
+          mode: "html5",
+          config: { canvasWidth: Number.MIN_VALUE },
+        }),
+    ).toThrow(InvalidOptionError);
+    expect(
+      () =>
+        new NiconiComments(new FakeRenderer(), [], {
+          format: "formatted",
+          mode: "html5",
+          config: { commentLimit: -1 },
+        }),
+    ).toThrow(InvalidOptionError);
+    expect(
+      () =>
+        new NiconiComments(new FakeRenderer(), [], {
+          format: "formatted",
+          mode: "html5",
+          config: {
+            fontSize: {
+              ...fontSize,
+              html5: {
+                ...fontSize.html5,
+                medium: {
+                  ...fontSize.html5.medium,
+                  default: Infinity,
+                },
+              },
+            },
+          },
+        }),
+    ).toThrow(InvalidOptionError);
+    expect(
+      () =>
+        new NiconiComments(new FakeRenderer(), [], {
+          format: "formatted",
+          mode: "html5",
+          config: { atButtonPadding: Infinity },
+        }),
+    ).toThrow(InvalidOptionError);
+    expect(
+      () =>
+        new NiconiComments(new FakeRenderer(), [], {
+          format: "formatted",
+          mode: "html5",
+          config: {
+            flashCommentYPaddingTop: {
+              default: Infinity,
+              resized: 3,
+            },
+          },
+        }),
+    ).toThrow(InvalidOptionError);
+  });
+
+  test("rejects invalid init and config control values", () => {
+    expect(
+      () =>
+        new NiconiComments(new FakeRenderer(), [], {
+          format: "formatted",
+          lazy: "true" as unknown as boolean,
+          mode: "html5",
+        }),
+    ).toThrow(InvalidOptionError);
+    expect(
+      () =>
+        new NiconiComments(new FakeRenderer(), [], {
+          format: "formatted",
+          mode: "legacy" as "html5",
+        }),
+    ).toThrow(InvalidOptionError);
+    expect(
+      () =>
+        new NiconiComments(new FakeRenderer(), [], {
+          format: "formatted",
+          mode: "html5",
+          config: { hideCommentOrder: "bad" as "asc" },
+        }),
+    ).toThrow(InvalidOptionError);
+    expect(
+      () =>
+        new NiconiComments(new FakeRenderer(), [], {
+          format: "formatted",
+          mode: "html5",
+          config: { plugins: {} as BaseConfig["plugins"] },
+        }),
+    ).toThrow(InvalidOptionError);
+    expect(
+      () =>
+        new NiconiComments(new FakeRenderer(), [], {
+          format: "formatted",
+          mode: "html5",
+          config: { commentPlugins: {} as BaseConfig["commentPlugins"] },
+        }),
+    ).toThrow(InvalidOptionError);
+  });
+
+  test("accepts the explicit default config", () => {
+    expect(
+      () =>
+        new NiconiComments(new FakeRenderer(), [], {
+          format: "formatted",
+          mode: "html5",
+          config: { ...defaultConfig },
+        }),
+    ).not.toThrow();
+  });
+
+  test("treats commentLimit 0 as drawing zero comments", () => {
+    const zeroLimitRenderer = new FakeRenderer();
+    const zeroLimit = new NiconiComments(
+      zeroLimitRenderer,
+      [createComment(1), createComment(2)],
+      {
+        format: "formatted",
+        mode: "html5",
+        config: { commentLimit: 0 },
+      },
+    );
+    zeroLimitRenderer.drawImageCalls = 0;
+    zeroLimit.drawCanvas(0, true);
+
+    const unlimitedRenderer = new FakeRenderer();
+    const unlimited = new NiconiComments(
+      unlimitedRenderer,
+      [createComment(1), createComment(2)],
+      {
+        format: "formatted",
+        mode: "html5",
+      },
+    );
+    unlimitedRenderer.drawImageCalls = 0;
+    unlimited.drawCanvas(0, true);
+
+    expect(zeroLimitRenderer.drawImageCalls).toBe(0);
+    expect(unlimitedRenderer.drawImageCalls).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/init-option-config-bounds.spec.ts
+++ b/tests/unit/init-option-config-bounds.spec.ts
@@ -247,6 +247,20 @@ describe("init option and config bounds", () => {
     ).not.toThrow();
   });
 
+  test("ignores explicit undefined config values and keeps defaults", () => {
+    expect(
+      () =>
+        new NiconiComments(new FakeRenderer(), [], {
+          format: "formatted",
+          mode: "html5",
+          config: {
+            canvasWidth: undefined as unknown as number,
+            commentLimit: undefined,
+          },
+        }),
+    ).not.toThrow();
+  });
+
   test("treats commentLimit 0 as drawing zero comments", () => {
     const zeroLimitRenderer = new FakeRenderer();
     const zeroLimit = new NiconiComments(


### PR DESCRIPTION
## Summary
- reject unsafe init option values such as non-finite/out-of-range scale and invalid lazy/mode controls
- validate resource/control config bounds for canvas sizing, font/line metrics, limits, plugin arrays, and related numeric fields
- define commentLimit: 0 as drawing zero comments

## Validation
- npm run check-types
- npm run lint
- npm run test:unit -- tests/unit/init-option-config-bounds.spec.ts
- npm run test:unit
- git diff --check

## Review
- deep-review self-review completed against final diff
- independent subagent review completed; findings were fixed and final pass reported no actionable findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds comprehensive input validation to `NiconiComments`: the init options now reject unsafe `scale` values (non-finite, zero, > 8), and the config object now validates numeric bounds, plugin arrays, and control enums before they reach any rendering or allocation code. A companion fix makes `commentLimit: 0` an explicit "draw nothing" instruction instead of falling through to `getSliceBounds` with an ambiguous `0` argument.

- **`typeGuard.ts`** — Adds ~280 lines of layered validators (`isFiniteNumberInRange`, `isBoundedSizeItem`, `isBoundedResizedItem`, etc.) that replace the former unchecked `isNumber`/`isObject` passes for `scale` and `config`.
- **`main.ts`** — Introduces `removeUndefinedConfigValues` to strip `undefined` config keys before `Object.assign`, preventing accidental clobbering of defaults; adds an explicit `commentLimit === 0 → endIndex = 0` branch.
- **`tests/unit/init-option-config-bounds.spec.ts`** — New test file covering rejection of out-of-range/non-finite values, invalid control strings, and the `commentLimit: 0` drawing guarantee.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — validation logic is correct and aligns with the BaseConfig type, the commentLimit: 0 fix is unambiguous, and undefined-stripping prevents accidental default clobbering.

The three changed files work together cleanly: validators in typeGuard.ts correctly reflect the BaseConfig type for every numeric and enum field in scope, removeUndefinedConfigValues closes the undefined-overwrite gap, and the new explicit commentLimit: 0 branch eliminates an edge-case in getSliceBounds. Tests cover both rejection and acceptance paths, including the new zero-limit drawing behaviour.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/typeGuard.ts | Core validation layer; replaces bare isNumber/isObject checks with bounded, finite-aware validators across all numeric config fields, plugin arrays, and control enums. Logic is correct and consistent with the BaseConfig type. |
| src/main.ts | Adds removeUndefinedConfigValues to prevent undefined overwriting defaults; adds commentLimit === 0 early-exit branch before getSliceBounds. Both changes are correct. |
| tests/unit/init-option-config-bounds.spec.ts | New test file with good coverage of rejection cases (unsafe scale, out-of-range config, invalid enums, bad plugin shapes) and acceptance cases (default config, explicit undefined values, commentLimit: 0). |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["Address init bounds review findings"](https://github.com/xpadev-net/niconicomments/commit/57002d7fb8f5fd718a81b0c9b7d0a97c6e4a9565) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35601181)</sub>

<!-- /greptile_comment -->