### PR TITLE
Fix WebGL custom renderer invalidation

### DIFF
--- a/src/__tests__/webgl2-renderer.spec.ts
+++ b/src/__tests__/webgl2-renderer.spec.ts
@@ -1,0 +1,120 @@
+import type { Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
+
+const baseUrl = process.env.TEST_BASE_URL ?? "";
+
+const loadBundle = async (page: Page) => {
+  await page.goto(`${baseUrl}/docs/sample/test.html`);
+  await page.waitForFunction(() => "NiconiComments" in window);
+  await page.waitForSelector("div#__bs_notify__", { state: "detached" });
+};
+
+test("WebGL2Renderer invalidates non-CanvasRenderer image sources", async ({
+  page,
+}) => {
+  await loadBundle(page);
+
+  const result = await page.evaluate(() => {
+    const global = window as typeof window & {
+      NiconiComments: typeof import("@/main").default;
+    };
+
+    const output = document.createElement("canvas");
+    output.width = 2;
+    output.height = 2;
+    document.body.appendChild(output);
+
+    let renderer: InstanceType<
+      typeof global.NiconiComments.internal.renderer.WebGL2Renderer
+    >;
+    try {
+      renderer = new global.NiconiComments.internal.renderer.WebGL2Renderer(
+        output,
+      );
+    } catch {
+      output.remove();
+      return { supported: false };
+    }
+
+    const source = document.createElement("canvas");
+    source.width = 2;
+    source.height = 2;
+    const sourceCtx = source.getContext("2d");
+    const readback = document.createElement("canvas");
+    readback.width = 2;
+    readback.height = 2;
+    const readCtx = readback.getContext("2d");
+    if (!sourceCtx || !readCtx) {
+      renderer.destroy();
+      output.remove();
+      return { supported: true, pixel: undefined };
+    }
+
+    const customRenderer = {
+      rendererName: "CustomRenderer",
+      canvas: source,
+      destroy() {},
+      drawVideo() {},
+      getFont: () => "10px sans-serif",
+      getFillStyle: () => "#000000",
+      setScale() {},
+      fillRect() {},
+      strokeRect() {},
+      fillText() {},
+      strokeText() {},
+      quadraticCurveTo() {},
+      clearRect() {},
+      setFont() {},
+      setFillStyle() {},
+      setStrokeStyle() {},
+      setLineWidth() {},
+      setGlobalAlpha() {},
+      setSize(width: number, height: number) {
+        source.width = width;
+        source.height = height;
+      },
+      getSize: () => ({ width: source.width, height: source.height }),
+      measureText: () => ({ width: 0 }) as TextMetrics,
+      beginPath() {},
+      closePath() {},
+      moveTo() {},
+      lineTo() {},
+      stroke() {},
+      save() {},
+      restore() {},
+      getCanvas: () => customRenderer,
+      drawImage() {},
+      flush() {},
+      invalidateImage() {},
+    };
+
+    sourceCtx.fillStyle = "#ff0000";
+    sourceCtx.fillRect(0, 0, 2, 2);
+    renderer.drawImage(customRenderer, 0, 0);
+    renderer.flush();
+
+    sourceCtx.fillStyle = "#00ff00";
+    sourceCtx.fillRect(0, 0, 2, 2);
+    renderer.invalidateImage(customRenderer);
+    renderer.clearRect(0, 0, 2, 2);
+    renderer.drawImage(customRenderer, 0, 0);
+    renderer.flush();
+
+    readCtx.drawImage(output, 0, 0);
+    const pixel = Array.from(readCtx.getImageData(0, 0, 1, 1).data);
+    renderer.destroy();
+    output.remove();
+    return { supported: true, pixel };
+  });
+
+  if (!result.supported) {
+    test.skip(true, "WebGL2 not available in this environment");
+    return;
+  }
+
+  expect(result.pixel).toBeDefined();
+  expect(result.pixel?.[0]).toBeLessThan(50);
+  expect(result.pixel?.[1]).toBeGreaterThan(200);
+  expect(result.pixel?.[2]).toBeLessThan(50);
+  expect(result.pixel?.[3]).toBe(255);
+});

--- a/src/renderer/webgl2.ts
+++ b/src/renderer/webgl2.ts
@@ -998,6 +998,7 @@ class WebGL2Renderer implements IRenderer {
   /* ═══ Texture invalidation ═══ */
 
   invalidateImage(image: IRenderer): void {
+    if (!image?.canvas) return;
     const entry = this.texMap.get(image.canvas);
     if (entry) {
       this._deleteTiles(entry);

--- a/src/renderer/webgl2.ts
+++ b/src/renderer/webgl2.ts
@@ -998,7 +998,6 @@ class WebGL2Renderer implements IRenderer {
   /* ═══ Texture invalidation ═══ */
 
   invalidateImage(image: IRenderer): void {
-    if (!(image instanceof CanvasRenderer)) return;
     const entry = this.texMap.get(image.canvas);
     if (entry) {
       this._deleteTiles(entry);


### PR DESCRIPTION
## Summary
- evict WebGL cached textures for any IRenderer canvas, not only CanvasRenderer instances
- add a focused WebGL regression for custom renderer drawImage sources

## Validation
- pnpm run check-types
- pnpm run test:unit
- pnpm run lint
- pnpm run build
- TEST_BASE_URL=http://127.0.0.1:18080 pnpm exec playwright test src/__tests__/webgl2-renderer.spec.ts

## Review
- independent subagent review: APPROVED, no findings

Docs were not changed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where `WebGL2Renderer.invalidateImage` was silently ignoring custom `IRenderer` implementations because it used an `instanceof CanvasRenderer` guard, which was too narrow — any `IRenderer` whose `.canvas` is cached in `texMap` would never have its texture evicted. The guard is replaced with `!image?.canvas`, which correctly covers all `IRenderer` types.

- **`src/renderer/webgl2.ts`**: Replaces `instanceof CanvasRenderer` with `!image?.canvas` in `invalidateImage`, aligning the eviction path with `drawImage` which keys on `image.canvas` for all `IRenderer` implementations.
- **`src/__tests__/webgl2-renderer.spec.ts`**: Adds a Playwright end-to-end test that verifies a custom (non-`CanvasRenderer`) drawImage source is correctly re-read after `invalidateImage` is called, catching the regression directly.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the single-line fix is tightly scoped to the invalidation guard and is directly validated by the new end-to-end test.

The change corrects a silent no-op: invalidateImage previously returned early for any renderer that was not a CanvasRenderer instance, leaving stale GPU textures in place. The fix aligns the guard with how drawImage actually keys the texture cache via image.canvas. The logic is straightforward, the new Playwright test reproduces the exact failure scenario, and no other call sites are affected.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/renderer/webgl2.ts | One-line guard fix in invalidateImage: replaces instanceof CanvasRenderer with !image?.canvas, correctly enabling cache eviction for all IRenderer implementations that expose a canvas property. |
| src/__tests__/webgl2-renderer.spec.ts | New Playwright spec that validates the WebGL2 texture invalidation path for a custom (non-CanvasRenderer) IRenderer by drawing red pixels, mutating the source to green, calling invalidateImage, and asserting the readback is green. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant WebGL2Renderer
    participant texMap

    Caller->>WebGL2Renderer: drawImage(customRenderer, x, y)
    WebGL2Renderer->>texMap: get(customRenderer.canvas)
    texMap-->>WebGL2Renderer: null (miss)
    WebGL2Renderer->>texMap: set(customRenderer.canvas, newEntry)

    Note over Caller,WebGL2Renderer: source canvas pixels change

    Caller->>WebGL2Renderer: invalidateImage(customRenderer)
    Note over WebGL2Renderer: OLD: instanceof CanvasRenderer returns early (bug)
    Note over WebGL2Renderer: NEW: !image?.canvas proceeds
    WebGL2Renderer->>texMap: get(customRenderer.canvas)
    texMap-->>WebGL2Renderer: stale entry
    WebGL2Renderer->>texMap: delete(customRenderer.canvas)

    Caller->>WebGL2Renderer: drawImage(customRenderer, x, y)
    WebGL2Renderer->>texMap: get(customRenderer.canvas)
    texMap-->>WebGL2Renderer: null (miss, re-uploads fresh pixels)
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Guard WebGL image invalidation"](https://github.com/xpadev-net/niconicomments/commit/1ff941b34305632a712d2cb9b649f738a71aea5a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36080926)</sub>

<!-- /greptile_comment -->