### PR TITLE
SEC-11: Make base button hooks no-op by default

### DIFF
--- a/src/comments/BaseComment.ts
+++ b/src/comments/BaseComment.ts
@@ -469,22 +469,19 @@ class BaseComment implements IComment {
   }
 
   protected getButtonImage(
-    posX: number,
-    posY: number,
-    cursor?: Position,
+    _posX: number,
+    _posY: number,
+    _cursor?: Position,
   ): IRenderer | undefined {
-    console.error(
-      "getButtonImage method is not implemented",
-      posX,
-      posY,
-      cursor,
-    );
-    throw new NotImplementedError(this.pluginName, "getButtonImage");
+    return undefined;
   }
 
-  public isHovered(cursor?: Position, posX?: number, posY?: number): boolean {
-    console.error("isHovered method is not implemented", posX, posY, cursor);
-    throw new NotImplementedError(this.pluginName, "getButtonImage");
+  public isHovered(
+    _cursor?: Position,
+    _posX?: number,
+    _posY?: number,
+  ): boolean {
+    return false;
   }
 
   protected getCacheKey() {

--- a/tests/unit/renderer-draw-robustness.spec.ts
+++ b/tests/unit/renderer-draw-robustness.spec.ts
@@ -315,9 +315,12 @@ describe("renderer draw robustness", () => {
         },
       },
     );
-    const state = instance as unknown as { comments: unknown[] };
+    const state = instance as unknown as {
+      comments: { comment: { button?: { limit: number } } }[];
+    };
 
     expect(() => instance.click(0, { x: 50, y: 10 })).not.toThrow();
     expect(state.comments).toHaveLength(1);
+    expect(state.comments[0]?.comment.button?.limit).toBe(1);
   });
 });

--- a/tests/unit/renderer-draw-robustness.spec.ts
+++ b/tests/unit/renderer-draw-robustness.spec.ts
@@ -1,6 +1,11 @@
 import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 
-import type { FormattedComment, IRenderer } from "@/@types";
+import type {
+  FormattedComment,
+  FormattedCommentWithSize,
+  IRenderer,
+} from "@/@types";
+import { BaseComment } from "@/comments";
 import { initConfig } from "@/definition/initConfig";
 import NiconiComments from "@/main";
 
@@ -103,6 +108,66 @@ class VideoSurfaceRenderer extends RecordingRenderer {
 
 class NullVideoRenderer extends RecordingRenderer {
   public readonly video = null;
+}
+
+class BaseStyleCommentWithoutButtons extends BaseComment {
+  protected override convertComment(
+    comment: FormattedComment,
+  ): FormattedCommentWithSize {
+    return {
+      ...comment,
+      loc: "ue",
+      size: "medium",
+      fontSize: 24,
+      font: "defont",
+      color: "#ffffff",
+      full: false,
+      ender: false,
+      _live: false,
+      long: 100,
+      invisible: false,
+      rawContent: comment.content,
+      flash: false,
+      lineCount: 1,
+      lineOffset: 0,
+      content: [
+        {
+          type: "text",
+          content: comment.content,
+          slicedContent: [comment.content],
+          width: [100],
+        },
+      ],
+      height: 24,
+      width: 100,
+      lineHeight: 24,
+      resized: false,
+      resizedX: false,
+      resizedY: false,
+      charSize: 24,
+      scale: 1,
+      scaleX: 1,
+      button: {
+        message: {
+          before: "",
+          body: "Push",
+          after: "",
+        },
+        commentMessage: "posted",
+        commentVisible: true,
+        commentMail: [],
+        limit: 1,
+        local: false,
+        hidden: false,
+      },
+    };
+  }
+
+  protected override _generateTextImage(): IRenderer {
+    return this.renderer.getCanvas();
+  }
+
+  protected override _drawCollision() {}
 }
 
 const createComment = (
@@ -208,5 +273,51 @@ describe("renderer draw robustness", () => {
     expect(instance.drawCanvas(2)).toBe(false);
     expect(renderer.clearRectCalls).toBe(1);
     expect(renderer.drawVideoCalls).toBe(1);
+  });
+
+  test("draws a base-style custom comment with button metadata as a no-op button", () => {
+    const renderer = new RecordingRenderer();
+    const instance = new NiconiComments(
+      renderer,
+      [createComment({ content: "custom button-like", mail: ["ue"] })],
+      {
+        format: "formatted",
+        mode: "html5",
+        config: {
+          commentPlugins: [
+            {
+              class: BaseStyleCommentWithoutButtons,
+              condition: () => true,
+            },
+          ],
+        },
+      },
+    );
+
+    expect(() => instance.drawCanvas(0, true, { x: 50, y: 10 })).not.toThrow();
+    expect(renderer.drawImageCalls).toBe(1);
+  });
+
+  test("click over a base-style custom comment with button metadata is a no-op", () => {
+    const instance = new NiconiComments(
+      new RecordingRenderer(),
+      [createComment({ content: "custom button-like", mail: ["ue"] })],
+      {
+        format: "formatted",
+        mode: "html5",
+        config: {
+          commentPlugins: [
+            {
+              class: BaseStyleCommentWithoutButtons,
+              condition: () => true,
+            },
+          ],
+        },
+      },
+    );
+    const state = instance as unknown as { comments: unknown[] };
+
+    expect(() => instance.click(0, { x: 50, y: 10 })).not.toThrow();
+    expect(state.comments).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary
- Make BaseComment button rendering and hover hooks safe no-op defaults for custom/base renderers.
- Add focused regressions covering drawCanvas() and click() with button-like metadata on a base-style custom comment.

## Validation
- npm run test:unit -- tests/unit/renderer-draw-robustness.spec.ts
- npm run check-types
- npm run test:unit
- npm run lint
- git diff --check
- pre-commit hook: lint, typecheck

## Review
- deep-review self-review: no actionable findings.
- independent subagent review: no actionable findings.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR converts two base-class methods in `BaseComment` — `getButtonImage` and `isHovered` — from error-throwing stubs into safe no-ops (`return undefined` and `return false`), so custom plugin authors who extend `BaseComment` without implementing button behaviour no longer get runtime crashes when a comment carries button metadata.

- **`src/comments/BaseComment.ts`**: `getButtonImage` now returns `undefined` (no button overlay drawn) and `isHovered` now returns `false` (click handler skips the comment), matching the safe defaults already implemented by `HTML5Comment`.
- **`tests/unit/renderer-draw-robustness.spec.ts`**: Two new regression tests confirm that `drawCanvas()` and `click()` both complete without throwing when a `BaseComment` subclass has button metadata but no button implementation.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change only widens the set of valid plugin subclasses by removing unnecessary throws on paths the caller already handles gracefully.

Both changed methods now return the same values as HTML5Comment's existing overrides, and the callers in _draw() and click() already guard against undefined/false returns. FlashComment's overrides are unaffected. The two new tests directly cover the previously-crashing code paths.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/comments/BaseComment.ts | Replaces two NotImplementedError-throwing stubs with safe no-ops; callers already handle undefined/false gracefully so no existing code paths are affected. |
| tests/unit/renderer-draw-robustness.spec.ts | Adds a minimal BaseComment subclass fixture and two focused regression tests verifying drawCanvas and click are no-ops when button metadata is present but no button implementation is provided. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["drawCanvas / click called"] --> B{"comment.button && !hidden?"}
    B -- "No" --> C["Draw text image only"]
    B -- "Yes" --> D["getButtonImage(posX, posY, cursor)"]
    D -- "BaseComment before" --> E["throw NotImplementedError"]
    D -- "BaseComment after / HTML5Comment" --> F["return undefined"]
    F --> G{"button defined?"}
    G -- "No" --> C
    G -- "Yes FlashComment" --> H["drawImage(button, posX, posY)"]
    H --> C
    I["click(vpos, pos)"] --> J["isHovered(pos)"]
    J -- "BaseComment before" --> K["throw NotImplementedError"]
    J -- "BaseComment after / HTML5Comment" --> L["return false, no action"]
    J -- "FlashComment" --> M["return true/false, build @button comment"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Assert base button click remains inert"](https://github.com/xpadev-net/niconicomments/commit/65b62e2b56e8365c7f62d6ff94ba18695e838071) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35988026)</sub>

<!-- /greptile_comment -->