### PR TITLE
Guard cached image renderer cleanup

### DIFF
--- a/src/comments/BaseComment.ts
+++ b/src/comments/BaseComment.ts
@@ -22,10 +22,9 @@ const imageCacheEntries = new WeakMap<object, Set<string>>();
 const destroyedTextImages = new WeakSet<IRenderer>();
 
 const destroyTextImage = (image: IRenderer) => {
-  const destroy = image.destroy;
-  if (typeof destroy !== "function") return false;
+  if (typeof image.destroy !== "function") return false;
   destroyedTextImages.add(image);
-  destroy.call(image);
+  image.destroy();
   return true;
 };
 

--- a/src/comments/BaseComment.ts
+++ b/src/comments/BaseComment.ts
@@ -21,6 +21,14 @@ const MAX_IMAGE_CACHE_ENTRIES = 1024;
 const imageCacheEntries = new WeakMap<object, Set<string>>();
 const destroyedTextImages = new WeakSet<IRenderer>();
 
+const destroyTextImage = (image: IRenderer) => {
+  const destroy = image.destroy;
+  if (typeof destroy !== "function") return false;
+  destroyedTextImages.add(image);
+  destroy.call(image);
+  return true;
+};
+
 const hashString = (input: string) => {
   let hash = 2166136261;
   for (let i = 0, n = input.length; i < n; i++) {
@@ -390,8 +398,7 @@ class BaseComment implements IComment {
       cache.timeout = window.setTimeout(
         () => {
           if (imageCache.get(key)?.image === cachedImage) {
-            destroyedTextImages.add(cachedImage);
-            cachedImage.destroy();
+            destroyTextImage(cachedImage);
             imageCache.delete(key);
             imageCacheEntries.get(imageCache)?.delete(key);
           }
@@ -439,8 +446,7 @@ class BaseComment implements IComment {
         const oldest = imageCache.get(oldestKey);
         if (oldest) {
           clearTimeout(oldest.timeout);
-          destroyedTextImages.add(oldest.image);
-          oldest.image.destroy();
+          destroyTextImage(oldest.image);
         }
         imageCache.delete(oldestKey);
         entries.delete(oldestKey);
@@ -452,8 +458,7 @@ class BaseComment implements IComment {
     imageCache.set(key, {
       timeout: window.setTimeout(() => {
         if (imageCache.get(key)?.image === image) {
-          destroyedTextImages.add(image);
-          image.destroy();
+          destroyTextImage(image);
           imageCache.delete(key);
           imageCacheEntries.get(imageCache)?.delete(key);
         }

--- a/src/comments/BaseComment.ts
+++ b/src/comments/BaseComment.ts
@@ -22,6 +22,8 @@ const imageCacheEntries = new WeakMap<object, Set<string>>();
 const destroyedTextImages = new WeakSet<IRenderer>();
 
 const destroyTextImage = (image: IRenderer) => {
+  // Legacy runtime renderers without destroy() are covered by
+  // html5-resource-bounds tests; only destroyed modern images need tracking.
   if (typeof image.destroy !== "function") return false;
   destroyedTextImages.add(image);
   image.destroy();

--- a/src/contexts/cache.ts
+++ b/src/contexts/cache.ts
@@ -20,7 +20,9 @@ class ImageCacheContext {
   reset() {
     for (const entry of Object.values(this._cache)) {
       clearTimeout(entry.timeout);
-      entry.image.destroy();
+      if (typeof entry.image.destroy === "function") {
+        entry.image.destroy();
+      }
     }
     this._cache = {};
   }

--- a/tests/unit/html5-resource-bounds.spec.ts
+++ b/tests/unit/html5-resource-bounds.spec.ts
@@ -504,6 +504,25 @@ describe("HTML5 comment resource bounds", () => {
     expect(ctx.imageCache.get(firstComment.exposeCacheKey())).toBeUndefined();
   });
 
+  test("resets legacy cached images without requiring destroy", () => {
+    const ctx = createContext();
+    const renderer = new LegacyImageSourceRenderer();
+    const comment = new TestHTML5Comment(
+      formattedComment(1, "legacy reset"),
+      renderer,
+      0,
+      ctx,
+    );
+
+    const image = comment.exposeTextImage();
+
+    expect(image).not.toBeNull();
+    expectLegacyImageWithoutDestroy(renderer.legacyImages);
+    expect(ctx.imageCache.get(comment.exposeCacheKey())?.image).toBe(image);
+    expect(() => ctx.imageCache.reset()).not.toThrow();
+    expect(ctx.imageCache.get(comment.exposeCacheKey())).toBeUndefined();
+  });
+
   test("preserves mail command order in image cache keys", () => {
     const ctx = createContext();
     const first = new TestHTML5Comment(

--- a/tests/unit/html5-resource-bounds.spec.ts
+++ b/tests/unit/html5-resource-bounds.spec.ts
@@ -91,6 +91,69 @@ class RecordingRenderer implements IRenderer {
   invalidateImage() {}
 }
 
+const createLegacyImageRenderer = (): Omit<IRenderer, "destroy"> => {
+  let font = "10px sans-serif";
+  let size = { width: 0, height: 0 };
+  return {
+    rendererName: "LegacyImageRenderer",
+    canvas: {} as HTMLCanvasElement,
+    drawVideo() {},
+    getFont() {
+      return font;
+    },
+    getFillStyle() {
+      return "#000000";
+    },
+    setScale() {},
+    fillRect() {},
+    strokeRect() {},
+    fillText() {},
+    strokeText() {},
+    quadraticCurveTo() {},
+    clearRect() {},
+    setFont(nextFont: string) {
+      font = nextFont;
+    },
+    setFillStyle() {},
+    setStrokeStyle() {},
+    setLineWidth() {},
+    setGlobalAlpha() {},
+    setSize(width: number, height: number) {
+      size = { width, height };
+    },
+    getSize() {
+      return size;
+    },
+    measureText(text: string) {
+      const fontSize = Number(/([0-9.]+)px/.exec(font)?.[1] ?? 10);
+      return textMetrics(text.length * fontSize * 0.5);
+    },
+    beginPath() {},
+    closePath() {},
+    moveTo() {},
+    lineTo() {},
+    stroke() {},
+    save() {},
+    restore() {},
+    getCanvas() {
+      return createLegacyImageRenderer() as IRenderer;
+    },
+    drawImage() {},
+    flush() {},
+    invalidateImage() {},
+  };
+};
+
+class LegacyImageSourceRenderer extends RecordingRenderer {
+  public readonly legacyImages: IRenderer[] = [];
+
+  override getCanvas() {
+    const image = createLegacyImageRenderer() as IRenderer;
+    this.legacyImages.push(image);
+    return image;
+  }
+}
+
 class TestHTML5Comment extends HTML5Comment {
   exposeTextImage() {
     return this.getTextImage();
@@ -149,6 +212,14 @@ const createContext = () => ({
 
 const cachedKeyCount = (imageCache: ImageCacheContext, keys: string[]) =>
   keys.filter((key) => imageCache.get(key)).length;
+
+const runWindowTimeout = (callIndex: number) => {
+  const timeoutCall = vi.mocked(window.setTimeout).mock.calls[callIndex];
+  const callback = timeoutCall?.[0];
+
+  expect(callback).toEqual(expect.any(Function));
+  (callback as () => void)();
+};
 
 describe("HTML5 comment resource bounds", () => {
   beforeEach(() => {
@@ -354,6 +425,79 @@ describe("HTML5 comment resource bounds", () => {
 
     expect(firstComment?.exposeCurrentImage()).not.toBe(firstImage);
     expect(firstComment?.exposeCurrentImage()).toBeTruthy();
+  });
+
+  test("expires legacy cached images without requiring destroy", () => {
+    const ctx = createContext();
+    const renderer = new LegacyImageSourceRenderer();
+    const comment = new TestHTML5Comment(
+      formattedComment(1, "legacy image"),
+      renderer,
+      0,
+      ctx,
+    );
+
+    const image = comment.exposeTextImage();
+
+    expect(image).not.toBeNull();
+    expect(renderer.legacyImages).toHaveLength(1);
+    expect("destroy" in renderer.legacyImages[0]!).toBe(false);
+    expect(ctx.imageCache.get(comment.exposeCacheKey())?.image).toBe(image);
+    expect(() => runWindowTimeout(1)).not.toThrow();
+    expect(ctx.imageCache.get(comment.exposeCacheKey())).toBeUndefined();
+  });
+
+  test("refreshes legacy cached image expiry without requiring destroy", () => {
+    const ctx = createContext();
+    const renderer = new LegacyImageSourceRenderer();
+    const first = new TestHTML5Comment(
+      formattedComment(1, "legacy cache hit"),
+      renderer,
+      0,
+      ctx,
+    );
+    const second = new TestHTML5Comment(
+      formattedComment(2, "legacy cache hit"),
+      renderer,
+      1,
+      ctx,
+    );
+
+    const image = first.exposeTextImage();
+    const cachedImage = second.exposeTextImage();
+
+    expect(cachedImage).toBe(image);
+    expect(renderer.legacyImages).toHaveLength(1);
+    expect("destroy" in renderer.legacyImages[0]!).toBe(false);
+    expect(() => runWindowTimeout(3)).not.toThrow();
+    expect(ctx.imageCache.get(second.exposeCacheKey())).toBeUndefined();
+  });
+
+  test("evicts legacy cached images without requiring destroy", () => {
+    const ctx = createContext();
+    const firstRenderer = new LegacyImageSourceRenderer();
+    const firstComment = new TestHTML5Comment(
+      formattedComment(1, "legacy evicted"),
+      firstRenderer,
+      0,
+      ctx,
+    );
+    const firstImage = firstComment.exposeTextImage();
+
+    for (let i = 0; i < 1024; i++) {
+      const comment = new TestHTML5Comment(
+        formattedComment(i + 2, `cache filler ${i}`),
+        new RecordingRenderer(),
+        i + 1,
+        ctx,
+      );
+      expect(comment.exposeTextImage()).not.toBeNull();
+    }
+
+    expect(firstImage).not.toBeNull();
+    expect(firstRenderer.legacyImages).toHaveLength(1);
+    expect("destroy" in firstRenderer.legacyImages[0]!).toBe(false);
+    expect(ctx.imageCache.get(firstComment.exposeCacheKey())).toBeUndefined();
   });
 
   test("preserves mail command order in image cache keys", () => {

--- a/tests/unit/html5-resource-bounds.spec.ts
+++ b/tests/unit/html5-resource-bounds.spec.ts
@@ -217,8 +217,11 @@ const createContext = () => ({
 const cachedKeyCount = (imageCache: ImageCacheContext, keys: string[]) =>
   keys.filter((key) => imageCache.get(key)).length;
 
-const runWindowTimeout = (callIndex: number) => {
-  const timeoutCall = vi.mocked(window.setTimeout).mock.calls[callIndex];
+const runWindowTimeout = (timeoutId: number) => {
+  const timeoutCallIndex = vi
+    .mocked(window.setTimeout)
+    .mock.results.findIndex((result) => result.value === timeoutId);
+  const timeoutCall = vi.mocked(window.setTimeout).mock.calls[timeoutCallIndex];
   const callback = timeoutCall?.[0];
 
   expect(callback).toEqual(expect.any(Function));
@@ -453,7 +456,9 @@ describe("HTML5 comment resource bounds", () => {
     expect(image).not.toBeNull();
     expectLegacyImageWithoutDestroy(renderer.legacyImages);
     expect(ctx.imageCache.get(comment.exposeCacheKey())?.image).toBe(image);
-    expect(() => runWindowTimeout(1)).not.toThrow();
+    const timeoutId = ctx.imageCache.get(comment.exposeCacheKey())?.timeout;
+    expect(timeoutId).toBeDefined();
+    expect(() => runWindowTimeout(timeoutId as number)).not.toThrow();
     expect(ctx.imageCache.get(comment.exposeCacheKey())).toBeUndefined();
   });
 
@@ -478,7 +483,9 @@ describe("HTML5 comment resource bounds", () => {
 
     expect(cachedImage).toBe(image);
     expectLegacyImageWithoutDestroy(renderer.legacyImages);
-    expect(() => runWindowTimeout(3)).not.toThrow();
+    const timeoutId = ctx.imageCache.get(second.exposeCacheKey())?.timeout;
+    expect(timeoutId).toBeDefined();
+    expect(() => runWindowTimeout(timeoutId as number)).not.toThrow();
     expect(ctx.imageCache.get(second.exposeCacheKey())).toBeUndefined();
   });
 

--- a/tests/unit/html5-resource-bounds.spec.ts
+++ b/tests/unit/html5-resource-bounds.spec.ts
@@ -221,6 +221,13 @@ const runWindowTimeout = (callIndex: number) => {
   (callback as () => void)();
 };
 
+const expectLegacyImageWithoutDestroy = (images: IRenderer[]) => {
+  expect(images).toHaveLength(1);
+  const image = images[0];
+  expect(image).toBeDefined();
+  expect("destroy" in (image as object)).toBe(false);
+};
+
 describe("HTML5 comment resource bounds", () => {
   beforeEach(() => {
     initConfig();
@@ -440,8 +447,7 @@ describe("HTML5 comment resource bounds", () => {
     const image = comment.exposeTextImage();
 
     expect(image).not.toBeNull();
-    expect(renderer.legacyImages).toHaveLength(1);
-    expect("destroy" in renderer.legacyImages[0]!).toBe(false);
+    expectLegacyImageWithoutDestroy(renderer.legacyImages);
     expect(ctx.imageCache.get(comment.exposeCacheKey())?.image).toBe(image);
     expect(() => runWindowTimeout(1)).not.toThrow();
     expect(ctx.imageCache.get(comment.exposeCacheKey())).toBeUndefined();
@@ -467,8 +473,7 @@ describe("HTML5 comment resource bounds", () => {
     const cachedImage = second.exposeTextImage();
 
     expect(cachedImage).toBe(image);
-    expect(renderer.legacyImages).toHaveLength(1);
-    expect("destroy" in renderer.legacyImages[0]!).toBe(false);
+    expectLegacyImageWithoutDestroy(renderer.legacyImages);
     expect(() => runWindowTimeout(3)).not.toThrow();
     expect(ctx.imageCache.get(second.exposeCacheKey())).toBeUndefined();
   });
@@ -495,8 +500,7 @@ describe("HTML5 comment resource bounds", () => {
     }
 
     expect(firstImage).not.toBeNull();
-    expect(firstRenderer.legacyImages).toHaveLength(1);
-    expect("destroy" in firstRenderer.legacyImages[0]!).toBe(false);
+    expectLegacyImageWithoutDestroy(firstRenderer.legacyImages);
     expect(ctx.imageCache.get(firstComment.exposeCacheKey())).toBeUndefined();
   });
 

--- a/tests/unit/html5-resource-bounds.spec.ts
+++ b/tests/unit/html5-resource-bounds.spec.ts
@@ -136,6 +136,8 @@ const createLegacyImageRenderer = (): Omit<IRenderer, "destroy"> => {
     save() {},
     restore() {},
     getCanvas() {
+      // Test-only runtime contract break: createLegacyImageRenderer omits
+      // destroy() while providing the members this cache path uses.
       return createLegacyImageRenderer() as IRenderer;
     },
     drawImage() {},
@@ -148,6 +150,8 @@ class LegacyImageSourceRenderer extends RecordingRenderer {
   public readonly legacyImages: IRenderer[] = [];
 
   override getCanvas() {
+    // Test-only runtime contract break for LegacyImageSourceRenderer; do not
+    // copy this cast outside legacy compatibility tests.
     const image = createLegacyImageRenderer() as IRenderer;
     this.legacyImages.push(image);
     return image;


### PR DESCRIPTION
## Summary
- guard cached text-image renderer destroy calls for runtime legacy renderers
- keep normal destroy cleanup behavior for renderers that implement destroy
- add regression coverage for expiry, cache-hit refresh, and LRU eviction paths

## Validation
- pnpm run test:unit -- tests/unit/html5-resource-bounds.spec.ts
- pnpm run check-types
- npx biome check src/comments/BaseComment.ts tests/unit/html5-resource-bounds.spec.ts
- git diff --check develop..HEAD

## Review
- independent subagent review: APPROVED, no findings

Docs were not changed.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a `destroyTextImage` helper in `BaseComment.ts` that guards all cached text-image cleanup calls behind a `typeof image.destroy === \"function\"` check, and applies the same guard to the `ImageCacheContext.reset()` path in `cache.ts`. This prevents runtime crashes when legacy renderers that don't implement `destroy()` flow through the cache eviction, LRU, or timeout expiry paths.

- **`BaseComment.ts`**: Extracts three inline `destroyedTextImages.add` + `image.destroy()` call-sites into a single `destroyTextImage` helper that short-circuits when `destroy` is absent; legacy images are skipped for `destroyedTextImages` tracking.
- **`cache.ts`**: The `reset()` loop now conditionally calls `destroy()` only when the method exists.
- **`html5-resource-bounds.spec.ts`**: Adds four regression tests covering expiry, cache-hit refresh, LRU eviction, and context reset with a `LegacyImageSourceRenderer`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are narrowly scoped guards that prevent crashes without altering existing destroy/tracking behavior for modern renderers.

All three call-sites in BaseComment.ts are consistently updated through the new helper, and the cache.ts reset path receives the same guard. The destroyedTextImages invalidation in _draw remains correct for modern renderers because legacy images are not tracked there. The four new regression tests directly exercise each eviction path with a legacy renderer, confirming the fix is complete.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/comments/BaseComment.ts | Adds destroyTextImage helper to guard all three cache-cleanup call-sites; legacy images are not tracked in destroyedTextImages because they are never destroyed prematurely, so _draw's invalidation path remains correct for modern renderers. |
| src/contexts/cache.ts | reset() now conditionally calls destroy() only when the method exists, matching the BaseComment guard pattern and preventing crashes on context reset for legacy renderers. |
| tests/unit/html5-resource-bounds.spec.ts | Adds LegacyImageSourceRenderer, createLegacyImageRenderer, and four targeted regression tests covering expiry, cache-hit refresh, LRU eviction, and reset. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Cache eviction / timeout / LRU / reset] --> B[destroyTextImage called]
    B --> C{typeof image.destroy === 'function'?}
    C -- No --> D[return false - Legacy renderer no-op]
    C -- Yes --> E[destroyedTextImages.add + image.destroy]
    D --> F[imageCache.delete key]
    E --> F
```
</details>

<sub>Reviews (4): Last reviewed commit: ["Avoid timeout order coupling in cache te..."](https://github.com/xpadev-net/niconicomments/commit/4c4ba3eae0001eba915ef5cebab9a5238ab1f0e9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36084768)</sub>

<!-- /greptile_comment -->