### PR TITLE
Fix CSS duplicate clone byte budget

### DIFF
--- a/src/__tests__/html5css-renderer.spec.ts
+++ b/src/__tests__/html5css-renderer.spec.ts
@@ -576,6 +576,46 @@ test("HTML5CSSRenderer bounds duplicate owned canvas clones per frame", async ({
         renderer.drawImage(image, i % 200, Math.floor(i / 200) * 12);
       }
     };
+    const withVirtualCreatedCanvases = <T>(callback: () => T): T => {
+      const originalCreateElement = document.createElement;
+      document.createElement = ((
+        tagName: string,
+        options?: ElementCreationOptions,
+      ) => {
+        const element = originalCreateElement.call(document, tagName, options);
+        if (tagName.toLowerCase() === "canvas") {
+          let virtualWidth = 0;
+          let virtualHeight = 0;
+          Object.defineProperty(element, "width", {
+            configurable: true,
+            get: () => virtualWidth,
+            set: (value) => {
+              virtualWidth = Number(value) || 0;
+            },
+          });
+          Object.defineProperty(element, "height", {
+            configurable: true,
+            get: () => virtualHeight,
+            set: (value) => {
+              virtualHeight = Number(value) || 0;
+            },
+          });
+          Object.defineProperty(element, "getContext", {
+            configurable: true,
+            value: () =>
+              ({
+                drawImage: () => undefined,
+              }) as unknown as CanvasRenderingContext2D,
+          });
+        }
+        return element;
+      }) as typeof document.createElement;
+      try {
+        return callback();
+      } finally {
+        document.createElement = originalCreateElement;
+      }
+    };
 
     const countCase = createRenderer();
     const smallImage = countCase.renderer.getCanvas();
@@ -607,7 +647,9 @@ test("HTML5CSSRenderer bounds duplicate owned canvas clones per frame", async ({
     const byteCase = createRenderer();
     const largeImage = byteCase.renderer.getCanvas();
     largeImage.setSize(2048, 2048);
-    drawRepeatedly(byteCase.renderer, largeImage, 20);
+    withVirtualCreatedCanvases(() => {
+      drawRepeatedly(byteCase.renderer, largeImage, 40);
+    });
     byteCase.renderer.flush();
     const byteCappedFrameConnectedCanvases = countLayerCanvases(byteCase.layer);
     const byteCappedFrameVisibleCanvases = countVisibleLayerCanvases(
@@ -625,7 +667,9 @@ test("HTML5CSSRenderer bounds duplicate owned canvas clones per frame", async ({
         externalElement,
       );
     externalImage.setSize(2048, 2048);
-    drawRepeatedly(externalCase.renderer, externalImage, 20);
+    withVirtualCreatedCanvases(() => {
+      drawRepeatedly(externalCase.renderer, externalImage, 40);
+    });
     externalCase.renderer.flush();
     const externalByteCappedFrameConnectedCanvases = countLayerCanvases(
       externalCase.layer,
@@ -653,15 +697,15 @@ test("HTML5CSSRenderer bounds duplicate owned canvas clones per frame", async ({
   // duplicate draws are skipped without throwing.
   expect(result.countCappedFrameVisibleCanvases).toBe(1025);
   expect(result.countCappedFrameConnectedCanvases).toBe(1025);
-  // 2048 x 2048 x 4 bytes = 16 MiB per clone, so the 64 MiB byte budget allows
-  // the source canvas plus 4 duplicate clones.
-  expect(result.byteCappedFrameVisibleCanvases).toBe(5);
-  expect(result.byteCappedFrameConnectedCanvases).toBe(5);
+  // 2048 x 2048 x 4 bytes = 16 MiB per clone, so the 512 MiB byte budget allows
+  // the source canvas plus 32 duplicate clones.
+  expect(result.byteCappedFrameVisibleCanvases).toBe(33);
+  expect(result.byteCappedFrameConnectedCanvases).toBe(33);
   // External canvases are copied instead of reparented. The first copy of a
   // source is allowed, then repeated copies of that source consume the same
-  // 64 MiB budget, allowing 4 more copied canvases.
-  expect(result.externalByteCappedFrameVisibleCanvases).toBe(5);
-  expect(result.externalByteCappedFrameConnectedCanvases).toBe(5);
+  // 512 MiB budget, allowing 32 more copied canvases.
+  expect(result.externalByteCappedFrameVisibleCanvases).toBe(33);
+  expect(result.externalByteCappedFrameConnectedCanvases).toBe(33);
   expect(result.recoveredFrameVisibleCanvases).toBe(2);
   expect(result.recoveredFrameConnectedCanvases).toBe(2);
 });

--- a/src/__tests__/html5css-renderer.spec.ts
+++ b/src/__tests__/html5css-renderer.spec.ts
@@ -611,9 +611,17 @@ test("HTML5CSSRenderer bounds duplicate owned canvas clones per frame", async ({
         return element;
       }) as typeof document.createElement;
       try {
-        return callback();
-      } finally {
+        const result = callback();
+        if (result instanceof Promise) {
+          return result.finally(() => {
+            document.createElement = originalCreateElement;
+          }) as T;
+        }
         document.createElement = originalCreateElement;
+        return result;
+      } catch (error) {
+        document.createElement = originalCreateElement;
+        throw error;
       }
     };
 

--- a/src/renderer/html5css.ts
+++ b/src/renderer/html5css.ts
@@ -4,7 +4,7 @@ import { CanvasRenderer, clampCanvasSize } from "@/renderer/canvas";
 // Must be >= 1; trimHelperSurfaces keeps surfaces[0..helperCursor] after each frame.
 const MAX_HELPER_SURFACES = 8;
 const MAX_DUPLICATE_CANVAS_CLONES_PER_FRAME = 1024;
-const MAX_DUPLICATE_CANVAS_CLONE_BYTES_PER_FRAME = 64 * 1024 * 1024;
+const MAX_DUPLICATE_CANVAS_CLONE_BYTES_PER_FRAME = 512 * 1024 * 1024;
 const CANVAS_RGBA_BYTES_PER_PIXEL = 4;
 
 type CssRenderState = {


### PR DESCRIPTION
## Summary
- Raise CSS duplicate canvas clone byte budget to 512 MiB while preserving per-source per-frame count and byte bounds.
- Update the HTML5CSSRenderer clone-bound regression for the new finite cap without allocating the full cap in browser memory.

## Validation
- rtk pnpm build
- rtk pnpm lint
- rtk pnpm check-types
- rtk docker-compose run --rm --user root --entrypoint sh pw -lc 'pnpm playwright install firefox >/tmp/pw-install.log && pnpm playwright test src/__tests__/html5css-renderer.spec.ts -g "bounds duplicate owned canvas clones per frame"'\n\n## Review\n- Independent review status: APPROVED, no REQUIRED findings.\n\n## Notes\n- No docs/ changes.\n- Stopped before PR creation previously per orchestrator instruction; now proceeding with hook/merge loop.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR raises the per-frame byte budget for CSS duplicate canvas clones from 64 MiB to 512 MiB, and updates the regression test to verify the new limit without allocating the full 512 MiB of real canvas memory in the test runner.

- **`src/renderer/html5css.ts`**: Single constant change — `MAX_DUPLICATE_CANVAS_CLONE_BYTES_PER_FRAME` increases 8× (64 MiB → 512 MiB), while the per-source count cap (1024) and per-source byte accounting remain intact.
- **`src/__tests__/html5css-renderer.spec.ts`**: Adds `withVirtualCreatedCanvases` to monkey-patch `document.createElement` so cloned canvases carry virtual dimensions without real pixel buffers, increases the draw count from 20 to 40, and updates expectations from 5 to 33 (1 source + 32 budget clones; 512 MiB / 16 MiB per 2048×2048 clone = 32).
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the production change is a single constant increase fully covered by the updated regression test.

The production diff is a one-line constant change; all surrounding per-source count and byte accounting logic is untouched. The test update correctly patches document.createElement to avoid real memory pressure, restores it in every code path (sync success, sync throw, Promise finally), and the expected canvas counts (33 = 1 source + 32 budget clones) follow directly from the new 512 MiB limit divided by 16 MiB per 2048x2048 clone.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/renderer/html5css.ts | Single constant bump from 64 MiB to 512 MiB; all surrounding budget enforcement logic (count cap, per-source byte accounting, reserve/release symmetry) is unchanged. |
| src/__tests__/html5css-renderer.spec.ts | Adds `withVirtualCreatedCanvases` helper to patch `document.createElement` for virtual canvas stubs, preventing actual 512 MiB allocation during tests; expectations updated to 33 (matches 512 MiB / 16 MiB = 32 clones + 1 source). |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["harden virtual canvas test helper"](https://github.com/xpadev-net/niconicomments/commit/28be5c7638f618ae011eb77415e108f8f44db77d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36076481)</sub>

<!-- /greptile_comment -->