### PR TITLE
[codex] Preserve HTML5 fixed resize visuals

### DIFF
--- a/src/comments/HTML5Comment.ts
+++ b/src/comments/HTML5Comment.ts
@@ -263,23 +263,94 @@ class HTML5Comment extends BaseComment {
       MIN_HTML5_RESIZE_CHAR_SIZE,
       comment.lineHeight ?? 0,
     );
-    const baseCharSize = Math.max(
-      MIN_HTML5_RESIZE_CHAR_SIZE,
-      currentCharSize * scale,
-    );
+    const rawBaseCharSize = currentCharSize * scale;
+    const rawBaseLineHeight = currentLineHeight * scale;
+    const baseCharSize = Math.max(MIN_HTML5_RESIZE_CHAR_SIZE, rawBaseCharSize);
     const baseLineHeight = Math.max(
       MIN_HTML5_RESIZE_CHAR_SIZE,
-      currentLineHeight * scale,
+      rawBaseLineHeight,
     );
+    const legacyBaseCharSize = Math.max(1, rawBaseCharSize);
+    const legacyBaseLineHeight = Math.max(1, rawBaseLineHeight);
 
     const workComment: MeasureTextInput = {
       ...comment,
-      charSize: baseCharSize,
-      lineHeight: baseLineHeight,
-      fontSize: baseCharSize * 0.8,
+      charSize: legacyBaseCharSize,
+      lineHeight: legacyBaseLineHeight,
+      fontSize: legacyBaseCharSize * 0.8,
     };
     if (!typeGuard.internal.MeasureInput(workComment)) {
       throw new TypeGuardError();
+    }
+
+    const getLegacyMeasured = (nextCharSize: number) => {
+      workComment.charSize = nextCharSize;
+      workComment.lineHeight =
+        legacyBaseLineHeight * (nextCharSize / legacyBaseCharSize);
+      workComment.fontSize = nextCharSize * 0.8;
+      return measure(workComment, this.renderer, this.config);
+    };
+
+    if (baseCharSize >= 1) {
+      let low = Math.max(1, Math.floor(legacyBaseCharSize * 0.5));
+      let high = Math.max(low, Math.ceil(legacyBaseCharSize * 1.5));
+      let best = legacyBaseCharSize;
+      let bestResult = getLegacyMeasured(legacyBaseCharSize);
+      if (bestResult.width > widthLimit) {
+        high = legacyBaseCharSize;
+        let remainingIterations = MAX_RESIZE_ITERATIONS;
+        while (remainingIterations-- > 0) {
+          const candidate = getLegacyMeasured(low);
+          const nextLow = Math.max(1, Math.floor(low * 0.5));
+          if (candidate.width <= widthLimit || nextLow === low) {
+            best = low;
+            bestResult = candidate;
+            break;
+          }
+          high = low;
+          low = nextLow;
+        }
+      } else {
+        let remainingIterations = MAX_RESIZE_ITERATIONS;
+        while (remainingIterations-- > 0) {
+          const candidate = getLegacyMeasured(high);
+          if (candidate.width > widthLimit) break;
+          best = high;
+          bestResult = candidate;
+          const nextHigh = Math.ceil(high * 1.5);
+          if (nextHigh === high) break;
+          high = nextHigh;
+        }
+      }
+      if (bestResult.width <= widthLimit && low < high) {
+        let left = best;
+        let right = high;
+        while (left <= right) {
+          const mid = Math.floor((left + right) / 2);
+          const candidate = getLegacyMeasured(mid);
+          if (candidate.width <= widthLimit) {
+            best = mid;
+            bestResult = candidate;
+            left = mid + 1;
+          } else {
+            right = mid - 1;
+          }
+        }
+      }
+      if (comment.resizedY) {
+        const resizeScale = best / (comment.charSize ?? 1);
+        comment.charSize = resizeScale * charSize;
+        comment.lineHeight = resizeScale * lineHeight;
+      } else {
+        comment.charSize = best;
+        comment.lineHeight = legacyBaseLineHeight * (best / legacyBaseCharSize);
+      }
+      comment.fontSize = (comment.charSize ?? 0) * 0.8;
+      return measure(
+        comment as MeasureTextInput & MeasureInput,
+        this.renderer,
+        this.config,
+      );
     }
 
     const getMeasured = (_nextCharSize: number) => {
@@ -399,10 +470,7 @@ class HTML5Comment extends BaseComment {
       scale *
       (this.comment.layer === -1 ? this.ctx.options.scale : 1);
     const image = this.renderer.getCanvas(HTML5_COMMENT_IMAGE_PADDING);
-    image.setSize(
-      Math.max(1, this.comment.width),
-      Math.max(1, this.comment.height),
-    );
+    image.setSize(this.comment.width, this.comment.height);
     image.setStrokeStyle(getStrokeColor(this.comment, this.config));
     image.setFillStyle(this.comment.color);
     image.setLineWidth(getConfig(this.config.contextLineWidth, false));


### PR DESCRIPTION
## Summary
- preserve legacy integer HTML5 fixed-comment resize behavior when the proportional target remains >= 1px
- keep SEC-10 fractional/sub-1 fixed-comment resize behavior for extremely long comments
- remove the broad minimum 1x1 generated-image sizing change that was unnecessary for the resource-bound tests

## Root cause
SEC-10 made fractional binary-search resizing the default for all HTML5 fixed comments. That changed ordinary visual fixture output in Firefox Playwright cases after merge. This follow-up limits fractional resizing to the sub-1 character-size path that the SEC-10 resource-bound bug requires.

## Validation
- npm run check-types
- npm run test:unit -- tests/unit/html5-resource-bounds.spec.ts
- npm run test:unit
- npm run lint
- git diff --check
- pre-commit hook: lint, typecheck
- focused local A/B: pre-SEC-10 base and follow-up branch produced the same canvas-vs-CSS diff for video=11,time=55 on local Firefox/port-isolated sample server

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR narrows the fractional (binary-search) resize path introduced by SEC-10 so it only fires when the proportionally-scaled target charSize falls below 1 px, restoring the pre-SEC-10 integer resize behavior for all ordinary HTML5 fixed comments. The `Math.max(1, …)` floor added to `setSize` in `_generateTextImage` is also removed, which is safe because the canvas renderer always adds 8 px of padding before clamping dimensions.

- Adds a new integer-only binary search branch (`getLegacyMeasured`) in `_processResizeX` that activates when `baseCharSize >= 1`, preserving whole-pixel charSize values and keeping visual output identical to pre-SEC-10 for the typical comment population.
- Retains the SEC-10 fractional binary search for the sub-1 px edge case (extremely long comments), so the resource-bound fix is not lost.
- Removes the `Math.max(1, …)` floor from `image.setSize(…)` in `_generateTextImage` as the 4 px canvas padding already ensures a valid minimum canvas size in all paths.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge — the new integer binary-search branch correctly routes only when the proportional target is ≥ 1 px, the fractional fallback for extreme comments is preserved intact, and the removed setSize floor is rendered redundant by the 4 px canvas padding in the renderer.

The new getLegacyMeasured closure works correctly for ordinary fixed comments. One subtle interaction exists for resizedY fixed comments: the search measures text at the raw integer charSize while the final assignment applies a configCharSize/commentCharSize scaling, so the search operates as a slight upper-bound proxy. The result is always within widthLimit, but such comments may be rendered a touch narrower than theoretically optimal. No data loss, no crash path, and all validation steps in the PR description were run.

src/comments/HTML5Comment.ts — the _processResizeX method now has two distinct binary-search branches; the getLegacyMeasured / resizedY interaction is the only area worth a second read.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/comments/HTML5Comment.ts | Adds an integer-only binary-search branch for the normal (baseCharSize ≥ 1) path in _processResizeX and removes a redundant Math.max(1, …) floor in _generateTextImage. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["_processResizeX"] --> B["rawBaseCharSize = currentCharSize * scale"]
    B --> C{"baseCharSize >= 1?"}
    C -- Yes --> D["Integer binary search via getLegacyMeasured"]
    D --> E["return measure(comment)"]
    C -- No --> F["Fractional binary search via getMeasured"]
    F --> E
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Preserve legacy HTML5 fixed resize visua..."](https://github.com/xpadev-net/niconicomments/commit/64e4383f1cf5faa3aee910ce87f4ae684ccf91d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35987525)</sub>

<!-- /greptile_comment -->