### PR TITLE
Fix Flash collision and button hit testing

### DIFF
--- a/src/comments/FlashComment.ts
+++ b/src/comments/FlashComment.ts
@@ -93,6 +93,9 @@ class FlashComment extends BaseComment {
   override get content() {
     return this.comment.rawContent;
   }
+  override get flash() {
+    return true;
+  }
   override set content(input: string) {
     const { content, lineCount, lineOffset } = this.parseContent(input);
     const comment: FormattedCommentWithFont = {
@@ -552,16 +555,16 @@ class FlashComment extends BaseComment {
   override isHovered(_cursor?: Position, _posX?: number, _posY?: number) {
     if (!_cursor || !this.comment.buttonObjects) return false;
     const { left, middle, right } = this.comment.buttonObjects;
-    const scale =
+    const scaleY =
       this._globalScale *
       this.comment.scale *
-      this.comment.scaleX *
       (this.comment.layer === -1 ? this.ctx.options.scale : 1);
-    const posX = (_posX ?? this.pos.x) / scale;
-    const posY = (_posY ?? this.pos.y) / scale;
+    const scaleX = scaleY * this.comment.scaleX;
+    const posX = (_posX ?? this.pos.x) / scaleX;
+    const posY = (_posY ?? this.pos.y) / scaleY;
     const cursor = {
-      x: _cursor.x / scale,
-      y: _cursor.y / scale,
+      x: _cursor.x / scaleX,
+      y: _cursor.y / scaleY,
     };
     if (
       cursor.x < posX ||

--- a/tests/unit/flash-resource-bounds.spec.ts
+++ b/tests/unit/flash-resource-bounds.spec.ts
@@ -230,6 +230,17 @@ describe("Flash and at-button resource bounds", () => {
     expect(image?.strokeTextCalls).toBeLessThanOrEqual(8);
   });
 
+  test("reports Flash comments as Flash instances", () => {
+    const comment = new TestFlashComment(
+      formattedComment("flash"),
+      new RecordingRenderer(),
+      0,
+      createContext(),
+    );
+
+    expect(comment.flash).toBe(true);
+  });
+
   test("does not allocate Flash text images outside bounded dimensions", () => {
     const renderer = new RecordingRenderer();
     const comment = new TestFlashComment(
@@ -307,6 +318,32 @@ describe("Flash and at-button resource bounds", () => {
 
     expect(renderer.children).toHaveLength(2);
     expect(buttonImage?.setSizeCalls).toBe(1);
+  });
+
+  test("keeps at-button vertical hit testing independent of horizontal scale", () => {
+    const comment = new TestFlashComment(
+      formattedComment('@ボタン "[Push]" "posted" "表示" "" "3"'),
+      new RecordingRenderer(),
+      0,
+      createContext(),
+    );
+    const button = comment.comment.buttonObjects;
+    if (!button) {
+      throw new Error("Expected at-button geometry");
+    }
+
+    comment.comment.scale = 1;
+    comment.comment.scaleX = 10;
+    const { left } = button;
+    expect(left.top).toBeGreaterThan(1);
+
+    const cursor = {
+      x: (left.left + left.width / 2) * comment.comment.scaleX,
+      y: left.top + left.height / 2,
+    };
+
+    expect(cursor.y / comment.comment.scaleX).toBeLessThan(left.top);
+    expect(comment.isHovered(cursor, 0, 0)).toBe(true);
   });
 
   test("does not allocate button canvases for hidden at-buttons", () => {

--- a/tests/unit/flash-resource-bounds.spec.ts
+++ b/tests/unit/flash-resource-bounds.spec.ts
@@ -342,7 +342,6 @@ describe("Flash and at-button resource bounds", () => {
       y: left.top + left.height / 2,
     };
 
-    expect(cursor.y / comment.comment.scaleX).toBeLessThan(left.top);
     expect(comment.isHovered(cursor, 0, 0)).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- report FlashComment instances as Flash for collision overlay config
- normalize Flash at-button hit testing with separate X/Y scales
- add focused unit coverage for both regressions

## Validation
- pnpm run test:unit -- tests/unit/flash-resource-bounds.spec.ts
- pnpm run check-types
- npx biome check src/comments/FlashComment.ts tests/unit/flash-resource-bounds.spec.ts
- git diff --check develop..HEAD

## Review
- independent subagent review: APPROVED, no findings

Docs were not changed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two separate regressions in `FlashComment`: one where Flash instances were not identified as Flash for collision-overlay config lookups, and one where button hit-testing applied the horizontal scale factor to both axes instead of only the horizontal one.

- **`flash` getter** (`FlashComment.ts` line 96–98): overrides `BaseComment.flash` to return `true`, so `getConfig(config.contextLineWidth, comment.flash)` in `main.ts` now selects the correct Flash-branch value for every `FlashComment` in the collision overlay.
- **`isHovered` scale split** (`FlashComment.ts` lines 558–568): separates `scaleY` (global × comment scale × layer) from `scaleX` (scaleY × `comment.scaleX`), then divides cursor and position X by `scaleX` and Y by `scaleY` independently — fixing incorrect vertical hit positions when `comment.scaleX ≠ 1`.
- **Tests** (`tests/unit/flash-resource-bounds.spec.ts`): two new unit tests cover both regressions, including an `isHovered` case with `scaleX = 10` that would have failed before the fix.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — both changes are narrowly scoped bug fixes with direct unit test coverage and no side effects on unrelated code paths.

The `flash` getter is a one-liner override with no branching. The `isHovered` refactor is a mechanical split of a single scale variable into two independent axes, leaving the hit-test geometry logic unchanged. Both fixes are validated by new unit tests that exercise the exact conditions that triggered the original bugs.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/comments/FlashComment.ts | Two targeted bug fixes: adds `flash` getter override returning `true` so collision-overlay calls pick up the correct config branch, and refactors `isHovered` to split `scaleX` out of the shared divisor so vertical hit-testing is no longer distorted when a comment has a non-unit horizontal scale. |
| tests/unit/flash-resource-bounds.spec.ts | Adds two focused unit tests: one directly checking the new `flash` getter returns `true`, and one exercising `isHovered` with `scaleX = 10` to confirm y-axis hit testing is unaffected by horizontal scale. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["isHovered(_cursor, _posX, _posY)"] --> B{buttonObjects?}
    B -- No --> C[return false]
    B -- Yes --> D["scaleY = _globalScale x scale x layerScale"]
    D --> E["scaleX = scaleY x comment.scaleX"]
    E --> F["posX = _posX / scaleX\nposY = _posY / scaleY"]
    F --> G["cursor.x = _cursor.x / scaleX\ncursor.y = _cursor.y / scaleY"]
    G --> H{Outside bounding box?}
    H -- Yes --> C
    H -- No --> I{Inside left/middle parts?}
    I -- Yes --> J[return true]
    I -- No --> K{Inside right part?}
    K -- Yes --> J
    K -- No --> C
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Harden Flash hit-test regression test"](https://github.com/xpadev-net/niconicomments/commit/fd59525fb8b01fbdda9b6dd8099a3cb2588c33c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36083097)</sub>

<!-- /greptile_comment -->