### PR TITLE
SEC-09 harden renderer draw robustness

### DIFF
--- a/src/comments/BaseComment.ts
+++ b/src/comments/BaseComment.ts
@@ -35,6 +35,24 @@ const boundedCachePart = (input: string) => {
   return `${input.slice(0, MAX_CACHE_KEY_EDGE_LENGTH)}\0${input.slice(-MAX_CACHE_KEY_EDGE_LENGTH)}\0${input.length}\0${hashString(input)}`;
 };
 
+const isOutsideStage = (
+  posX: number,
+  posY: number,
+  width: number,
+  height: number,
+  config: BaseConfig,
+) =>
+  !Number.isFinite(posX) ||
+  !Number.isFinite(posY) ||
+  !Number.isFinite(width) ||
+  !Number.isFinite(height) ||
+  width <= 0 ||
+  height <= 0 ||
+  posX >= config.canvasWidth ||
+  posY >= config.canvasHeight ||
+  posX + width <= 0 ||
+  posY + height <= 0;
+
 /**
  * コメントの描画を行うクラスの基底クラス
  */
@@ -205,6 +223,17 @@ class BaseComment implements IComment {
       x: posX,
       y: posY,
     };
+    if (
+      isOutsideStage(
+        posX,
+        posY,
+        this.comment.width,
+        this.comment.height,
+        this.config,
+      )
+    ) {
+      return;
+    }
     this._drawBackgroundColor(posX, posY);
     this._draw(posX, posY, cursor);
     this._drawRectColor(posX, posY);
@@ -236,13 +265,16 @@ class BaseComment implements IComment {
         this.renderer.save();
         this.renderer.setGlobalAlpha(effectiveAlpha);
       }
-      if (this.comment.button && !this.comment.button.hidden) {
-        const button = this.getButtonImage(posX, posY, cursor);
-        button && this.renderer.drawImage(button, posX, posY);
-      }
-      this.renderer.drawImage(this.image, posX, posY);
-      if (effectiveAlpha !== 1) {
-        this.renderer.restore();
+      try {
+        if (this.comment.button && !this.comment.button.hidden) {
+          const button = this.getButtonImage(posX, posY, cursor);
+          button && this.renderer.drawImage(button, posX, posY);
+        }
+        this.renderer.drawImage(this.image, posX, posY);
+      } finally {
+        if (effectiveAlpha !== 1) {
+          this.renderer.restore();
+        }
       }
     }
   }
@@ -255,14 +287,17 @@ class BaseComment implements IComment {
   protected _drawRectColor(posX: number, posY: number) {
     if (this.comment.wakuColor) {
       this.renderer.save();
-      this.renderer.setStrokeStyle(this.comment.wakuColor);
-      this.renderer.strokeRect(
-        posX,
-        posY,
-        this.comment.width,
-        this.comment.height,
-      );
-      this.renderer.restore();
+      try {
+        this.renderer.setStrokeStyle(this.comment.wakuColor);
+        this.renderer.strokeRect(
+          posX,
+          posY,
+          this.comment.width,
+          this.comment.height,
+        );
+      } finally {
+        this.renderer.restore();
+      }
     }
   }
 
@@ -274,14 +309,17 @@ class BaseComment implements IComment {
   protected _drawBackgroundColor(posX: number, posY: number) {
     if (this.comment.fillColor) {
       this.renderer.save();
-      this.renderer.setFillStyle(this.comment.fillColor);
-      this.renderer.fillRect(
-        posX,
-        posY,
-        this.comment.width,
-        this.comment.height,
-      );
-      this.renderer.restore();
+      try {
+        this.renderer.setFillStyle(this.comment.fillColor);
+        this.renderer.fillRect(
+          posX,
+          posY,
+          this.comment.width,
+          this.comment.height,
+        );
+      } finally {
+        this.renderer.restore();
+      }
     }
   }
 
@@ -293,10 +331,13 @@ class BaseComment implements IComment {
   protected _drawDebugInfo(posX: number, posY: number) {
     if (this.ctx.options.debug) {
       this.renderer.save();
-      this.renderer.setFont(parseFont("defont", 30, this.config));
-      this.renderer.setFillStyle("#ff00ff");
-      this.renderer.fillText(this.comment.mail.join(","), posX, posY + 30);
-      this.renderer.restore();
+      try {
+        this.renderer.setFont(parseFont("defont", 30, this.config));
+        this.renderer.setFillStyle("#ff00ff");
+        this.renderer.fillText(this.comment.mail.join(","), posX, posY + 30);
+      } finally {
+        this.renderer.restore();
+      }
     }
   }
 

--- a/src/comments/FlashComment.ts
+++ b/src/comments/FlashComment.ts
@@ -393,34 +393,37 @@ class FlashComment extends BaseComment {
   override _drawCollision(posX: number, posY: number, showCollision: boolean) {
     if (showCollision) {
       this.renderer.save();
-      this.renderer.setStrokeStyle("rgba(255,0,255,1)");
-      this.renderer.strokeRect(
-        posX,
-        posY,
-        this.comment.width,
-        this.comment.height,
-      );
-      for (let i = 0, n = this.comment.lineCount; i < n; i++) {
-        const linePosY =
-          ((i + 1) * (this.comment.fontSize * this.comment.lineHeight) +
-            this.config.flashCommentYPaddingTop[
-              this.comment.resizedY ? "resized" : "default"
-            ]) *
-          this.comment.scale;
-        this.renderer.setStrokeStyle("rgba(255,255,0,0.25)");
+      try {
+        this.renderer.setStrokeStyle("rgba(255,0,255,1)");
         this.renderer.strokeRect(
           posX,
-          posY + linePosY * this._globalScale,
+          posY,
           this.comment.width,
-          this.comment.fontSize *
-            this.comment.lineHeight *
-            -1 *
-            this._globalScale *
-            this.comment.scale *
-            (this.comment.layer === -1 ? this.ctx.options.scale : 1),
+          this.comment.height,
         );
+        for (let i = 0, n = this.comment.lineCount; i < n; i++) {
+          const linePosY =
+            ((i + 1) * (this.comment.fontSize * this.comment.lineHeight) +
+              this.config.flashCommentYPaddingTop[
+                this.comment.resizedY ? "resized" : "default"
+              ]) *
+            this.comment.scale;
+          this.renderer.setStrokeStyle("rgba(255,255,0,0.25)");
+          this.renderer.strokeRect(
+            posX,
+            posY + linePosY * this._globalScale,
+            this.comment.width,
+            this.comment.fontSize *
+              this.comment.lineHeight *
+              -1 *
+              this._globalScale *
+              this.comment.scale *
+              (this.comment.layer === -1 ? this.ctx.options.scale : 1),
+          );
+        }
+      } finally {
+        this.renderer.restore();
       }
-      this.renderer.restore();
     }
   }
 

--- a/src/comments/HTML5Comment.ts
+++ b/src/comments/HTML5Comment.ts
@@ -338,32 +338,35 @@ class HTML5Comment extends BaseComment {
   override _drawCollision(posX: number, posY: number, showCollision: boolean) {
     if (showCollision) {
       this.renderer.save();
-      const scale = getConfig(this.config.commentScale, false);
-      this.renderer.setStrokeStyle("rgba(0,255,255,1)");
-      this.renderer.strokeRect(
-        posX,
-        posY,
-        this.comment.width,
-        this.comment.height,
-      );
-      for (let i = 0, n = this.comment.lineCount; i < n; i++) {
-        if (!typeGuard.internal.HTML5Fonts(this.comment.font))
-          throw new TypeGuardError();
-        const linePosY =
-          (this.comment.lineHeight * (i + 1) +
-            (this.comment.charSize - this.comment.lineHeight) / 2 +
-            this.comment.lineHeight * -0.16 +
-            (this.config.fonts.html5[this.comment.font]?.offset || 0)) *
-          scale;
-        this.renderer.setStrokeStyle("rgba(255,255,0,0.5)");
+      try {
+        const scale = getConfig(this.config.commentScale, false);
+        this.renderer.setStrokeStyle("rgba(0,255,255,1)");
         this.renderer.strokeRect(
           posX,
-          posY + linePosY,
+          posY,
           this.comment.width,
-          this.comment.fontSize * -1 * scale,
+          this.comment.height,
         );
+        for (let i = 0, n = this.comment.lineCount; i < n; i++) {
+          if (!typeGuard.internal.HTML5Fonts(this.comment.font))
+            throw new TypeGuardError();
+          const linePosY =
+            (this.comment.lineHeight * (i + 1) +
+              (this.comment.charSize - this.comment.lineHeight) / 2 +
+              this.comment.lineHeight * -0.16 +
+              (this.config.fonts.html5[this.comment.font]?.offset || 0)) *
+            scale;
+          this.renderer.setStrokeStyle("rgba(255,255,0,0.5)");
+          this.renderer.strokeRect(
+            posX,
+            posY + linePosY,
+            this.comment.width,
+            this.comment.fontSize * -1 * scale,
+          );
+        }
+      } finally {
+        this.renderer.restore();
       }
-      this.renderer.restore();
     }
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -89,6 +89,10 @@ const hasNakaComment = (items: readonly IComment[]) => {
   return hasNaka;
 };
 
+const rendererHasVideoSurface = (renderer: IRenderer) =>
+  "video" in renderer &&
+  (renderer as IRenderer & { readonly video?: unknown }).video != null;
+
 const removeUndefinedConfigValues = (
   config: NonNullable<Options["config"]>,
 ): NonNullable<Options["config"]> =>
@@ -550,7 +554,10 @@ class NiconiComments {
 
     const vposInt = Math.floor(vpos);
     const drawCanvasStart = performance.now();
-    if (this.lastVpos === vpos && !forceRendering) return false;
+    const requiresVideoRedraw = rendererHasVideoSurface(this.renderer);
+    if (this.lastVpos === vpos && !forceRendering && !requiresVideoRedraw) {
+      return false;
+    }
     const triggerHandlerStart = profile ? performance.now() : 0;
     this.eventHandler.trigger(vposInt, this.lastVposInt, this.ctx.nicoScripts);
     setProfile("triggerHandler", triggerHandlerStart);
@@ -573,6 +580,7 @@ class NiconiComments {
     this._cachedSplit = { vpos: vposInt, hasNaka: currentHasNaka };
     if (
       !forceRendering &&
+      !requiresVideoRedraw &&
       this.plugins.length === 0 &&
       !currentHasNaka &&
       !lastHasNaka &&
@@ -743,8 +751,15 @@ class NiconiComments {
           continue;
         }
       }
-      comment.draw(vpos, this.showCollision, cursor, frameActiveState);
-      drawnCount += 1;
+      try {
+        comment.draw(vpos, this.showCollision, cursor, frameActiveState);
+        drawnCount += 1;
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        this._log(
+          `_drawComments: failed to draw comment index=${comment.index}: ${message}`,
+        );
+      }
     }
     return drawnCount;
   }

--- a/tests/unit/renderer-draw-robustness.spec.ts
+++ b/tests/unit/renderer-draw-robustness.spec.ts
@@ -1,0 +1,212 @@
+import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { FormattedComment, IRenderer } from "@/@types";
+import { initConfig } from "@/definition/initConfig";
+import NiconiComments from "@/main";
+
+class HTMLCanvasElementMock {}
+
+const textMetrics = (width: number): TextMetrics =>
+  ({
+    width,
+    actualBoundingBoxLeft: 0,
+    actualBoundingBoxRight: width,
+    actualBoundingBoxAscent: 0,
+    actualBoundingBoxDescent: 0,
+    alphabeticBaseline: 0,
+    hangingBaseline: 0,
+    emHeightAscent: 0,
+    emHeightDescent: 0,
+    fontBoundingBoxAscent: 0,
+    fontBoundingBoxDescent: 0,
+    ideographicBaseline: 0,
+  }) as TextMetrics;
+
+class RecordingRenderer implements IRenderer {
+  public readonly rendererName = "RecordingRenderer";
+  public readonly canvas = {} as HTMLCanvasElement;
+  public readonly children: RecordingRenderer[] = [];
+  public clearRectCalls = 0;
+  public drawImageCalls = 0;
+  public drawImageFailuresRemaining = 0;
+  public drawVideoCalls = 0;
+  public saveDepth = 0;
+  private font = "10px sans-serif";
+  private size = { width: 1920, height: 1080 };
+
+  destroy() {}
+  drawVideo() {
+    this.drawVideoCalls++;
+  }
+  getFont() {
+    return this.font;
+  }
+  getFillStyle() {
+    return "#000000";
+  }
+  setScale() {}
+  fillRect() {}
+  strokeRect() {}
+  fillText() {}
+  strokeText() {}
+  quadraticCurveTo() {}
+  clearRect() {
+    this.clearRectCalls++;
+  }
+  setFont(font: string) {
+    this.font = font;
+  }
+  setFillStyle() {}
+  setStrokeStyle() {}
+  setLineWidth() {}
+  setGlobalAlpha() {}
+  setSize(width: number, height: number) {
+    this.size = { width, height };
+  }
+  getSize() {
+    return this.size;
+  }
+  measureText(text: string) {
+    const fontSize = Number(/([0-9.]+)px/.exec(this.font)?.[1] ?? 10);
+    return textMetrics(text.length * fontSize * 0.5);
+  }
+  beginPath() {}
+  closePath() {}
+  moveTo() {}
+  lineTo() {}
+  stroke() {}
+  save() {
+    this.saveDepth++;
+  }
+  restore() {
+    this.saveDepth--;
+  }
+  getCanvas() {
+    const child = new RecordingRenderer();
+    this.children.push(child);
+    return child;
+  }
+  drawImage() {
+    this.drawImageCalls++;
+    if (this.drawImageFailuresRemaining > 0) {
+      this.drawImageFailuresRemaining--;
+      throw new Error("invalid draw source");
+    }
+  }
+  flush() {}
+  invalidateImage() {}
+}
+
+class VideoSurfaceRenderer extends RecordingRenderer {
+  public readonly video = {} as HTMLVideoElement;
+}
+
+class NullVideoRenderer extends RecordingRenderer {
+  public readonly video = null;
+}
+
+const createComment = (
+  overrides: Partial<FormattedComment> = {},
+): FormattedComment => ({
+  id: overrides.id ?? 1,
+  vpos: overrides.vpos ?? 0,
+  content: overrides.content ?? "test comment",
+  date: overrides.date ?? 1,
+  date_usec: overrides.date_usec ?? 0,
+  owner: overrides.owner ?? false,
+  premium: overrides.premium ?? false,
+  mail: overrides.mail ?? [],
+  user_id: overrides.user_id ?? 1,
+  layer: overrides.layer ?? -1,
+  is_my_post: overrides.is_my_post ?? false,
+});
+
+describe("renderer draw robustness", () => {
+  beforeAll(() => {
+    if (typeof HTMLCanvasElement === "undefined") {
+      Object.defineProperty(globalThis, "HTMLCanvasElement", {
+        value: HTMLCanvasElementMock,
+        configurable: true,
+      });
+    }
+  });
+
+  beforeEach(() => {
+    initConfig();
+    let timeoutId = 0;
+    vi.stubGlobal("window", {
+      setTimeout: vi.fn(() => ++timeoutId),
+    });
+    vi.stubGlobal("clearTimeout", vi.fn());
+  });
+
+  test("culls an offscreen naka lead-in before text image generation", () => {
+    const renderer = new RecordingRenderer();
+    const instance = new NiconiComments(
+      renderer,
+      [createComment({ content: "lead-in", mail: ["@10"] })],
+      { format: "formatted", mode: "html5" },
+    );
+
+    expect(instance.drawCanvas(-250, true)).toBe(true);
+
+    expect(renderer.children).toHaveLength(0);
+    expect(renderer.drawImageCalls).toBe(0);
+  });
+
+  test.each([
+    "html5",
+    "flash",
+  ] as const)("keeps drawing after one %s comment image source fails", (mode) => {
+    const renderer = new RecordingRenderer();
+    renderer.drawImageFailuresRemaining = 1;
+    const instance = new NiconiComments(
+      renderer,
+      [
+        createComment({ id: 1, content: "bad source", mail: ["ue"] }),
+        createComment({
+          id: 2,
+          content: "still draws",
+          mail: ["ue", "nico:opacity:0.5"],
+        }),
+      ],
+      { format: "formatted", mode },
+    );
+
+    expect(() => instance.drawCanvas(0, true)).not.toThrow();
+    expect(renderer.drawImageCalls).toBe(2);
+    expect(renderer.drawImageFailuresRemaining).toBe(0);
+    expect(renderer.saveDepth).toBe(0);
+  });
+
+  test("redraws static frames when the renderer has a video surface", () => {
+    const renderer = new VideoSurfaceRenderer();
+    const instance = new NiconiComments(renderer, [], {
+      format: "formatted",
+      mode: "html5",
+    });
+
+    expect(instance.drawCanvas(1)).toBe(true);
+    expect(instance.drawCanvas(2)).toBe(true);
+    expect(instance.drawCanvas(2)).toBe(true);
+    expect(renderer.clearRectCalls).toBe(3);
+    expect(renderer.drawVideoCalls).toBe(3);
+  });
+
+  test("does not treat a null renderer video property as a video surface", () => {
+    const renderer = new NullVideoRenderer();
+    const instance = new NiconiComments(
+      renderer,
+      [createComment({ content: "static", mail: ["ue"] })],
+      {
+        format: "formatted",
+        mode: "html5",
+      },
+    );
+
+    expect(instance.drawCanvas(1)).toBe(true);
+    expect(instance.drawCanvas(2)).toBe(false);
+    expect(renderer.clearRectCalls).toBe(1);
+    expect(renderer.drawVideoCalls).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Cull fully offscreen comments after updating their draw position so text images and renderer drawImage work are skipped outside the stage.
- Contain per-comment draw failures to the current comment/frame with debug logging and renderer state restoration around saved draw paths.
- Keep video-backed renderers redrawing unchanged static timelines, while ignoring null/nonexistent video surfaces.

## Validation
- npm run check-types
- npm run test:unit -- tests/unit/renderer-draw-robustness.spec.ts tests/unit/html5-resource-bounds.spec.ts tests/unit/flash-resource-bounds.spec.ts tests/unit/duration-lazy.spec.ts
- npm run test:unit
- npm run lint
- git diff --check HEAD~1 HEAD

## Review
- Self-reviewed with deep-review failure/lifecycle, boundary, and test coverage passes.
- Independent subagent review found video detection and state lifecycle issues; fixed before PR.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds three complementary robustness layers to the renderer pipeline: an `isOutsideStage` guard that culls fully offscreen comments before any canvas work is attempted, per-`save`/`restore` try/finally wrapping in every draw helper so renderer context state is always balanced even when an individual operation throws, and a `rendererHasVideoSurface` duck-type check that keeps video-backed renderers redrawing on every frame to stay composited with the video surface.

- **Offscreen culling** (`BaseComment.draw`): position is committed to `this.pos` then the guard exits early, skipping text-image generation and all `drawImage` calls for comments outside the canvas bounds.
- **Per-comment error isolation** (`_drawComments`): a try/catch around each `comment.draw()` prevents a single bad comment from aborting the rest of the frame; each draw helper independently restores renderer state via `finally`.
- **Video-surface forced redraw** (`drawCanvas`): both the same-vpos early-exit and the static-timeline optimisation are bypassed when the renderer exposes a non-null `video` property, ensuring the video frame is always composited with comments.
</details>


<h3>Confidence Score: 4/5</h3>

The core changes are safe and well-tested; two small gaps in the defensive patterns are worth addressing before merge.

The offscreen culling, try/finally state wrapping, and video-surface detection are all well-reasoned and covered by new unit tests. Two gaps remain: the setGlobalAlpha call in _draw sits between save() and the try block, so a throwing custom renderer would leave an unmatched save inconsistent with the hardening goal. Additionally, per-comment draw errors are completely invisible in non-debug production builds.

src/comments/BaseComment.ts — the _draw method's save/setGlobalAlpha placement relative to the try/finally block.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/comments/BaseComment.ts | Adds isOutsideStage culling guard before all draw operations, and wraps each draw helper in try/finally for renderer state safety; setGlobalAlpha in _draw sits outside the try block |
| src/main.ts | Adds rendererHasVideoSurface duck-type check to bypass static-timeline optimisation for video-backed renderers, and wraps per-comment draw in try/catch with debug-only logging |
| src/comments/FlashComment.ts | Wraps _drawCollision body in try/finally so renderer.restore() is guaranteed even if a strokeRect call throws |
| src/comments/HTML5Comment.ts | Wraps _drawCollision body in try/finally; TypeGuardError thrown in the for-loop now correctly triggers restore() before propagating |
| tests/unit/renderer-draw-robustness.spec.ts | New unit test suite covering offscreen culling, per-comment drawImage failure isolation (save-depth balance), video-surface forced redraw, and null-video non-redraw |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["drawCanvas(vpos, force)"] --> B{"lastVpos == vpos\n&& !force\n&& !requiresVideoRedraw?"}
    B -- yes --> Z["return false (no-op)"]
    B -- no --> C["clearRect + _drawVideo"]
    C --> D["static timeline optimisation\n(skipped if requiresVideoRedraw)"]
    D -- skip --> E["_drawComments loop"]
    D -- return false --> Z
    E --> F{"isOutsideStage?"}
    F -- yes --> G["update this.pos, return\n(no canvas ops)"]
    F -- no --> H["_drawBackgroundColor\n_draw  _drawRectColor\n_drawCollision  _drawDebugInfo\n(each in try/finally)"]
    H --> I{"drawImage throws?"}
    I -- yes --> J["finally: renderer.restore()\ndrawnCount NOT incremented\n_log in debug mode only"]
    I -- no --> K["drawnCount += 1"]
    J --> E
    K --> E
    E --> L["_drawFPS / _drawCommentCount\nflush to return true"]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/comments/BaseComment.ts`, line 264-278 ([link](https://github.com/xpadev-net/niconicomments/blob/8f329914fa01c4db1f7c5d5e5c809a275e430548/src/comments/BaseComment.ts#L264-L278)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> `setGlobalAlpha` is called between `save()` and the `try` block. If `setGlobalAlpha` throws (e.g. in a custom renderer or strict test double), the `finally` is never reached, so `restore()` is never called and the renderer context is left with an unmatched `save()`. Since this PR is specifically hardening renderer state lifecycle, both calls should be inside the `try` guard.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/comments/BaseComment.ts
   Line: 264-278

   Comment:
   `setGlobalAlpha` is called between `save()` and the `try` block. If `setGlobalAlpha` throws (e.g. in a custom renderer or strict test double), the `finally` is never reached, so `restore()` is never called and the renderer context is left with an unmatched `save()`. Since this PR is specifically hardening renderer state lifecycle, both calls should be inside the `try` guard.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fcomments%2FBaseComment.ts%0ALine%3A%20264-278%0A%0AComment%3A%0A%60setGlobalAlpha%60%20is%20called%20between%20%60save%28%29%60%20and%20the%20%60try%60%20block.%20If%20%60setGlobalAlpha%60%20throws%20%28e.g.%20in%20a%20custom%20renderer%20or%20strict%20test%20double%29%2C%20the%20%60finally%60%20is%20never%20reached%2C%20so%20%60restore%28%29%60%20is%20never%20called%20and%20the%20renderer%20context%20is%20left%20with%20an%20unmatched%20%60save%28%29%60.%20Since%20this%20PR%20is%20specifically%20hardening%20renderer%20state%20lifecycle%2C%20both%20calls%20should%20be%20inside%20the%20%60try%60%20guard.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20try%20%7B%0A%20%20%20%20%20%20%20%20if%20%28effectiveAlpha%20!%3D%3D%201%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20this.renderer.save%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20this.renderer.setGlobalAlpha%28effectiveAlpha%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20if%20%28this.comment.button%20%26%26%20!this.comment.button.hidden%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20const%20button%20%3D%20this.getButtonImage%28posX%2C%20posY%2C%20cursor%29%3B%0A%20%20%20%20%20%20%20%20%20%20button%20%26%26%20this.renderer.drawImage%28button%2C%20posX%2C%20posY%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20this.renderer.drawImage%28this.image%2C%20posX%2C%20posY%29%3B%0A%20%20%20%20%20%20%7D%20finally%20%7B%0A%20%20%20%20%20%20%20%20if%20%28effectiveAlpha%20!%3D%3D%201%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20this.renderer.restore%28%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=xpadev-net%2Fniconicomments&pr=306&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fcomments%2FBaseComment.ts%3A264-278%0A%60setGlobalAlpha%60%20is%20called%20between%20%60save%28%29%60%20and%20the%20%60try%60%20block.%20If%20%60setGlobalAlpha%60%20throws%20%28e.g.%20in%20a%20custom%20renderer%20or%20strict%20test%20double%29%2C%20the%20%60finally%60%20is%20never%20reached%2C%20so%20%60restore%28%29%60%20is%20never%20called%20and%20the%20renderer%20context%20is%20left%20with%20an%20unmatched%20%60save%28%29%60.%20Since%20this%20PR%20is%20specifically%20hardening%20renderer%20state%20lifecycle%2C%20both%20calls%20should%20be%20inside%20the%20%60try%60%20guard.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20try%20%7B%0A%20%20%20%20%20%20%20%20if%20%28effectiveAlpha%20!%3D%3D%201%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20this.renderer.save%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20this.renderer.setGlobalAlpha%28effectiveAlpha%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20if%20%28this.comment.button%20%26%26%20!this.comment.button.hidden%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20const%20button%20%3D%20this.getButtonImage%28posX%2C%20posY%2C%20cursor%29%3B%0A%20%20%20%20%20%20%20%20%20%20button%20%26%26%20this.renderer.drawImage%28button%2C%20posX%2C%20posY%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20this.renderer.drawImage%28this.image%2C%20posX%2C%20posY%29%3B%0A%20%20%20%20%20%20%7D%20finally%20%7B%0A%20%20%20%20%20%20%20%20if%20%28effectiveAlpha%20!%3D%3D%201%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20this.renderer.restore%28%29%3B%0A%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fmain.ts%3A757-762%0ADraw%20errors%20are%20routed%20through%20%60this._log%60%2C%20which%20only%20emits%20output%20when%20%60ctx.options.debug%60%20is%20%60true%60.%20In%20production%20builds%20every%20per-comment%20rendering%20failure%20is%20completely%20silent%2C%20so%20a%20visual%20glitch%20%28missing%20comment%29%20leaves%20no%20trace%20at%20all.%20At%20minimum%20a%20%60console.warn%60%20%28not%20gated%20on%20%60debug%60%29%20would%20surface%20the%20failure%20to%20integrators%20without%20creating%20debug-mode%20noise.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%7D%20catch%20%28e%29%20%7B%0A%20%20%20%20%20%20%20%20const%20message%20%3D%20e%20instanceof%20Error%20%3F%20e.message%20%3A%20String%28e%29%3B%0A%20%20%20%20%20%20%20%20console.warn%28%0A%20%20%20%20%20%20%20%20%20%20%60%5Bniconicomments%5D%20_drawComments%3A%20failed%20to%20draw%20comment%20index%3D%24%7Bcomment.index%7D%3A%20%24%7Bmessage%7D%60%2C%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20this._log%28%0A%20%20%20%20%20%20%20%20%20%20%60_drawComments%3A%20failed%20to%20draw%20comment%20index%3D%24%7Bcomment.index%7D%3A%20%24%7Bmessage%7D%60%2C%0A%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A&repo=xpadev-net%2Fniconicomments&pr=306&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/comments/BaseComment.ts:264-278
`setGlobalAlpha` is called between `save()` and the `try` block. If `setGlobalAlpha` throws (e.g. in a custom renderer or strict test double), the `finally` is never reached, so `restore()` is never called and the renderer context is left with an unmatched `save()`. Since this PR is specifically hardening renderer state lifecycle, both calls should be inside the `try` guard.

```suggestion
      try {
        if (effectiveAlpha !== 1) {
          this.renderer.save();
          this.renderer.setGlobalAlpha(effectiveAlpha);
        }
        if (this.comment.button && !this.comment.button.hidden) {
          const button = this.getButtonImage(posX, posY, cursor);
          button && this.renderer.drawImage(button, posX, posY);
        }
        this.renderer.drawImage(this.image, posX, posY);
      } finally {
        if (effectiveAlpha !== 1) {
          this.renderer.restore();
        }
      }
```

### Issue 2 of 2
src/main.ts:757-762
Draw errors are routed through `this._log`, which only emits output when `ctx.options.debug` is `true`. In production builds every per-comment rendering failure is completely silent, so a visual glitch (missing comment) leaves no trace at all. At minimum a `console.warn` (not gated on `debug`) would surface the failure to integrators without creating debug-mode noise.

```suggestion
      } catch (e) {
        const message = e instanceof Error ? e.message : String(e);
        console.warn(
          `[niconicomments] _drawComments: failed to draw comment index=${comment.index}: ${message}`,
        );
        this._log(
          `_drawComments: failed to draw comment index=${comment.index}: ${message}`,
        );
      }
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Harden comment draw robustness"](https://github.com/xpadev-net/niconicomments/commit/8f329914fa01c4db1f7c5d5e5c809a275e430548) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35986028)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->