### PR TITLE
[codex] Fix HTML5 fixed comment resize bounds

### DIFF
--- a/src/comments/HTML5Comment.ts
+++ b/src/comments/HTML5Comment.ts
@@ -304,14 +304,16 @@ class HTML5Comment extends BaseComment {
       let remainingIterations = MAX_RESIZE_ITERATIONS;
       const lowResult = getMeasured(low);
       best = low;
-      while (remainingIterations-- > 0 && lowResult.width <= widthLimit) {
-        const candidateCharSize = (low + high) / 2;
-        const candidate = getMeasured(candidateCharSize);
-        if (candidate.width <= widthLimit) {
-          best = candidateCharSize;
-          low = candidateCharSize;
-        } else {
-          high = candidateCharSize;
+      if (lowResult.width <= widthLimit) {
+        while (remainingIterations-- > 0 && low < high) {
+          const candidateCharSize = (low + high) / 2;
+          const candidate = getMeasured(candidateCharSize);
+          if (candidate.width <= widthLimit) {
+            best = candidateCharSize;
+            low = candidateCharSize;
+          } else {
+            high = candidateCharSize;
+          }
         }
       }
     } else {
@@ -397,7 +399,10 @@ class HTML5Comment extends BaseComment {
       scale *
       (this.comment.layer === -1 ? this.ctx.options.scale : 1);
     const image = this.renderer.getCanvas(HTML5_COMMENT_IMAGE_PADDING);
-    image.setSize(this.comment.width, this.comment.height);
+    image.setSize(
+      Math.max(1, this.comment.width),
+      Math.max(1, this.comment.height),
+    );
     image.setStrokeStyle(getStrokeColor(this.comment, this.config));
     image.setFillStyle(this.comment.color);
     image.setLineWidth(getConfig(this.config.contextLineWidth, false));

--- a/src/comments/HTML5Comment.ts
+++ b/src/comments/HTML5Comment.ts
@@ -29,6 +29,7 @@ import { addHTML5PartToResult } from "@/utils/niconico";
 import { BaseComment } from "./BaseComment";
 
 const MAX_RESIZE_ITERATIONS = 20;
+const MIN_HTML5_RESIZE_CHAR_SIZE = 1e-6;
 const MAX_HTML5_COMMENT_CHARS = 16_384;
 const MAX_HTML5_COMMENT_LINES = 256;
 const HTML5_COMMENT_IMAGE_PADDING = 4;
@@ -254,8 +255,22 @@ class HTML5Comment extends BaseComment {
     const charSize = getCharSize(comment.size, false, this.config);
     const scale = widthLimit / width;
     comment.resizedX = true;
-    const baseCharSize = Math.max(1, (comment.charSize ?? 0) * scale);
-    const baseLineHeight = Math.max(1, (comment.lineHeight ?? 0) * scale);
+    const currentCharSize = Math.max(
+      MIN_HTML5_RESIZE_CHAR_SIZE,
+      comment.charSize ?? 0,
+    );
+    const currentLineHeight = Math.max(
+      MIN_HTML5_RESIZE_CHAR_SIZE,
+      comment.lineHeight ?? 0,
+    );
+    const baseCharSize = Math.max(
+      MIN_HTML5_RESIZE_CHAR_SIZE,
+      currentCharSize * scale,
+    );
+    const baseLineHeight = Math.max(
+      MIN_HTML5_RESIZE_CHAR_SIZE,
+      currentLineHeight * scale,
+    );
 
     const workComment: MeasureTextInput = {
       ...comment,
@@ -267,60 +282,55 @@ class HTML5Comment extends BaseComment {
       throw new TypeGuardError();
     }
 
-    const getMeasured = (nextCharSize: number) => {
-      workComment.charSize = nextCharSize;
-      workComment.lineHeight = baseLineHeight * (nextCharSize / baseCharSize);
-      workComment.fontSize = nextCharSize * 0.8;
+    const getMeasured = (_nextCharSize: number) => {
+      const nextCharSize = Math.max(MIN_HTML5_RESIZE_CHAR_SIZE, _nextCharSize);
+      if (comment.resizedY) {
+        const resizeScale = nextCharSize / currentCharSize;
+        workComment.charSize = resizeScale * charSize;
+        workComment.lineHeight = resizeScale * lineHeight;
+      } else {
+        workComment.charSize = nextCharSize;
+        workComment.lineHeight = baseLineHeight * (nextCharSize / baseCharSize);
+      }
+      workComment.fontSize = (workComment.charSize ?? 0) * 0.8;
       return measure(workComment, this.renderer, this.config);
     };
 
-    let low = Math.max(1, Math.floor(baseCharSize * 0.5));
-    let high = Math.max(low, Math.ceil(baseCharSize * 1.5));
     let best = baseCharSize;
-    let bestResult = getMeasured(baseCharSize);
-    if (bestResult.width > widthLimit) {
-      high = baseCharSize;
+    const baseResult = getMeasured(baseCharSize);
+    if (baseResult.width > widthLimit) {
+      let low = MIN_HTML5_RESIZE_CHAR_SIZE;
+      let high = baseCharSize;
       let remainingIterations = MAX_RESIZE_ITERATIONS;
-      while (remainingIterations-- > 0) {
-        const candidate = getMeasured(low);
-        const nextLow = Math.max(1, Math.floor(low * 0.5));
-        if (candidate.width <= widthLimit || nextLow === low) {
-          best = low;
-          bestResult = candidate;
-          break;
+      const lowResult = getMeasured(low);
+      best = low;
+      while (remainingIterations-- > 0 && lowResult.width <= widthLimit) {
+        const candidateCharSize = (low + high) / 2;
+        const candidate = getMeasured(candidateCharSize);
+        if (candidate.width <= widthLimit) {
+          best = candidateCharSize;
+          low = candidateCharSize;
+        } else {
+          high = candidateCharSize;
         }
-        high = low;
-        low = nextLow;
       }
     } else {
+      let low = baseCharSize;
+      let high = currentCharSize;
       let remainingIterations = MAX_RESIZE_ITERATIONS;
-      while (remainingIterations-- > 0) {
-        const candidate = getMeasured(high);
-        if (candidate.width > widthLimit) break;
-        best = high;
-        bestResult = candidate;
-        const nextHigh = Math.ceil(high * 1.5);
-        if (nextHigh === high) break;
-        high = nextHigh;
-      }
-    }
-    if (bestResult.width <= widthLimit && low < high) {
-      let left = best;
-      let right = high;
-      while (left <= right) {
-        const mid = Math.floor((left + right) / 2);
+      while (remainingIterations-- > 0 && low < high) {
+        const mid = (low + high) / 2;
         const candidate = getMeasured(mid);
         if (candidate.width <= widthLimit) {
           best = mid;
-          bestResult = candidate;
-          left = mid + 1;
+          low = mid;
         } else {
-          right = mid - 1;
+          high = mid;
         }
       }
     }
     if (comment.resizedY) {
-      const resizeScale = best / (comment.charSize ?? 1);
+      const resizeScale = best / currentCharSize;
       comment.charSize = resizeScale * charSize;
       comment.lineHeight = resizeScale * lineHeight;
     } else {

--- a/src/renderer/canvas.ts
+++ b/src/renderer/canvas.ts
@@ -7,10 +7,10 @@ export const MAX_CANVAS_AREA = 16_777_216;
 const MAX_MEASURE_TEXT_CACHE_TEXT_LENGTH = 512;
 
 export const clampCanvasSize = (width: number, height: number) => {
-  let nextWidth = Number.isFinite(width) ? Math.max(0, Math.floor(width)) : 0;
-  let nextHeight = Number.isFinite(height)
-    ? Math.max(0, Math.floor(height))
-    : 0;
+  let nextWidth =
+    Number.isFinite(width) && width > 0 ? Math.max(1, Math.ceil(width)) : 0;
+  let nextHeight =
+    Number.isFinite(height) && height > 0 ? Math.max(1, Math.ceil(height)) : 0;
   if (nextWidth > MAX_CANVAS_DIMENSION || nextHeight > MAX_CANVAS_DIMENSION) {
     const scale = Math.min(
       MAX_CANVAS_DIMENSION / Math.max(1, nextWidth),

--- a/src/renderer/canvas.ts
+++ b/src/renderer/canvas.ts
@@ -7,10 +7,10 @@ export const MAX_CANVAS_AREA = 16_777_216;
 const MAX_MEASURE_TEXT_CACHE_TEXT_LENGTH = 512;
 
 export const clampCanvasSize = (width: number, height: number) => {
-  let nextWidth =
-    Number.isFinite(width) && width > 0 ? Math.max(1, Math.ceil(width)) : 0;
-  let nextHeight =
-    Number.isFinite(height) && height > 0 ? Math.max(1, Math.ceil(height)) : 0;
+  let nextWidth = Number.isFinite(width) ? Math.max(0, Math.floor(width)) : 0;
+  let nextHeight = Number.isFinite(height)
+    ? Math.max(0, Math.floor(height))
+    : 0;
   if (nextWidth > MAX_CANVAS_DIMENSION || nextHeight > MAX_CANVAS_DIMENSION) {
     const scale = Math.min(
       MAX_CANVAS_DIMENSION / Math.max(1, nextWidth),

--- a/tests/unit/html5-resource-bounds.spec.ts
+++ b/tests/unit/html5-resource-bounds.spec.ts
@@ -194,17 +194,76 @@ describe("HTML5 comment resource bounds", () => {
     expect(renderer.children[0]?.strokeTextCalls).toBe(3);
   });
 
-  test("keeps fixed-comment resize measurement bounded for huge text", () => {
+  test.each([
+    "ue",
+    "shita",
+  ] as const)("keeps %s fixed-comment resize measurement bounded for huge text", (loc) => {
     const renderer = new RecordingRenderer();
     const comment = new TestHTML5Comment(
-      formattedComment(1, "x".repeat(5000), ["ue"]),
+      formattedComment(1, "x".repeat(5000), [loc]),
       renderer,
       0,
       createContext(),
     );
+    const widthLimit =
+      defaultConfig.commentStageSize.html5.width *
+      defaultConfig.commentScale.html5;
 
     expect(comment.comment.resizedX).toBe(true);
+    expect(comment.comment.charSize).toBeLessThan(1);
+    expect(comment.comment.width).toBeLessThanOrEqual(widthLimit);
     expect(renderer.measureCalls).toBeLessThanOrEqual(80);
+
+    const image = comment.exposeTextImage() as RecordingRenderer | null;
+
+    expect(image).not.toBeNull();
+    expect(image?.getSize().width).toBeLessThanOrEqual(widthLimit);
+    expect(image?.getSize().height).toBeGreaterThan(0);
+  });
+
+  test("keeps fixed-comment resize measurement bounded at max content length", () => {
+    const renderer = new RecordingRenderer();
+    const comment = new TestHTML5Comment(
+      formattedComment(1, "x".repeat(20_000), ["ue"]),
+      renderer,
+      0,
+      createContext(),
+    );
+    const widthLimit =
+      defaultConfig.commentStageSize.html5.width *
+      defaultConfig.commentScale.html5;
+
+    expect(comment.comment.resizedX).toBe(true);
+    expect(comment.comment.width).toBeLessThanOrEqual(widthLimit);
+    expect(renderer.measureCalls).toBeLessThanOrEqual(80);
+  });
+
+  test("keeps fixed-comment resize bounded when max line count also applies", () => {
+    const renderer = new RecordingRenderer();
+    const comment = new TestHTML5Comment(
+      formattedComment(1, `${"x".repeat(5000)}\n${"\n".repeat(10_000)}`, [
+        "shita",
+      ]),
+      renderer,
+      0,
+      createContext(),
+    );
+    const widthLimit =
+      defaultConfig.commentStageSize.html5.width *
+      defaultConfig.commentScale.html5;
+
+    expect(comment.comment.lineCount).toBe(256);
+    expect(comment.comment.resizedX).toBe(true);
+    expect(comment.comment.resizedY).toBe(true);
+    expect(comment.comment.charSize).toBeLessThan(1);
+    expect(comment.comment.width).toBeLessThanOrEqual(widthLimit);
+    expect(renderer.measureCalls).toBeLessThanOrEqual(7000);
+
+    const image = comment.exposeTextImage() as RecordingRenderer | null;
+
+    expect(image).not.toBeNull();
+    expect(image?.getSize().width).toBeLessThanOrEqual(widthLimit);
+    expect(image?.getSize().height).toBeGreaterThan(0);
   });
 
   test("bounds cache keys and per-context image cache growth", () => {
@@ -270,5 +329,28 @@ describe("HTML5 comment resource bounds", () => {
     expect(canvas.height).toBeLessThanOrEqual(8192);
     expect(renderer.getSize().width).toBe(canvas.width - 8);
     expect(renderer.getSize().height).toBe(canvas.height - 8);
+  });
+
+  test("keeps subpixel padded canvas dimensions visible", () => {
+    const context = {
+      textAlign: "start",
+      textBaseline: "alphabetic",
+      lineJoin: "round",
+      translate: vi.fn(),
+      measureText: vi.fn(() => textMetrics(1)),
+    };
+    const canvas = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn(() => context),
+    } as unknown as HTMLCanvasElement;
+    const renderer = new CanvasRenderer(canvas, undefined, 4);
+
+    renderer.setSize(0.25, 0.25);
+
+    expect(canvas.width).toBe(9);
+    expect(canvas.height).toBe(9);
+    expect(renderer.getSize().width).toBe(1);
+    expect(renderer.getSize().height).toBe(1);
   });
 });

--- a/tests/unit/html5-resource-bounds.spec.ts
+++ b/tests/unit/html5-resource-bounds.spec.ts
@@ -330,27 +330,4 @@ describe("HTML5 comment resource bounds", () => {
     expect(renderer.getSize().width).toBe(canvas.width - 8);
     expect(renderer.getSize().height).toBe(canvas.height - 8);
   });
-
-  test("keeps subpixel padded canvas dimensions visible", () => {
-    const context = {
-      textAlign: "start",
-      textBaseline: "alphabetic",
-      lineJoin: "round",
-      translate: vi.fn(),
-      measureText: vi.fn(() => textMetrics(1)),
-    };
-    const canvas = {
-      width: 0,
-      height: 0,
-      getContext: vi.fn(() => context),
-    } as unknown as HTMLCanvasElement;
-    const renderer = new CanvasRenderer(canvas, undefined, 4);
-
-    renderer.setSize(0.25, 0.25);
-
-    expect(canvas.width).toBe(9);
-    expect(canvas.height).toBe(9);
-    expect(renderer.getSize().width).toBe(1);
-    expect(renderer.getSize().height).toBe(1);
-  });
 });


### PR DESCRIPTION
## Summary
- allow HTML5 fixed-comment X resize to search fractional/sub-1 character sizes
- keep extremely long ue/shita comments within fixed-comment width bounds instead of depending on oversized canvas guards
- preserve visibility for subpixel generated canvases by rounding positive canvas dimensions up

## Validation
- npm run check-types
- npm run test:unit -- tests/unit/html5-resource-bounds.spec.ts
- npm run test:unit
- npm run lint
- git diff --check
- pre-commit hook: lint, typecheck

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the HTML5 fixed-comment (`ue`/`shita`) resize path to allow sub-1px character sizes, replacing an integer-clamped halving loop with a proper floating-point binary search, and adds a `Math.max(1, …)` guard on canvas dimensions so subpixel-sized comments still produce a visible 1-pixel canvas.

- **`_processResizeX` rewrite**: `Math.max(1, …)` floors replaced with `MIN_HTML5_RESIZE_CHAR_SIZE = 1e-6`; two clean binary-search branches (shrink / refine-up), each bounded at `MAX_RESIZE_ITERATIONS = 20`; `getMeasured` now handles the `resizedY` case correctly by applying proportional scaling from `currentCharSize`.
- **Canvas dimension guard**: `_generateTextImage` wraps `setSize` in `Math.max(1, comment.width)` / `Math.max(1, comment.height)` so fractional pixel dimensions round up instead of producing a zero-size canvas.
- **New tests**: parameterised `ue`/`shita` coverage, max-content-length case, and a combined `resizedX + resizedY` (256-line) scenario with image-dimension assertions.
</details>

<h3>Confidence Score: 4/5</h3>

The change is safe to merge; the rewritten binary search is well-bounded and tests cover the key edge cases.

The logic for finding the right char size is correct and consistent between the search loop and the final application. The one area worth a second look is the per-call measurement bound in the 256-line combined test (7000) — it is considerably looser than the ~5600 theoretical maximum, so a moderate regression in iteration count could slip through undetected.

tests/unit/html5-resource-bounds.spec.ts — specifically the `measureCalls <= 7000` bound in the combined-resize test, which is substantially above the algorithm's theoretical maximum.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/comments/HTML5Comment.ts | Replaces integer-clamped binary search with a floating-point search (MIN_HTML5_RESIZE_CHAR_SIZE = 1e-6) so extremely long fixed comments can reach sub-1px char sizes; canvas setSize now clamps to Math.max(1, …) to avoid zero-dimension canvases |
| tests/unit/html5-resource-bounds.spec.ts | Expands coverage: parameterises ue/shita, adds max-content-length and combined resizedX+resizedY test cases; introduces a loose 7000 measureCall ceiling for the 256-line scenario |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[_measureComment] --> B{width over widthLimit?}
    B -- No --> Z[Return measurement]
    B -- Yes --> C[_processResizeX compute scale and baseCharSize]
    C --> D[getMeasured at baseCharSize]
    D --> E{baseResult fits?}
    E -- No: shrink --> G[low = 1e-6, high = baseCharSize]
    G --> H[getMeasured at low]
    H --> I{lowResult fits?}
    I -- Yes --> J[Binary search up to 20 iters finds largest fitting size]
    I -- No --> K[best stays at 1e-6]
    J --> L[best = largest fitting mid]
    E -- Yes: refine up --> M[low = baseCharSize, high = currentCharSize]
    M --> N[Binary search up to 20 iters finds largest fitting size]
    N --> O[best = largest fitting mid]
    L --> P{resizedY?}
    K --> P
    O --> P
    P -- Yes --> Q[scale best over currentCharSize apply to BASE charSize and lineHeight]
    P -- No --> R[charSize = best, lineHeight scaled from baseLineHeight]
    Q --> S[Final measure call]
    R --> S
    S --> T[_generateTextImage setSize with Math.max 1 for width and height]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Atests%2Funit%2Fhtml5-resource-bounds.spec.ts%3A260%0A**Loose%20iteration-count%20ceiling%20in%20combined-resize%20test**%0A%0AWith%20%60MAX_RESIZE_ITERATIONS%20%3D%2020%60%20and%20256%20clamped%20lines%2C%20the%20theoretical%20maximum%20for%20%60measureCalls%60%20in%20this%20branch%20is%20roughly%20%60%281%20%2B%201%20%2B%2020%29%20%C3%97%20256%20%E2%89%88%205632%60%20%28initial%20measurement%20%2B%20%60getMeasured%28low%29%60%20%2B%2020%20binary-search%20steps%2C%20each%20measuring%20all%20256%20lines%29.%20The%20current%20bound%20of%207000%20is%20~25%20%25%20above%20that%2C%20so%20a%20regression%20that%20inflates%20the%20iteration%20count%20by%20hundreds%20of%20calls%20could%20go%20unnoticed.%20Tightening%20it%20to%20something%20like%20%606000%60%20would%20still%20give%20a%20comfortable%20margin%20while%20making%20the%20guard%20more%20useful%20as%20a%20regression%20detector.%0A%0A&repo=xpadev-net%2Fniconicomments&pr=307&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
tests/unit/html5-resource-bounds.spec.ts:260
**Loose iteration-count ceiling in combined-resize test**

With `MAX_RESIZE_ITERATIONS = 20` and 256 clamped lines, the theoretical maximum for `measureCalls` in this branch is roughly `(1 + 1 + 20) × 256 ≈ 5632` (initial measurement + `getMeasured(low)` + 20 binary-search steps, each measuring all 256 lines). The current bound of 7000 is ~25 % above that, so a regression that inflates the iteration count by hundreds of calls could go unnoticed. Tightening it to something like `6000` would still give a comfortable margin while making the guard more useful as a regression detector.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Narrow HTML5 resize image bounds"](https://github.com/xpadev-net/niconicomments/commit/0ba30e0535a2b9634d057d495c00d9322e23bbaa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35986740)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->