### PR TITLE
Preserve mail command order in image cache keys

### DIFF
--- a/src/comments/BaseComment.ts
+++ b/src/comments/BaseComment.ts
@@ -485,8 +485,7 @@ class BaseComment implements IComment {
   }
 
   protected getCacheKey() {
-    const sortedMail = [...this.comment.mail].sort().join(",");
-    return `${this.pluginName}\0${sortedMail}\0${boundedCachePart(this.comment.rawContent)}`;
+    return `${this.pluginName}\0${this.comment.mail.join(",")}\0${boundedCachePart(this.comment.rawContent)}`;
   }
 }
 

--- a/src/comments/BaseComment.ts
+++ b/src/comments/BaseComment.ts
@@ -485,7 +485,7 @@ class BaseComment implements IComment {
   }
 
   protected getCacheKey() {
-    const mail = boundedCachePart(JSON.stringify(this.comment.mail));
+    const mail = boundedCachePart(JSON.stringify(this.comment.mail ?? []));
     return `${this.pluginName}\0${mail}\0${boundedCachePart(this.comment.rawContent)}`;
   }
 }

--- a/src/comments/BaseComment.ts
+++ b/src/comments/BaseComment.ts
@@ -485,7 +485,8 @@ class BaseComment implements IComment {
   }
 
   protected getCacheKey() {
-    return `${this.pluginName}\0${this.comment.mail.join(",")}\0${boundedCachePart(this.comment.rawContent)}`;
+    const mail = boundedCachePart(JSON.stringify(this.comment.mail));
+    return `${this.pluginName}\0${mail}\0${boundedCachePart(this.comment.rawContent)}`;
   }
 }
 

--- a/tests/unit/html5-resource-bounds.spec.ts
+++ b/tests/unit/html5-resource-bounds.spec.ts
@@ -308,6 +308,41 @@ describe("HTML5 comment resource bounds", () => {
     expect(firstComment?.exposeCurrentImage()).toBeTruthy();
   });
 
+  test("preserves mail command order in image cache keys", () => {
+    const ctx = createContext();
+    const first = new TestHTML5Comment(
+      formattedComment(1, "same content", ["red", "blue"]),
+      new RecordingRenderer(),
+      0,
+      ctx,
+    );
+    const reversed = new TestHTML5Comment(
+      formattedComment(2, "same content", ["blue", "red"]),
+      new RecordingRenderer(),
+      1,
+      ctx,
+    );
+    const identical = new TestHTML5Comment(
+      formattedComment(3, "same content", ["red", "blue"]),
+      new RecordingRenderer(),
+      2,
+      ctx,
+    );
+
+    expect(first.comment.color).not.toBe(reversed.comment.color);
+    expect(first.exposeCacheKey()).not.toBe(reversed.exposeCacheKey());
+    expect(first.exposeCacheKey()).toBe(identical.exposeCacheKey());
+
+    const firstImage = first.exposeTextImage();
+    const reversedImage = reversed.exposeTextImage();
+    const identicalImage = identical.exposeTextImage();
+
+    expect(firstImage).not.toBeNull();
+    expect(reversedImage).not.toBeNull();
+    expect(firstImage).not.toBe(reversedImage);
+    expect(identicalImage).toBe(firstImage);
+  });
+
   test("clamps backing canvas dimensions including padding", () => {
     const context = {
       textAlign: "start",

--- a/tests/unit/html5-resource-bounds.spec.ts
+++ b/tests/unit/html5-resource-bounds.spec.ts
@@ -343,6 +343,34 @@ describe("HTML5 comment resource bounds", () => {
     expect(identicalImage).toBe(firstImage);
   });
 
+  test("keeps delimiter-ambiguous mail arrays out of the same image cache entry", () => {
+    const ctx = createContext();
+    const commaCommand = new TestHTML5Comment(
+      formattedComment(1, "same content", ["red,blue"]),
+      new RecordingRenderer(),
+      0,
+      ctx,
+    );
+    const separateCommands = new TestHTML5Comment(
+      formattedComment(2, "same content", ["red", "blue"]),
+      new RecordingRenderer(),
+      1,
+      ctx,
+    );
+
+    expect(commaCommand.comment.color).not.toBe(separateCommands.comment.color);
+    expect(commaCommand.exposeCacheKey()).not.toBe(
+      separateCommands.exposeCacheKey(),
+    );
+
+    const commaImage = commaCommand.exposeTextImage();
+    const separateImage = separateCommands.exposeTextImage();
+
+    expect(commaImage).not.toBeNull();
+    expect(separateImage).not.toBeNull();
+    expect(commaImage).not.toBe(separateImage);
+  });
+
   test("clamps backing canvas dimensions including padding", () => {
     const context = {
       textAlign: "start",


### PR DESCRIPTION
## Summary
- Preserve ordered mail command arrays in HTML5 comment image cache keys
- Use unambiguous, bounded JSON serialization for mail key data
- Add regressions for reversed conflicting colors and delimiter-ambiguous mail arrays

## Validation
- rtk pnpm vitest run tests/unit/html5-resource-bounds.spec.ts
- rtk pnpm lint
- rtk pnpm check-types
- rtk git diff --check

Independent review: APPROVED, no REQUIRED findings.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a cache key collision bug in `BaseComment.getCacheKey()` where sorting and joining mail commands with a comma delimiter could cause two logically distinct comments to share the same image cache entry, resulting in incorrect rendering. The fix replaces `[...mail].sort().join(",")` with `JSON.stringify(mail ?? [])` wrapped in the existing `boundedCachePart` guard.

- **Order-sensitive cache keys**: `["red","blue"]` and `["blue","red"]` previously produced identical sorted cache keys; they now produce distinct JSON-serialized keys that correctly reflect the different processing order of mail commands.
- **Delimiter ambiguity fixed**: A single mail element containing `","` (e.g. `["red,blue"]`) previously collided with two separate elements `["red","blue"]`; JSON encoding eliminates this ambiguity.
- **Null guard added**: The `?? []` fallback gracefully handles a potentially absent `mail` field at runtime, whereas the old spread `[...mail]` would have thrown.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted, self-contained fix to an internal cache key function with no public API impact.

The diff replaces a sort-then-join heuristic with unambiguous JSON serialization. Both code paths are short, the logic is straightforward, and two purpose-built regression tests cover the two distinct failure modes the old code exhibited (reversed order and comma-in-element ambiguity). The ?? [] null guard adds resilience without risk.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/comments/BaseComment.ts | Two-line fix replacing sort+join with JSON.stringify for cache key generation; correctly preserves mail order and eliminates delimiter ambiguity. |
| tests/unit/html5-resource-bounds.spec.ts | Two new regression tests added: one for reversed mail command order, one for delimiter-ambiguous arrays; both test cache key distinctness and actual image cache behaviour. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["getCacheKey() called"] --> B["JSON.stringify(mail ?? [])"]
    B --> C["boundedCachePart(jsonMail)"]
    C --> D{"len <= 512?"}
    D -- yes --> E["use raw JSON string"]
    D -- no --> F["prefix + suffix + len + hash"]
    E --> G["assemble key:\npluginName + NUL + mailPart + NUL + contentPart"]
    F --> G
    G --> H{"imageCache.get(key)?"}
    H -- hit --> I["return cached IRenderer"]
    H -- miss --> J["render text to new IRenderer"]
    J --> K["imageCache.set(key, renderer)"]
    K --> I
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Handle missing mail in comment image cac..."](https://github.com/xpadev-net/niconicomments/commit/8a47e265eb776a39bf63bfae02aef1422049f14f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36074171)</sub>

<!-- /greptile_comment -->