### PR TITLE
Bound CSS renderer duplicate canvas clones

### DIFF
--- a/src/__tests__/html5css-renderer.spec.ts
+++ b/src/__tests__/html5css-renderer.spec.ts
@@ -617,6 +617,26 @@ test("HTML5CSSRenderer bounds duplicate owned canvas clones per frame", async ({
     largeImage.destroy();
     byteCase.renderer.destroy();
     byteCase.root.remove();
+
+    const externalCase = createRenderer();
+    const externalElement = document.createElement("canvas");
+    const externalImage =
+      new global.NiconiComments.internal.renderer.CanvasRenderer(
+        externalElement,
+      );
+    externalImage.setSize(2048, 2048);
+    drawRepeatedly(externalCase.renderer, externalImage, 20);
+    externalCase.renderer.flush();
+    const externalByteCappedFrameConnectedCanvases = countLayerCanvases(
+      externalCase.layer,
+    );
+    const externalByteCappedFrameVisibleCanvases = countVisibleLayerCanvases(
+      externalCase.layer,
+    );
+
+    externalImage.destroy();
+    externalCase.renderer.destroy();
+    externalCase.root.remove();
     return {
       countCappedFrameVisibleCanvases,
       countCappedFrameConnectedCanvases,
@@ -624,6 +644,8 @@ test("HTML5CSSRenderer bounds duplicate owned canvas clones per frame", async ({
       recoveredFrameConnectedCanvases,
       byteCappedFrameVisibleCanvases,
       byteCappedFrameConnectedCanvases,
+      externalByteCappedFrameVisibleCanvases,
+      externalByteCappedFrameConnectedCanvases,
     };
   });
 
@@ -635,6 +657,10 @@ test("HTML5CSSRenderer bounds duplicate owned canvas clones per frame", async ({
   // the source canvas plus 4 duplicate clones.
   expect(result.byteCappedFrameVisibleCanvases).toBe(5);
   expect(result.byteCappedFrameConnectedCanvases).toBe(5);
+  // External canvases are copied instead of reparented, so the same 64 MiB
+  // budget allows 4 copied canvases total.
+  expect(result.externalByteCappedFrameVisibleCanvases).toBe(4);
+  expect(result.externalByteCappedFrameConnectedCanvases).toBe(4);
   expect(result.recoveredFrameVisibleCanvases).toBe(2);
   expect(result.recoveredFrameConnectedCanvases).toBe(2);
 });

--- a/src/__tests__/html5css-renderer.spec.ts
+++ b/src/__tests__/html5css-renderer.spec.ts
@@ -533,6 +533,59 @@ test("HTML5CSSRenderer refreshes drawImage snapshots after sub-renderer resize",
   expect(metrics.height).toBe("5px");
 });
 
+test("HTML5CSSRenderer bounds duplicate owned canvas clones per frame", async ({
+  page,
+}) => {
+  await loadBundle(page);
+
+  const result = await page.evaluate(() => {
+    const root = document.createElement("div");
+    root.dataset.width = "200";
+    root.dataset.height = "100";
+    document.body.appendChild(root);
+    const global = window as typeof window & {
+      NiconiComments: typeof import("@/main").default;
+    };
+    const renderer =
+      new global.NiconiComments.internal.renderer.HTML5CSSRenderer(root);
+    const image = renderer.getCanvas();
+    image.setSize(10, 10);
+    image.setFillStyle("#ff0000");
+    image.fillRect(0, 0, 10, 10);
+    const layer = root.querySelector<HTMLElement>("div");
+    const visibleLayerCanvases = () =>
+      layer
+        ? Array.from(layer.children).filter(
+            (child) =>
+              child.tagName.toLowerCase() === "canvas" &&
+              getComputedStyle(child).display !== "none",
+          ).length
+        : 0;
+
+    for (let i = 0; i < 300; i++) {
+      renderer.drawImage(image, i % 200, Math.floor(i / 200) * 12);
+    }
+    renderer.flush();
+    const cappedFrameVisibleCanvases = visibleLayerCanvases();
+
+    renderer.clearRect(0, 0, 200, 100);
+    renderer.drawImage(image, 0, 0);
+    renderer.drawImage(image, 20, 0);
+    renderer.flush();
+    const recoveredFrameVisibleCanvases = visibleLayerCanvases();
+
+    image.destroy();
+    renderer.destroy();
+    root.remove();
+    return { cappedFrameVisibleCanvases, recoveredFrameVisibleCanvases };
+  });
+
+  // Source canvas + at most 128 duplicate clones. The remaining over-cap
+  // duplicate draws are skipped without throwing.
+  expect(result.cappedFrameVisibleCanvases).toBe(129);
+  expect(result.recoveredFrameVisibleCanvases).toBe(2);
+});
+
 test("HTML5CSSRenderer uses clamped canvas dimensions consistently", async ({
   page,
 }) => {

--- a/src/__tests__/html5css-renderer.spec.ts
+++ b/src/__tests__/html5css-renderer.spec.ts
@@ -3,9 +3,7 @@ import { expect, test } from "@playwright/test";
 
 // Used by the layout test that inspects the CSS renderer mounted on the page.
 const loadCssSample = async (page: Page) => {
-  await page.goto(
-    "http://localhost:8080/docs/sample/test.html?renderer=css&time=20&video=0",
-  );
+  await page.goto("/docs/sample/test.html?renderer=css&time=20&video=0");
   // BrowserSync injects this overlay only during local runs; in CI the detached
   // wait resolves immediately, matching the existing visual regression tests.
   await Promise.race([
@@ -23,7 +21,7 @@ const loadCssSample = async (page: Page) => {
 // Used by tests that construct their own renderer inside page.evaluate —
 // they only need the bundle present, not a CSS-rendered page.
 const loadBundle = async (page: Page) => {
-  await page.goto("http://localhost:8080/docs/sample/test.html?time=0&video=0");
+  await page.goto("/docs/sample/test.html?time=0&video=0");
   await Promise.race([
     page.waitForSelector("div#loaded", { state: "attached" }),
     page.waitForSelector("div#renderer-error", { state: "attached" }),
@@ -539,51 +537,106 @@ test("HTML5CSSRenderer bounds duplicate owned canvas clones per frame", async ({
   await loadBundle(page);
 
   const result = await page.evaluate(() => {
-    const root = document.createElement("div");
-    root.dataset.width = "200";
-    root.dataset.height = "100";
-    document.body.appendChild(root);
     const global = window as typeof window & {
       NiconiComments: typeof import("@/main").default;
     };
-    const renderer =
-      new global.NiconiComments.internal.renderer.HTML5CSSRenderer(root);
-    const image = renderer.getCanvas();
-    image.setSize(10, 10);
-    image.setFillStyle("#ff0000");
-    image.fillRect(0, 0, 10, 10);
-    const layer = root.querySelector<HTMLElement>("div");
-    const visibleLayerCanvases = () =>
-      layer
-        ? Array.from(layer.children).filter(
-            (child) =>
-              child.tagName.toLowerCase() === "canvas" &&
-              getComputedStyle(child).display !== "none",
-          ).length
-        : 0;
+    const createRenderer = () => {
+      const root = document.createElement("div");
+      root.dataset.width = "200";
+      root.dataset.height = "100";
+      document.body.appendChild(root);
+      const renderer =
+        new global.NiconiComments.internal.renderer.HTML5CSSRenderer(root);
+      const layer = root.querySelector<HTMLElement>("div");
+      if (!layer) throw new Error("missing renderer layer");
+      return { root, renderer, layer };
+    };
+    const countLayerCanvases = (layer: HTMLElement) =>
+      Array.from(layer.children).filter(
+        (child) => child.tagName.toLowerCase() === "canvas",
+      ).length;
+    const countVisibleLayerCanvases = (layer: HTMLElement) =>
+      Array.from(layer.children).filter(
+        (child) =>
+          child.tagName.toLowerCase() === "canvas" &&
+          getComputedStyle(child).display !== "none",
+      ).length;
+    const drawRepeatedly = (
+      renderer: InstanceType<
+        typeof global.NiconiComments.internal.renderer.HTML5CSSRenderer
+      >,
+      image: ReturnType<
+        InstanceType<
+          typeof global.NiconiComments.internal.renderer.HTML5CSSRenderer
+        >["getCanvas"]
+      >,
+      count: number,
+    ) => {
+      for (let i = 0; i < count; i++) {
+        renderer.drawImage(image, i % 200, Math.floor(i / 200) * 12);
+      }
+    };
 
-    for (let i = 0; i < 300; i++) {
-      renderer.drawImage(image, i % 200, Math.floor(i / 200) * 12);
-    }
-    renderer.flush();
-    const cappedFrameVisibleCanvases = visibleLayerCanvases();
+    const countCase = createRenderer();
+    const smallImage = countCase.renderer.getCanvas();
+    smallImage.setSize(10, 10);
+    smallImage.setFillStyle("#ff0000");
+    smallImage.fillRect(0, 0, 10, 10);
+    drawRepeatedly(countCase.renderer, smallImage, 300);
+    countCase.renderer.flush();
+    const countCappedFrameVisibleCanvases = countVisibleLayerCanvases(
+      countCase.layer,
+    );
+    const countCappedFrameConnectedCanvases = countLayerCanvases(
+      countCase.layer,
+    );
 
-    renderer.clearRect(0, 0, 200, 100);
-    renderer.drawImage(image, 0, 0);
-    renderer.drawImage(image, 20, 0);
-    renderer.flush();
-    const recoveredFrameVisibleCanvases = visibleLayerCanvases();
+    countCase.renderer.clearRect(0, 0, 200, 100);
+    countCase.renderer.drawImage(smallImage, 0, 0);
+    countCase.renderer.drawImage(smallImage, 20, 0);
+    countCase.renderer.flush();
+    const recoveredFrameVisibleCanvases = countVisibleLayerCanvases(
+      countCase.layer,
+    );
+    const recoveredFrameConnectedCanvases = countLayerCanvases(countCase.layer);
 
-    image.destroy();
-    renderer.destroy();
-    root.remove();
-    return { cappedFrameVisibleCanvases, recoveredFrameVisibleCanvases };
+    smallImage.destroy();
+    countCase.renderer.destroy();
+    countCase.root.remove();
+
+    const byteCase = createRenderer();
+    const largeImage = byteCase.renderer.getCanvas();
+    largeImage.setSize(2048, 2048);
+    drawRepeatedly(byteCase.renderer, largeImage, 20);
+    byteCase.renderer.flush();
+    const byteCappedFrameConnectedCanvases = countLayerCanvases(byteCase.layer);
+    const byteCappedFrameVisibleCanvases = countVisibleLayerCanvases(
+      byteCase.layer,
+    );
+
+    largeImage.destroy();
+    byteCase.renderer.destroy();
+    byteCase.root.remove();
+    return {
+      countCappedFrameVisibleCanvases,
+      countCappedFrameConnectedCanvases,
+      recoveredFrameVisibleCanvases,
+      recoveredFrameConnectedCanvases,
+      byteCappedFrameVisibleCanvases,
+      byteCappedFrameConnectedCanvases,
+    };
   });
 
   // Source canvas + at most 128 duplicate clones. The remaining over-cap
   // duplicate draws are skipped without throwing.
-  expect(result.cappedFrameVisibleCanvases).toBe(129);
+  expect(result.countCappedFrameVisibleCanvases).toBe(129);
+  expect(result.countCappedFrameConnectedCanvases).toBe(129);
+  // 2048 x 2048 x 4 bytes = 16 MiB per clone, so the 64 MiB byte budget allows
+  // the source canvas plus 4 duplicate clones.
+  expect(result.byteCappedFrameVisibleCanvases).toBe(5);
+  expect(result.byteCappedFrameConnectedCanvases).toBe(5);
   expect(result.recoveredFrameVisibleCanvases).toBe(2);
+  expect(result.recoveredFrameConnectedCanvases).toBe(2);
 });
 
 test("HTML5CSSRenderer uses clamped canvas dimensions consistently", async ({

--- a/src/__tests__/html5css-renderer.spec.ts
+++ b/src/__tests__/html5css-renderer.spec.ts
@@ -657,10 +657,11 @@ test("HTML5CSSRenderer bounds duplicate owned canvas clones per frame", async ({
   // the source canvas plus 4 duplicate clones.
   expect(result.byteCappedFrameVisibleCanvases).toBe(5);
   expect(result.byteCappedFrameConnectedCanvases).toBe(5);
-  // External canvases are copied instead of reparented, so the same 64 MiB
-  // budget allows 4 copied canvases total.
-  expect(result.externalByteCappedFrameVisibleCanvases).toBe(4);
-  expect(result.externalByteCappedFrameConnectedCanvases).toBe(4);
+  // External canvases are copied instead of reparented. The first copy of a
+  // source is allowed, then repeated copies of that source consume the same
+  // 64 MiB budget, allowing 4 more copied canvases.
+  expect(result.externalByteCappedFrameVisibleCanvases).toBe(5);
+  expect(result.externalByteCappedFrameConnectedCanvases).toBe(5);
   expect(result.recoveredFrameVisibleCanvases).toBe(2);
   expect(result.recoveredFrameConnectedCanvases).toBe(2);
 });

--- a/src/__tests__/html5css-renderer.spec.ts
+++ b/src/__tests__/html5css-renderer.spec.ts
@@ -582,7 +582,7 @@ test("HTML5CSSRenderer bounds duplicate owned canvas clones per frame", async ({
     smallImage.setSize(10, 10);
     smallImage.setFillStyle("#ff0000");
     smallImage.fillRect(0, 0, 10, 10);
-    drawRepeatedly(countCase.renderer, smallImage, 300);
+    drawRepeatedly(countCase.renderer, smallImage, 1200);
     countCase.renderer.flush();
     const countCappedFrameVisibleCanvases = countVisibleLayerCanvases(
       countCase.layer,
@@ -649,10 +649,10 @@ test("HTML5CSSRenderer bounds duplicate owned canvas clones per frame", async ({
     };
   });
 
-  // Source canvas + at most 128 duplicate clones. The remaining over-cap
+  // Source canvas + at most 1024 duplicate clones. The remaining over-cap
   // duplicate draws are skipped without throwing.
-  expect(result.countCappedFrameVisibleCanvases).toBe(129);
-  expect(result.countCappedFrameConnectedCanvases).toBe(129);
+  expect(result.countCappedFrameVisibleCanvases).toBe(1025);
+  expect(result.countCappedFrameConnectedCanvases).toBe(1025);
   // 2048 x 2048 x 4 bytes = 16 MiB per clone, so the 64 MiB byte budget allows
   // the source canvas plus 4 duplicate clones.
   expect(result.byteCappedFrameVisibleCanvases).toBe(5);

--- a/src/renderer/html5css.ts
+++ b/src/renderer/html5css.ts
@@ -68,6 +68,7 @@ class HTML5CSSRenderer implements IRenderer {
   >();
   private duplicateCloneCount = 0;
   private duplicateCloneBytes = 0;
+  private externalCanvasSet = new WeakSet<HTMLCanvasElement>();
   // Canvases created by this renderer's getCanvas() — safe to reparent in drawImage.
   // External canvases are never reparented; pixels are copied instead.
   private readonly ownedCanvases = new WeakSet<HTMLCanvasElement>();
@@ -561,19 +562,21 @@ class HTML5CSSRenderer implements IRenderer {
     let element: HTMLCanvasElement;
     if (!this.ownedCanvases.has(source)) {
       const cloneBytes = this.getCanvasByteSize(source);
-      if (!this.reserveDuplicateClone(cloneBytes)) return;
+      const seenExternalCanvas = this.externalCanvasSet.has(source);
+      if (seenExternalCanvas && !this.reserveDuplicateClone(cloneBytes)) return;
       element = this.root.ownerDocument.createElement("canvas");
       element.width = source.width;
       element.height = source.height;
       const ctx = element.getContext("2d");
       if (!ctx) {
-        this.releaseDuplicateClone(cloneBytes);
+        if (seenExternalCanvas) this.releaseDuplicateClone(cloneBytes);
         console.warn(
           "HTML5CSSRenderer: failed to acquire 2D context for canvas copy.",
         );
         return;
       }
       ctx.drawImage(source, 0, 0);
+      this.externalCanvasSet.add(source);
     } else if (this.activeCanvasSet.has(source)) {
       const cloneBytes = this.getCanvasByteSize(source);
       if (!this.reserveDuplicateClone(cloneBytes)) return;
@@ -935,6 +938,7 @@ class HTML5CSSRenderer implements IRenderer {
   private resetDuplicateCloneAccounting(): void {
     this.duplicateCloneCount = 0;
     this.duplicateCloneBytes = 0;
+    this.externalCanvasSet = new WeakSet();
   }
 
   private trimHelperSurfaces(): void {

--- a/src/renderer/html5css.ts
+++ b/src/renderer/html5css.ts
@@ -21,6 +21,11 @@ type SavedCssRenderState = CssRenderState & {
   helper: CanvasRenderer;
 };
 
+type DuplicateCloneBudget = {
+  bytes: number;
+  count: number;
+};
+
 const DEFAULT_CSS_RENDER_STATE: CssRenderState = {
   alpha: 1,
   fillStyle: "#000000",
@@ -66,8 +71,10 @@ class HTML5CSSRenderer implements IRenderer {
     HTMLCanvasElement,
     HTMLCanvasElement
   >();
-  private duplicateCloneCount = 0;
-  private duplicateCloneBytes = 0;
+  private duplicateCloneBudgetMap = new Map<
+    HTMLCanvasElement,
+    DuplicateCloneBudget
+  >();
   private externalCanvasSet = new WeakSet<HTMLCanvasElement>();
   // Canvases created by this renderer's getCanvas() — safe to reparent in drawImage.
   // External canvases are never reparented; pixels are copied instead.
@@ -563,13 +570,14 @@ class HTML5CSSRenderer implements IRenderer {
     if (!this.ownedCanvases.has(source)) {
       const cloneBytes = this.getCanvasByteSize(source);
       const seenExternalCanvas = this.externalCanvasSet.has(source);
-      if (seenExternalCanvas && !this.reserveDuplicateClone(cloneBytes)) return;
+      if (seenExternalCanvas && !this.reserveDuplicateClone(source, cloneBytes))
+        return;
       element = this.root.ownerDocument.createElement("canvas");
       element.width = source.width;
       element.height = source.height;
       const ctx = element.getContext("2d");
       if (!ctx) {
-        if (seenExternalCanvas) this.releaseDuplicateClone(cloneBytes);
+        if (seenExternalCanvas) this.releaseDuplicateClone(source, cloneBytes);
         console.warn(
           "HTML5CSSRenderer: failed to acquire 2D context for canvas copy.",
         );
@@ -579,13 +587,13 @@ class HTML5CSSRenderer implements IRenderer {
       this.externalCanvasSet.add(source);
     } else if (this.activeCanvasSet.has(source)) {
       const cloneBytes = this.getCanvasByteSize(source);
-      if (!this.reserveDuplicateClone(cloneBytes)) return;
+      if (!this.reserveDuplicateClone(source, cloneBytes)) return;
       element = this.root.ownerDocument.createElement("canvas");
       element.width = source.width;
       element.height = source.height;
       const ctx = element.getContext("2d");
       if (!ctx) {
-        this.releaseDuplicateClone(cloneBytes);
+        this.releaseDuplicateClone(source, cloneBytes);
         console.warn(
           "HTML5CSSRenderer: failed to acquire 2D context for canvas clone.",
         );
@@ -917,27 +925,41 @@ class HTML5CSSRenderer implements IRenderer {
       : 0;
   }
 
-  private reserveDuplicateClone(bytes: number): boolean {
+  private reserveDuplicateClone(
+    source: HTMLCanvasElement,
+    bytes: number,
+  ): boolean {
+    const budget = this.duplicateCloneBudgetMap.get(source) ?? {
+      bytes: 0,
+      count: 0,
+    };
     if (
-      this.duplicateCloneCount >= MAX_DUPLICATE_CANVAS_CLONES_PER_FRAME ||
-      this.duplicateCloneBytes + bytes >
-        MAX_DUPLICATE_CANVAS_CLONE_BYTES_PER_FRAME
+      budget.count >= MAX_DUPLICATE_CANVAS_CLONES_PER_FRAME ||
+      budget.bytes + bytes > MAX_DUPLICATE_CANVAS_CLONE_BYTES_PER_FRAME
     ) {
       return false;
     }
-    this.duplicateCloneCount++;
-    this.duplicateCloneBytes += bytes;
+    budget.count++;
+    budget.bytes += bytes;
+    this.duplicateCloneBudgetMap.set(source, budget);
     return true;
   }
 
-  private releaseDuplicateClone(bytes: number): void {
-    this.duplicateCloneCount = Math.max(0, this.duplicateCloneCount - 1);
-    this.duplicateCloneBytes = Math.max(0, this.duplicateCloneBytes - bytes);
+  private releaseDuplicateClone(
+    source: HTMLCanvasElement,
+    bytes: number,
+  ): void {
+    const budget = this.duplicateCloneBudgetMap.get(source);
+    if (!budget) return;
+    budget.count = Math.max(0, budget.count - 1);
+    budget.bytes = Math.max(0, budget.bytes - bytes);
+    if (budget.count === 0 && budget.bytes === 0) {
+      this.duplicateCloneBudgetMap.delete(source);
+    }
   }
 
   private resetDuplicateCloneAccounting(): void {
-    this.duplicateCloneCount = 0;
-    this.duplicateCloneBytes = 0;
+    this.duplicateCloneBudgetMap.clear();
     this.externalCanvasSet = new WeakSet();
   }
 

--- a/src/renderer/html5css.ts
+++ b/src/renderer/html5css.ts
@@ -3,6 +3,9 @@ import { CanvasRenderer, clampCanvasSize } from "@/renderer/canvas";
 
 // Must be >= 1; trimHelperSurfaces keeps surfaces[0..helperCursor] after each frame.
 const MAX_HELPER_SURFACES = 8;
+const MAX_DUPLICATE_CANVAS_CLONES_PER_FRAME = 128;
+const MAX_DUPLICATE_CANVAS_CLONE_BYTES_PER_FRAME = 64 * 1024 * 1024;
+const CANVAS_RGBA_BYTES_PER_PIXEL = 4;
 
 type CssRenderState = {
   alpha: number;
@@ -63,6 +66,8 @@ class HTML5CSSRenderer implements IRenderer {
     HTMLCanvasElement,
     HTMLCanvasElement
   >();
+  private duplicateCloneCount = 0;
+  private duplicateCloneBytes = 0;
   // Canvases created by this renderer's getCanvas() — safe to reparent in drawImage.
   // External canvases are never reparented; pixels are copied instead.
   private readonly ownedCanvases = new WeakSet<HTMLCanvasElement>();
@@ -182,6 +187,7 @@ class HTML5CSSRenderer implements IRenderer {
     this.prevCanvasSet.clear();
     this.activeCanvasSet.clear();
     this.cloneMap.clear();
+    this.resetDuplicateCloneAccounting();
     this.layer.remove();
     this.canvas.remove();
     this.root.classList.remove("niconicomments-html5css-renderer");
@@ -336,6 +342,7 @@ class HTML5CSSRenderer implements IRenderer {
     // Source canvases are NOT hidden here — they remain visible until flush()
     // removes stale ones, keeping them flicker-free across frames.
     this.trimHelperSurfaces();
+    this.resetDuplicateCloneAccounting();
     this.helper = this.prepareHelperSurface(0);
     this.helper.canvas.style.display = "none";
     if (this.videoSurface) {
@@ -386,6 +393,7 @@ class HTML5CSSRenderer implements IRenderer {
     this.prevCanvasSet.clear();
     this.activeCanvasSet.clear();
     this.cloneMap.clear();
+    this.resetDuplicateCloneAccounting();
     this.canvas.width = size.width;
     this.canvas.height = size.height;
     this.layer.style.width = `${size.width}px`;
@@ -564,11 +572,14 @@ class HTML5CSSRenderer implements IRenderer {
       }
       ctx.drawImage(source, 0, 0);
     } else if (this.activeCanvasSet.has(source)) {
+      const cloneBytes = this.getCanvasByteSize(source);
+      if (!this.reserveDuplicateClone(cloneBytes)) return;
       element = this.root.ownerDocument.createElement("canvas");
       element.width = source.width;
       element.height = source.height;
       const ctx = element.getContext("2d");
       if (!ctx) {
+        this.releaseDuplicateClone(cloneBytes);
         console.warn(
           "HTML5CSSRenderer: failed to acquire 2D context for canvas clone.",
         );
@@ -639,6 +650,7 @@ class HTML5CSSRenderer implements IRenderer {
     this.prevCanvasSet = this.activeCanvasSet;
     this.activeCanvasSet = tmp;
     this.activeCanvasSet.clear();
+    this.resetDuplicateCloneAccounting();
     this.textDrawnBeforeDom = false;
     if (this.stateStack.length > 0) {
       console.warn(
@@ -890,6 +902,36 @@ class HTML5CSSRenderer implements IRenderer {
       this.helperCursor + 1 >= MAX_HELPER_SURFACES &&
       this.helper.canvas.isConnected
     );
+  }
+
+  private getCanvasByteSize(canvas: HTMLCanvasElement): number {
+    const pixels = canvas.width * canvas.height;
+    return Number.isFinite(pixels) && pixels > 0
+      ? pixels * CANVAS_RGBA_BYTES_PER_PIXEL
+      : 0;
+  }
+
+  private reserveDuplicateClone(bytes: number): boolean {
+    if (
+      this.duplicateCloneCount >= MAX_DUPLICATE_CANVAS_CLONES_PER_FRAME ||
+      this.duplicateCloneBytes + bytes >
+        MAX_DUPLICATE_CANVAS_CLONE_BYTES_PER_FRAME
+    ) {
+      return false;
+    }
+    this.duplicateCloneCount++;
+    this.duplicateCloneBytes += bytes;
+    return true;
+  }
+
+  private releaseDuplicateClone(bytes: number): void {
+    this.duplicateCloneCount = Math.max(0, this.duplicateCloneCount - 1);
+    this.duplicateCloneBytes = Math.max(0, this.duplicateCloneBytes - bytes);
+  }
+
+  private resetDuplicateCloneAccounting(): void {
+    this.duplicateCloneCount = 0;
+    this.duplicateCloneBytes = 0;
   }
 
   private trimHelperSurfaces(): void {

--- a/src/renderer/html5css.ts
+++ b/src/renderer/html5css.ts
@@ -3,7 +3,7 @@ import { CanvasRenderer, clampCanvasSize } from "@/renderer/canvas";
 
 // Must be >= 1; trimHelperSurfaces keeps surfaces[0..helperCursor] after each frame.
 const MAX_HELPER_SURFACES = 8;
-const MAX_DUPLICATE_CANVAS_CLONES_PER_FRAME = 128;
+const MAX_DUPLICATE_CANVAS_CLONES_PER_FRAME = 1024;
 const MAX_DUPLICATE_CANVAS_CLONE_BYTES_PER_FRAME = 64 * 1024 * 1024;
 const CANVAS_RGBA_BYTES_PER_PIXEL = 4;
 

--- a/src/renderer/html5css.ts
+++ b/src/renderer/html5css.ts
@@ -560,11 +560,14 @@ class HTML5CSSRenderer implements IRenderer {
     // occurrences to be independently positioned.
     let element: HTMLCanvasElement;
     if (!this.ownedCanvases.has(source)) {
+      const cloneBytes = this.getCanvasByteSize(source);
+      if (!this.reserveDuplicateClone(cloneBytes)) return;
       element = this.root.ownerDocument.createElement("canvas");
       element.width = source.width;
       element.height = source.height;
       const ctx = element.getContext("2d");
       if (!ctx) {
+        this.releaseDuplicateClone(cloneBytes);
         console.warn(
           "HTML5CSSRenderer: failed to acquire 2D context for canvas copy.",
         );


### PR DESCRIPTION
## Summary
- bound per-frame duplicate owned canvas clone allocation by count and estimated RGBA bytes
- skip over-cap duplicate draws without throwing
- add regression coverage for count cap, byte cap, and connected-canvas recovery across frames

## Validation
- rtk pnpm build
- rtk pnpm exec playwright test src/__tests__/html5css-renderer.spec.ts -g "bounds duplicate owned canvas clones per frame" --config /tmp/niconicomments-playwright-18080.config.ts
- rtk pnpm exec playwright test src/__tests__/html5css-renderer.spec.ts --config /tmp/niconicomments-playwright-18080.config.ts
- rtk pnpm vitest run src/__tests__/html5css-renderer.spec.ts (exit 0; no files found because Vitest config excludes Playwright specs)
- rtk pnpm vitest run tests/unit/html5-resource-bounds.spec.ts
- rtk pnpm lint
- rtk pnpm check-types

## Review
Independent re-review: APPROVED, no REQUIRED findings.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces per-frame bounding of duplicate canvas clone allocation in the CSS renderer. When the same source canvas is drawn more than once in a frame, copies are now capped at 1024 clones per source and 64 MiB total bytes per source, with over-cap draws silently skipped. Test URLs are also changed from hardcoded `http://localhost:8080/...` to root-relative `/...` paths.

- **New budget accounting** (`duplicateCloneBudgetMap`, `externalCanvasSet`): tracks clone count and estimated RGBA byte cost per source canvas per frame; `reserveDuplicateClone`/`releaseDuplicateClone` guard the creation paths, and `resetDuplicateCloneAccounting` clears accounting at every frame boundary (`clearRect`, `flush`, `setSize`, `destroy`).
- **External canvas distinction**: first copy of an external (non-owned) canvas is allowed unconditionally; only subsequent copies of the same source consume the duplicate budget — owned canvases are budgeted starting from the second draw.
- **New Playwright test** covers count-cap, byte-cap, connected-canvas recovery across frames, and external-canvas copy budgeting, with all expectations validated against the implementation's constants.
</details>

<h3>Confidence Score: 5/5</h3>

The change is safe to merge; it adds opt-out guard paths with no mutations to existing happy-path rendering logic.

Budget accounting is reset at every frame boundary (clearRect, flush, setSize, destroy), reserve/release symmetry on context-acquisition failure is correct, and all test expectations were verified against the implementation constants.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/renderer/html5css.ts | Adds per-source-per-frame duplicate clone budget (count ≤ 1024, bytes ≤ 64 MiB); accounting is correctly reset at all frame boundaries; release on context-acquisition failure is symmetric; logic, constants, and test expectations all match. |
| src/__tests__/html5css-renderer.spec.ts | URL hardcoding removed in favour of root-relative paths; new regression test exercises count cap, byte cap, cross-frame recovery, and external-canvas copy budgeting with correct expectations derived from the implementation constants. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[drawImage called] --> B{ownedCanvas?}
    B -- No --> C{seenExternalCanvas?}
    C -- No --> D[Create canvas copy\nfree, no budget charged]
    D --> E[externalCanvasSet.add source]
    C -- Yes --> F{reserveDuplicateClone\ncount < 1024 AND\nbytes <= 64 MiB?}
    F -- No --> G[return - draw skipped]
    F -- Yes --> H[Create canvas copy]
    H --> I{getContext 2d OK?}
    I -- No --> J[releaseDuplicateClone\nreturn]
    I -- Yes --> K[ctx.drawImage / add to DOM]
    B -- Yes --> L{activeCanvasSet.has source?}
    L -- No --> M[Reparent source canvas\nno clone needed]
    L -- Yes --> N{reserveDuplicateClone\ncount < 1024 AND\nbytes <= 64 MiB?}
    N -- No --> G
    N -- Yes --> O[Clone source canvas]
    O --> P{getContext 2d OK?}
    P -- No --> Q[releaseDuplicateClone\nreturn]
    P -- Yes --> R[ctx.drawImage / cloneMap.set / add to DOM]
    K --> S[layer.appendChild / activeCanvasSet.add]
    M --> S
    R --> S
    S --> T[flush - resetDuplicateCloneAccounting]
```
</details>

<sub>Reviews (5): Last reviewed commit: ["Track CSS renderer clone budgets per sou..."](https://github.com/xpadev-net/niconicomments/commit/85eb2957d9316c03b4796a5f6b03088f74e3adc7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36070619)</sub>

<!-- /greptile_comment -->