### PR TITLE
Apply plugin transforms before timeline build

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -296,10 +296,6 @@ class NiconiComments {
       pv.push(createCommentInstance(val, this.renderer, index, this.ctx));
       return pv;
     }, []);
-    if (!this.ctx.options.lazy) {
-      this.getCommentPos(instances, instances.length);
-      this.sortTimelineComment();
-    }
 
     const plugins: IPluginList = [];
     for (const plugin of this.ctx.config.plugins) {
@@ -329,9 +325,8 @@ class NiconiComments {
         );
       },
     );
-    if (this.ctx.options.lazy && !this.lazyCommentOrderSortedByVpos) {
-      // Lazy resolution assumes constructor input is vpos-ordered. Preserve
-      // correctness for unsorted input by resolving all comments eagerly once.
+    if (!this.ctx.options.lazy || !this.lazyCommentOrderSortedByVpos) {
+      // Non-lazy rendering and lazy fallback both need final plugin output.
       this.getCommentPos(instances, instances.length);
       this.sortTimelineComment();
     }

--- a/tests/unit/duration-lazy.spec.ts
+++ b/tests/unit/duration-lazy.spec.ts
@@ -45,6 +45,7 @@ class FakeRenderer implements IRenderer {
   public readonly rendererName = "FakeRenderer";
   public readonly canvas = {} as HTMLCanvasElement;
   public clearRectCalls = 0;
+  public fillTextCalls: string[] = [];
   private font = "";
   private size = { width: 1920, height: 1080 };
 
@@ -59,7 +60,9 @@ class FakeRenderer implements IRenderer {
   setScale() {}
   fillRect() {}
   strokeRect() {}
-  fillText() {}
+  fillText(text: string) {
+    this.fillTextCalls.push(text);
+  }
   strokeText() {}
   quadraticCurveTo() {}
   clearRect() {
@@ -99,7 +102,10 @@ class FakeRenderer implements IRenderer {
 class ReverseCommentsPlugin {
   static readonly id = "reverse-comments-plugin";
 
-  constructor(_canvas: IRenderer, _comments: IComment[]) {}
+  constructor(canvas: IRenderer, comments: IComment[]) {
+    void canvas;
+    void comments;
+  }
 
   draw() {
     return false;
@@ -107,6 +113,23 @@ class ReverseCommentsPlugin {
 
   transformComments(comments: IComment[]) {
     return [...comments].reverse();
+  }
+}
+
+class FilterSecondCommentPlugin {
+  static readonly id = "filter-second-comment-plugin";
+
+  constructor(canvas: IRenderer, comments: IComment[]) {
+    void canvas;
+    void comments;
+  }
+
+  draw() {
+    return false;
+  }
+
+  transformComments(comments: IComment[]) {
+    return comments.filter((comment) => comment.comment.id !== 2);
   }
 }
 
@@ -378,6 +401,38 @@ describe("duration bounds and lazy timeline expansion", () => {
     expect(state.comments[0]?.posY).not.toBe(-1);
     expect(state.comments[1]?.posY).not.toBe(-1);
     expect(state.timeline[0]).toBeDefined();
+  });
+
+  test("non-lazy constructor builds timeline from plugin-transformed comments", () => {
+    const renderer = new FakeRenderer();
+    const instance = new NiconiComments(
+      renderer,
+      [
+        createComment({ id: 1, vpos: 0, content: "kept", mail: ["ue"] }),
+        createComment({ id: 2, vpos: 0, content: "removed", mail: ["ue"] }),
+      ],
+      {
+        format: "formatted",
+        lazy: false,
+        mode: "html5",
+        showCommentCount: true,
+        config: { plugins: [FilterSecondCommentPlugin] },
+      },
+    );
+    const state = instance as unknown as {
+      comments: IComment[];
+      timeline: Record<number, IComment[]>;
+    };
+
+    expect(state.comments.map((comment) => comment.comment.id)).toEqual([1]);
+    expect(state.timeline[0]?.map((comment) => comment.comment.id)).toEqual([
+      1,
+    ]);
+
+    instance.drawCanvas(0, true);
+
+    expect(renderer.fillTextCalls).toContain("Count:1");
+    expect(renderer.fillTextCalls).not.toContain("Count:2");
   });
 
   test("addComments keeps hostile durations bounded on the production path", () => {


### PR DESCRIPTION
## Summary
- move non-lazy timeline construction after plugin transformComments output
- preserve sequential plugin constructor/transform ordering
- add a regression test for transformed comments driving timeline and drawn count

## Validation
- pnpm run test:unit -- tests/unit/duration-lazy.spec.ts
- pnpm run check-types
- npx biome check src/main.ts tests/unit/duration-lazy.spec.ts
- git diff --check develop..HEAD

## Review
- independent subagent review: APPROVED, no findings

Docs were not changed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where the non-lazy constructor built the comment timeline **before** plugin `transformComments` was applied, causing the timeline (and drawn-comment count) to reflect the original, untransformed comment set. The fix moves the `getCommentPos` / `sortTimelineComment` call to after all plugin transforms complete and adjusts the guard condition accordingly.

- **`src/main.ts`**: Removes the early eager-timeline block (which ran before plugins), and changes the post-plugin condition from `lazy && !sortedByVpos` to `!lazy || !sortedByVpos` so both the non-lazy path and the lazy-unsorted fallback both build the timeline from the final plugin output.
- **`tests/unit/duration-lazy.spec.ts`**: Adds `FilterSecondCommentPlugin` and a regression test confirming that in non-lazy mode, the timeline and `drawCanvas` comment count reflect only the plugin-transformed comment list.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change correctly defers timeline construction to after all plugin transforms, and the regression test directly exercises the previously broken non-lazy path.

The two-line condition change is a straightforward boolean fix: `lazy && !sorted` is replaced by `!lazy || !sorted`, cleanly covering all four combinations of lazy/sorted without introducing new states. The early eager-build block is removed rather than duplicated, so `processedCommentIndex` (initialized to -1) is consumed exactly once. The related plugin consumer (niconicomments-plugin-niwango) does not implement `transformComments`, so the reordering has no cross-repo impact. The added test covers the previously unguarded code path end-to-end.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/main.ts | Removes early pre-plugin eager timeline build; moves it to after all plugin transforms with corrected condition covering both non-lazy and lazy-unsorted paths — logic is correct and no edge cases missed. |
| tests/unit/duration-lazy.spec.ts | Adds FilterSecondCommentPlugin and a regression test that verifies the timeline and drawCanvas comment count are driven by the post-transform comment list in non-lazy mode. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Constructor
    participant PR as preRendering()
    participant PL as Plugins
    participant TL as Timeline (getCommentPos / sort)

    Note over C,TL: Before this PR (non-lazy path)
    C->>PR: preRendering(data)
    PR->>TL: getCommentPos + sortTimeline (EARLY before plugins)
    PR->>PL: new plugin(canvas, instances)
    PL-->>PR: transformComments(instances)
    PR-->>C: instances (transformed)
    Note over TL: Timeline built from PRE-transform data

    Note over C,TL: After this PR (non-lazy path)
    C->>PR: preRendering(data)
    PR->>PL: new plugin(canvas, instances)
    PL-->>PR: transformComments(instances)
    PR->>TL: getCommentPos + sortTimeline (AFTER plugins)
    PR-->>C: instances (transformed)
    Note over TL: Timeline built from POST-transform data
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Refresh plugin transform review state"](https://github.com/xpadev-net/niconicomments/commit/76e637c0391f509fa97e6ca64c61c3ed6a3334cb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36083980)</sub>

<!-- /greptile_comment -->