### PR TITLE
Fix HTML5 max-line clamping

### DIFF
--- a/src/comments/HTML5Comment.ts
+++ b/src/comments/HTML5Comment.ts
@@ -42,11 +42,10 @@ const clampHTML5Content = (input: string) => {
   let end = 0;
   for (; end < input.length && end < MAX_HTML5_COMMENT_CHARS; end++) {
     if (input[end] === "\n") {
-      lineCount++;
       if (lineCount >= MAX_HTML5_COMMENT_LINES) {
-        end++;
         break;
       }
+      lineCount++;
     }
   }
   const content = input.slice(0, end);

--- a/tests/unit/html5-resource-bounds.spec.ts
+++ b/tests/unit/html5-resource-bounds.spec.ts
@@ -194,6 +194,54 @@ describe("HTML5 comment resource bounds", () => {
     expect(renderer.children[0]?.strokeTextCalls).toBe(3);
   });
 
+  test("preserves text on the final allowed HTML5 line", () => {
+    const renderer = new RecordingRenderer();
+    const content = Array.from({ length: 256 }, (_, i) => `line-${i + 1}`).join(
+      "\n",
+    );
+    const comment = new TestHTML5Comment(
+      formattedComment(1, content),
+      renderer,
+      0,
+      createContext(),
+    );
+
+    expect(comment.comment.lineCount).toBe(256);
+    expect(comment.comment.content).toContainEqual(
+      expect.objectContaining({
+        content: expect.stringContaining("line-256"),
+        slicedContent: expect.arrayContaining(["line-256"]),
+      }),
+    );
+  });
+
+  test("clamps over-limit HTML5 lines after preserving the final allowed line", () => {
+    const renderer = new RecordingRenderer();
+    const content = Array.from({ length: 300 }, (_, i) => `line-${i + 1}`).join(
+      "\n",
+    );
+    const comment = new TestHTML5Comment(
+      formattedComment(1, content),
+      renderer,
+      0,
+      createContext(),
+    );
+
+    expect(comment.comment.lineCount).toBe(256);
+    expect(comment.comment.content).toContainEqual(
+      expect.objectContaining({
+        content: expect.stringContaining("line-256"),
+        slicedContent: expect.arrayContaining(["line-256"]),
+      }),
+    );
+    expect(comment.comment.content).not.toContainEqual(
+      expect.objectContaining({
+        content: expect.stringContaining("line-257"),
+        slicedContent: expect.arrayContaining(["line-257"]),
+      }),
+    );
+  });
+
   test.each([
     "ue",
     "shita",


### PR DESCRIPTION
## Summary
- preserve text on the final allowed HTML5 comment line
- keep over-limit comments clamped to the max line count
- add focused regression coverage for exact and over-limit max-line inputs

## Validation
- rtk pnpm vitest run tests/unit/html5-resource-bounds.spec.ts
- rtk pnpm lint
- rtk pnpm check-types
- rtk git diff --check

Independent review: APPROVED, no REQUIRED findings.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Fixes a line-counting off-by-one in `clampHTML5Content` that caused the text on the final allowed HTML5 comment line to be silently dropped. The root cause was that the old code incremented `lineCount` before the limit check and then advanced `end` past the newline before breaking, so `input.slice(0, end)` captured the newline separator but none of the text that followed it.

- **`src/comments/HTML5Comment.ts`**: Reorders the guard and increment so that when the limit is reached the loop breaks with `end` pointing *at* the newline, preserving all characters on line 256 in the sliced content.
- **`tests/unit/html5-resource-bounds.spec.ts`**: Adds two regression tests — one for exactly 256 lines (verifies "line-256" is present) and one for 300 lines (verifies "line-256" is present and "line-257" is absent).
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, well-tested reorder of two lines in a single pure function with no side effects.

The fix correctly moves the limit guard before the increment so that breaking at a newline leaves `end` pointing at the newline character, preserving all content on the final allowed line. Both edge cases (exact limit and over-limit) are covered by new regression tests, and the function has no I/O or mutable state beyond its local variables.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/comments/HTML5Comment.ts | Fixes `clampHTML5Content` off-by-one: reorders the `lineCount >= MAX_HTML5_COMMENT_LINES` guard to fire before incrementing so the break leaves `end` at the newline boundary, preserving all text on line 256. |
| tests/unit/html5-resource-bounds.spec.ts | Adds two targeted regression tests covering the exact-limit (256 lines) and over-limit (300 lines) cases; both verify the presence of "line-256" and the absence of "line-257". |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["clampHTML5Content(input)"] --> B["lineCount = 1, end = 0"]
    B --> C{"end < input.length\nAND end < MAX_CHARS?"}
    C -- No --> G["content = input.slice(0, end)"]
    C -- Yes --> D{"input[end] === '\\n'?"}
    D -- No --> E["end++"] --> C
    D -- Yes --> F{"lineCount >= MAX_LINES\n(256)?"}
    F -- Yes --> H["break — end points AT newline\n(final line text preserved)"]
    F -- No --> I["lineCount++"] --> E
    H --> G
    G --> J["return { content, lineCount }"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/dev..."](https://github.com/xpadev-net/niconicomments/commit/9e700a6823960239c30dd0129ecf71ea79f4eabc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36074860)</sub>

<!-- /greptile_comment -->