### PR TITLE
fix: accept plugin constructors without static ids

### DIFF
--- a/src/@types/IPlugins.ts
+++ b/src/@types/IPlugins.ts
@@ -1,7 +1,7 @@
 import type { IComment, IRenderer } from "@/@types/";
 
 export interface IPluginConstructor {
-  id: string;
+  id?: string;
   new (Canvas: IRenderer, comments: IComment[]): IPlugin;
 }
 

--- a/src/typeGuard.ts
+++ b/src/typeGuard.ts
@@ -246,12 +246,7 @@ const isBoundedFlashDoubleResizeHeights = (item: unknown): boolean => {
 };
 
 const isValidPlugins = (item: unknown): boolean =>
-  Array.isArray(item) &&
-  item.every(
-    (plugin) =>
-      typeof plugin === "function" &&
-      typeof (plugin as { id?: unknown }).id === "string",
-  );
+  Array.isArray(item) && item.every((plugin) => typeof plugin === "function");
 
 const isValidCommentPlugins = (item: unknown): boolean =>
   Array.isArray(item) &&

--- a/tests/unit/init-option-config-bounds.spec.ts
+++ b/tests/unit/init-option-config-bounds.spec.ts
@@ -80,6 +80,8 @@ class FakeRenderer implements IRenderer {
   invalidateImage() {}
 }
 
+class IdlessPlugin {}
+
 const createComment = (id: number): FormattedComment => ({
   id,
   vpos: 0,
@@ -243,6 +245,17 @@ describe("init option and config bounds", () => {
           format: "formatted",
           mode: "html5",
           config: { ...defaultConfig },
+        }),
+    ).not.toThrow();
+  });
+
+  test("accepts plugin constructors without static ids for compatibility", () => {
+    expect(
+      () =>
+        new NiconiComments(new FakeRenderer(), [], {
+          format: "formatted",
+          mode: "html5",
+          config: { plugins: [IdlessPlugin] },
         }),
     ).not.toThrow();
   });


### PR DESCRIPTION
## Summary
- allow config.plugins entries to be plugin constructors without a static id
- make IPluginConstructor.id optional to match existing external plugin compatibility
- add a regression test for idless plugin constructors

## Test
- npm run test:unit -- tests/unit/init-option-config-bounds.spec.ts tests/unit/duration-lazy.spec.ts
- npm run lint
- pre-commit hook: lint + typecheck

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR relaxes the plugin constructor validation to accept constructors that lack a static `id` property, fixing compatibility with external plugins (like [`niconicomments-plugin-niwango`](https://github.com/xpadev-net/niconicomments-plugin-niwango/blob/HEAD/src/main.ts)) whose classes never exposed a static `id`. The `id` field was verified by `isValidPlugins` but was never accessed at runtime in `main.ts`, making the guard purely a gatekeeping artifact.

- **`IPluginConstructor.id`** is widened from `string` to `string | undefined`, preserving type compatibility for existing plugins that do set an `id`.
- **`isValidPlugins`** now only checks `typeof plugin === "function"`, dropping the now-unnecessary `id` string check; plugin construction is already guarded by a try/catch in `preRendering`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the removed `id` check was purely a gatekeeping artifact; the field is never read at runtime.

All three changed files are coherent and tightly scoped: the type definition, the runtime guard, and the regression test all move together. The `id` property on `IPluginConstructor` was never accessed anywhere in `main.ts` or any utility, so removing the guard introduces no behavioral risk. Plugin instantiation failures are already caught by the existing try/catch in `preRendering`. The related external plugin (`niconicomments-plugin-niwango`) has no static `id`, confirming this fixes a real compatibility gap.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/@types/IPlugins.ts | Makes `IPluginConstructor.id` optional; non-breaking for existing plugins and consistent with actual runtime usage where `id` is never read. |
| src/typeGuard.ts | Drops the static `id` string check from `isValidPlugins`; the remaining `typeof === "function"` guard is sufficient since plugin instantiation is wrapped in a try/catch in `preRendering`. |
| tests/unit/init-option-config-bounds.spec.ts | Adds `IdlessPlugin` stub and a targeted regression test confirming idless constructors are accepted without throwing. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[config.plugins entry] --> B{typeof plugin === 'function'?}
    B -- No --> C[isValidPlugins returns false\nInvalidOptionError thrown]
    B -- Yes --> D[OLD: typeof plugin.id === 'string'?]
    D -- No --> C
    D -- Yes --> E[Accepted - plugin queued]
    B -- Yes --> F[NEW: Accepted directly - plugin queued]
    E --> G[preRendering: new plugin canvas, instances\nwrapped in try/catch]
    F --> G
    G -- success --> H[plugin instance added to this.plugins]
    G -- throws --> I[console.error 'Failed to init plugin'\ncontinue silently]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: accept idless plugin constructors"](https://github.com/xpadev-net/niconicomments/commit/d01e5bdd78e8a9e201bb1d5f83a3e0f8be650372) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35993440)</sub>

<!-- /greptile_comment -->