### PR TITLE
ci: allow typedoc deploy from develop via workflow_dispatch and update artifact actions

### DIFF
--- a/.github/workflows/release-typedoc.yml
+++ b/.github/workflows/release-typedoc.yml
@@ -61,7 +61,7 @@ jobs:
         run: find .gitignore docs/type dist/bundle.js -type f -print0 | tar --null --hard-dereference -czf typedoc-artifacts.tgz --files-from -
 
       - name: Upload generated artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: typedoc-artifacts
           path: typedoc-artifacts.tgz
@@ -71,7 +71,7 @@ jobs:
   push-typedoc:
     needs: typedoc
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/develop')
     permissions:
       contents: write
     steps:
@@ -80,7 +80,7 @@ jobs:
           persist-credentials: false
 
       - name: Download generated artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: typedoc-artifacts
           path: ${{ runner.temp }}/typedoc-artifacts


### PR DESCRIPTION
## Summary

- `push-typedoc` ジョブの `if` 条件を更新し、`workflow_dispatch` で `develop` ブランチから手動実行した際も TypeDoc デプロイが走るように変更
- `actions/upload-artifact` を v4.x → v7.0.1 に更新（Node.js 24対応）
- `actions/download-artifact` を v4.3.0 → v8.0.1 に更新（Node.js 24対応）

## Test plan

- [ ] `develop` ブランチから `workflow_dispatch` で TypeDoc ワークフローを手動実行し、`push-typedoc` ジョブが実行されることを確認
- [ ] Node.js 20 の deprecation 警告が出なくなることを確認

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the `release-typedoc.yml` workflow with two changes: it widens the `push-typedoc` job gate to also deploy when `workflow_dispatch` is triggered from the `develop` branch, and it bumps both artifact actions to their latest Node.js 24-compatible versions.

- The `push-typedoc` `if` condition now allows `workflow_dispatch` from `develop` in addition to the existing `push` to `master`, enabling manual TypeDoc deployments during development without touching the master gate.
- `actions/upload-artifact` is updated to `v7.0.1` (commit `043fb46`) and `actions/download-artifact` to `v8.0.1` (commit `3e5f45b`); both commit hashes are verified against the official releases and the v7/v8 pairing is the correct combination for these actions.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the three-line change correctly extends the deploy gate for manual runs from develop and pins both artifact actions to verified release commits.

The if condition extension is logically correct: it preserves all existing master-push behaviour and adds a narrowly scoped path (workflow_dispatch from develop only). Both upgraded action versions are real published releases whose pinned commit SHAs match the official GitHub repositories. No deploy path, permission boundary, or secret exposure is altered.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-typedoc.yml | Widens push-typedoc job condition to include workflow_dispatch from develop, and bumps upload-artifact to v7.0.1 and download-artifact to v8.0.1 with verified pinned commit hashes. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Trigger] --> B{Event type?}
    B -- push to master --> C[typedoc job]
    B -- workflow_dispatch --> D{Which branch?}
    D -- master --> C
    D -- develop --> C
    D -- other branch --> C
    C --> E[Build TypeDoc & package artifacts]
    E --> F[Upload artifact\nupload-artifact v7.0.1]
    F --> G{push-typedoc condition}
    G -- "ref == master\nOR\n(workflow_dispatch && ref == develop)" --> H[push-typedoc job]
    G -- Otherwise --> I[Skip push-typedoc]
    H --> J[Download artifact\ndownload-artifact v8.0.1]
    J --> K[Validate artifacts]
    K --> L[Force-push to typedoc branch]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: allow typedoc deploy from develop vi..."](https://github.com/xpadev-net/niconicomments/commit/350a6298d50448bbe2fc556a894e6c70f12a8766) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36206761)</sub>

<!-- /greptile_comment -->