### PR TITLE
[codex] Update dev build artifact actions

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -42,7 +42,7 @@ jobs:
         run: tar --hard-dereference -czf dev-build-artifacts.tgz dist/bundle.js
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: dev-build-artifacts
           path: dev-build-artifacts.tgz
@@ -61,7 +61,7 @@ jobs:
           persist-credentials: false
 
       - name: Download build artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
           name: dev-build-artifacts
           path: ${{ runner.temp }}/dev-build-artifacts


### PR DESCRIPTION
## Summary

- Update dev build artifact upload/download actions to Node 24-compatible pinned commits.
- Keep the workflow using hash-pinned actions.

## Why

GitHub Actions warns that the previously pinned artifact actions run on Node.js 20, which is deprecated and scheduled for removal from runners.

## Validation

- Confirmed the new pinned upload-artifact commit uses `runs.using: node24`.
- Confirmed the new pinned download-artifact commit uses `runs.using: node24`.
- Pre-commit hook ran; lint/typecheck skipped because only workflow YAML changed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the hash-pinned `actions/upload-artifact` and `actions/download-artifact` steps in the dev-build workflow to commits that run on Node.js 24, replacing the previously pinned commits that ran on the now-deprecated Node.js 20 runtime.

- `upload-artifact` pin changed from `ea165f8` (Node 20) to `043fb46` (Node 24).
- `download-artifact` pin changed from `d3f86a1` (Node 20) to `3e5f45b` (Node 24).
- All other workflow steps, permissions, and the artifact validation script are unchanged.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — only two action commit hashes are changed; all workflow logic, permissions, and the artifact validation script are untouched.

The old upload-artifact pin (ea165f8) is explicitly confirmed as a Node 20 action now deprecated on GitHub-hosted runners. The replacement hashes align with the known Node 24 migration and the PR author verified the runs.using: node24 field in each action. No other workflow behaviour changes.

No files require special attention. The three other hash-pinned actions in the same workflow (actions/checkout, pnpm/action-setup, actions/setup-node) were not changed; it may be worth verifying they are already on Node 24-compatible commits, but that is outside the scope of this PR.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/dev-build.yml | Bumps hash-pinned upload-artifact and download-artifact actions to Node 24-compatible commits; no logic changes. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GH as GitHub Runner
    participant Build as build job
    participant UA as upload-artifact (043fb46, Node 24)
    participant DA as download-artifact (3e5f45b, Node 24)
    participant Push as push-dev-build job

    GH->>Build: trigger on push to develop
    Build->>Build: "pnpm install & build"
    Build->>Build: tar dist/bundle.js
    Build->>UA: upload dev-build-artifacts
    UA-->>Build: artifact stored

    GH->>Push: needs: build
    Push->>DA: download dev-build-artifacts
    DA-->>Push: artifact retrieved
    Push->>Push: "validate & extract via Python"
    Push->>GH: git push to dev-build branch
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Update dev build artifact actions"](https://github.com/xpadev-net/niconicomments/commit/c1012cf4a36d437a98f2955d783e0f2bf3cffce7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35994179)</sub>

<!-- /greptile_comment -->