### PR TITLE
Fix scaled CanvasRenderer clearing

### DIFF
--- a/src/renderer/canvas.ts
+++ b/src/renderer/canvas.ts
@@ -157,7 +157,13 @@ class CanvasRenderer implements IRenderer {
   }
 
   clearRect(x: number, y: number, width: number, height: number): void {
-    this.context.clearRect(x, y, width, height);
+    this.context.save();
+    try {
+      this.context.setTransform(1, 0, 0, 1, 0, 0);
+      this.context.clearRect(x + this.padding, y + this.padding, width, height);
+    } finally {
+      this.context.restore();
+    }
   }
 
   setFont(font: string): void {

--- a/src/renderer/canvas.ts
+++ b/src/renderer/canvas.ts
@@ -157,10 +157,16 @@ class CanvasRenderer implements IRenderer {
   }
 
   clearRect(x: number, y: number, width: number, height: number): void {
+    const transform = this.context.getTransform();
     this.context.save();
     try {
       this.context.setTransform(1, 0, 0, 1, 0, 0);
-      this.context.clearRect(x + this.padding, y + this.padding, width, height);
+      this.context.clearRect(
+        x * transform.a + transform.e,
+        y * transform.d + transform.f,
+        width * transform.a,
+        height * transform.d,
+      );
     } finally {
       this.context.restore();
     }

--- a/tests/unit/canvas-renderer-clear.spec.ts
+++ b/tests/unit/canvas-renderer-clear.spec.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { CanvasRenderer } from "@/renderer/canvas";
+
+type Transform = {
+  scaleX: number;
+  scaleY: number;
+};
+
+class RecordingCanvasContext {
+  public calls: string[] = [];
+  public fillStyle: string | CanvasGradient | CanvasPattern = "#000000";
+  public font = "10px sans-serif";
+  public lineJoin: CanvasLineJoin = "miter";
+  public strokeStyle: string | CanvasGradient | CanvasPattern = "#000000";
+  public textAlign: CanvasTextAlign = "start";
+  public textBaseline: CanvasTextBaseline = "alphabetic";
+  private transform: Transform = { scaleX: 1, scaleY: 1 };
+  private stack: Transform[] = [];
+
+  save() {
+    this.calls.push("save");
+    this.stack.push({ ...this.transform });
+  }
+
+  restore() {
+    this.calls.push("restore");
+    const restored = this.stack.pop();
+    if (restored) this.transform = restored;
+  }
+
+  setTransform(
+    a: number,
+    b: number,
+    c: number,
+    d: number,
+    e: number,
+    f: number,
+  ) {
+    this.calls.push(`setTransform(${a},${b},${c},${d},${e},${f})`);
+    this.transform = { scaleX: a, scaleY: d };
+  }
+
+  translate(x: number, y: number) {
+    this.calls.push(`translate(${x},${y})`);
+  }
+
+  scale(x: number, y: number) {
+    this.calls.push(`scale(${x},${y})`);
+    this.transform.scaleX *= x;
+    this.transform.scaleY *= y;
+  }
+
+  clearRect(x: number, y: number, width: number, height: number) {
+    this.calls.push(`clearRect(${x},${y},${width},${height})`);
+  }
+
+  fillRect(x: number, y: number, width: number, height: number) {
+    this.calls.push(
+      `fillRect(${x},${y},${width},${height})@${this.transform.scaleX},${this.transform.scaleY}`,
+    );
+  }
+}
+
+const createRenderer = (padding = 0) => {
+  const context = new RecordingCanvasContext();
+  const canvas = {
+    width: 640,
+    height: 360,
+    getContext: vi.fn(() => context),
+  } as unknown as HTMLCanvasElement;
+  const renderer = new CanvasRenderer(canvas, undefined, padding);
+  context.calls = [];
+  return { context, renderer };
+};
+
+describe("CanvasRenderer.clearRect", () => {
+  test("clears with an identity transform and restores scale for subsequent drawing", () => {
+    const { context, renderer } = createRenderer();
+
+    renderer.setScale(0.5);
+    renderer.clearRect(0, 0, 640, 360);
+    renderer.fillRect(10, 20, 30, 40);
+
+    expect(context.calls).toEqual([
+      "scale(0.5,0.5)",
+      "save",
+      "setTransform(1,0,0,1,0,0)",
+      "clearRect(0,0,640,360)",
+      "restore",
+      "fillRect(10,20,30,40)@0.5,0.5",
+    ]);
+  });
+
+  test("preserves padded renderer clear coordinates while resetting scale", () => {
+    const { context, renderer } = createRenderer(4);
+
+    renderer.setScale(0.5, 0.25);
+    renderer.clearRect(1, 2, 100, 50);
+
+    expect(context.calls).toEqual([
+      "scale(0.5,0.25)",
+      "save",
+      "setTransform(1,0,0,1,0,0)",
+      "clearRect(5,6,100,50)",
+      "restore",
+    ]);
+  });
+});

--- a/tests/unit/canvas-renderer-clear.spec.ts
+++ b/tests/unit/canvas-renderer-clear.spec.ts
@@ -5,6 +5,8 @@ import { CanvasRenderer } from "@/renderer/canvas";
 type Transform = {
   scaleX: number;
   scaleY: number;
+  translateX: number;
+  translateY: number;
 };
 
 class RecordingCanvasContext {
@@ -15,7 +17,12 @@ class RecordingCanvasContext {
   public strokeStyle: string | CanvasGradient | CanvasPattern = "#000000";
   public textAlign: CanvasTextAlign = "start";
   public textBaseline: CanvasTextBaseline = "alphabetic";
-  private transform: Transform = { scaleX: 1, scaleY: 1 };
+  private transform: Transform = {
+    scaleX: 1,
+    scaleY: 1,
+    translateX: 0,
+    translateY: 0,
+  };
   private stack: Transform[] = [];
 
   save() {
@@ -38,17 +45,35 @@ class RecordingCanvasContext {
     f: number,
   ) {
     this.calls.push(`setTransform(${a},${b},${c},${d},${e},${f})`);
-    this.transform = { scaleX: a, scaleY: d };
+    this.transform = {
+      scaleX: a,
+      scaleY: d,
+      translateX: e,
+      translateY: f,
+    };
   }
 
   translate(x: number, y: number) {
     this.calls.push(`translate(${x},${y})`);
+    this.transform.translateX += x * this.transform.scaleX;
+    this.transform.translateY += y * this.transform.scaleY;
   }
 
   scale(x: number, y: number) {
     this.calls.push(`scale(${x},${y})`);
     this.transform.scaleX *= x;
     this.transform.scaleY *= y;
+  }
+
+  getTransform() {
+    return {
+      a: this.transform.scaleX,
+      b: 0,
+      c: 0,
+      d: this.transform.scaleY,
+      e: this.transform.translateX,
+      f: this.transform.translateY,
+    };
   }
 
   clearRect(x: number, y: number, width: number, height: number) {
@@ -86,7 +111,7 @@ describe("CanvasRenderer.clearRect", () => {
       "scale(0.5,0.5)",
       "save",
       "setTransform(1,0,0,1,0,0)",
-      "clearRect(0,0,640,360)",
+      "clearRect(0,0,320,180)",
       "restore",
       "fillRect(10,20,30,40)@0.5,0.5",
     ]);
@@ -102,7 +127,22 @@ describe("CanvasRenderer.clearRect", () => {
       "scale(0.5,0.25)",
       "save",
       "setTransform(1,0,0,1,0,0)",
-      "clearRect(5,6,100,50)",
+      "clearRect(4.5,4.5,50,12.5)",
+      "restore",
+    ]);
+  });
+
+  test("expands logical clears when the renderer scale is greater than one", () => {
+    const { context, renderer } = createRenderer();
+
+    renderer.setScale(2);
+    renderer.clearRect(0, 0, 640, 360);
+
+    expect(context.calls).toEqual([
+      "scale(2,2)",
+      "save",
+      "setTransform(1,0,0,1,0,0)",
+      "clearRect(0,0,1280,720)",
       "restore",
     ]);
   });


### PR DESCRIPTION
## Summary
- clear CanvasRenderer backing pixels with an identity transform
- preserve the renderer scale/state after clearRect
- add unit coverage for scaled and padded clears

## Validation
- pnpm run test:unit -- tests/unit/canvas-renderer-clear.spec.ts
- pnpm run check-types
- npx biome check src/renderer/canvas.ts tests/unit/canvas-renderer-clear.spec.ts
- git diff --check develop..HEAD

## Review
- independent subagent review: APPROVED, no findings

Docs were not changed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes `CanvasRenderer.clearRect()` to operate correctly when a non-identity transform (scale and/or padding translate) is active on the backing canvas context. The previous implementation passed logical coordinates directly to `context.clearRect`, which could produce incorrect physical-pixel coverage when the CTM's translate offset (`e`/`f`) combined with explicit scaling.

- **`src/renderer/canvas.ts`**: Snapshots the current CTM via `getTransform()`, resets to identity with `save()`/`setTransform(1,0,0,1,0,0)`, manually maps the logical rect into physical device coordinates, then restores the original state with `restore()` — correctly handling both sub-unity and greater-than-unity scales and padding offsets.
- **`tests/unit/canvas-renderer-clear.spec.ts`**: Adds a self-contained `RecordingCanvasContext` mock and three test cases covering scale < 1, non-uniform scale with padding, and scale > 1 (the regression path flagged in prior review).
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the coordinate mapping is correct for all axis-aligned transforms the renderer exposes, and all three test cases (sub-unity scale, non-uniform scale with padding, and super-unity scale) pass the expected physical-pixel coordinates through to the underlying context.

The change is narrowly scoped to one method: the CTM capture, identity reset, manual coordinate mapping, and save/restore are all straightforward and verified by tests that cover the full range of scale factors used in production. The formula x·a + e, y·d + f, w·a, h·d is exact for the transforms the renderer constructs (scale + translate only, never rotation or shear).

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/renderer/canvas.ts | clearRect now correctly maps logical coordinates to physical device space using the captured CTM before resetting to identity; save()/restore() wraps the temporary transform change in a try/finally to guarantee state recovery. |
| tests/unit/canvas-renderer-clear.spec.ts | New test file covering scale=0.5, non-uniform scale with padding, and scale=2 (regression path); RecordingCanvasContext mock faithfully emulates translate/scale/getTransform semantics used by the production code. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant CanvasRenderer
    participant Context as CanvasRenderingContext2D

    Note over Context: CTM = scale(sx,sy) · translate(px,py)

    Caller->>CanvasRenderer: clearRect(x, y, w, h)
    CanvasRenderer->>Context: getTransform()
    Context-->>CanvasRenderer: "{a, b, c, d, e, f}"
    CanvasRenderer->>Context: save()
    CanvasRenderer->>Context: setTransform(1,0,0,1,0,0)
    Note over CanvasRenderer: x_phys = x·a + e, y_phys = y·d + f
    CanvasRenderer->>Context: clearRect(x_phys, y_phys, w·a, h·d)
    CanvasRenderer->>Context: restore()
    Note over Context: CTM restored to original
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Account for transform when clearing canv..."](https://github.com/xpadev-net/niconicomments/commit/21df65d5f7e8466f22d29957970dd347b998b844) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36081664)</sub>

<!-- /greptile_comment -->