### PR TITLE
Update GitHub Actions to use major version tags

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
@@ -27,7 +27,7 @@ jobs:
           run_install: false
 
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: 'pnpm'
@@ -42,7 +42,7 @@ jobs:
         run: tar --hard-dereference -czf dev-build-artifacts.tgz dist/bundle.js
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dev-build-artifacts
           path: dev-build-artifacts.tgz
@@ -56,12 +56,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
       - name: Download build artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: dev-build-artifacts
           path: ${{ runner.temp }}/dev-build-artifacts

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -27,7 +27,7 @@ jobs:
           run_install: false
 
       - name: Install Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: 'pnpm'
@@ -42,7 +42,7 @@ jobs:
         run: tar --hard-dereference -czf dev-build-artifacts.tgz dist/bundle.js
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@v7
         with:
           name: dev-build-artifacts
           path: dev-build-artifacts.tgz
@@ -56,12 +56,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: Download build artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        uses: actions/download-artifact@v8
         with:
           name: dev-build-artifacts
           path: ${{ runner.temp }}/dev-build-artifacts

--- a/.github/workflows/pr-test-playwright-comment.yml
+++ b/.github/workflows/pr-test-playwright-comment.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Download test results
         id: test-results
         if: ${{ github.event.workflow_run.conclusion == 'failure' && fromJSON(steps.pr-context.outputs.result).trusted && fromJSON(steps.pr-context.outputs.result).artifactDisposition == 'download' && fromJSON(steps.pr-context.outputs.result).testResultsArtifactCount > 0 }}
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           pattern: test-results-node-*
           path: all-test-results/

--- a/.github/workflows/pr-test-playwright-comment.yml
+++ b/.github/workflows/pr-test-playwright-comment.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Download test results
         id: test-results
         if: ${{ github.event.workflow_run.conclusion == 'failure' && fromJSON(steps.pr-context.outputs.result).trusted && fromJSON(steps.pr-context.outputs.result).artifactDisposition == 'download' && fromJSON(steps.pr-context.outputs.result).testResultsArtifactCount > 0 }}
-        uses: actions/download-artifact@974686ed5098c7f9c9289ec946b9058e496a2561
+        uses: actions/download-artifact@v8
         with:
           pattern: test-results-node-*
           path: all-test-results/

--- a/.github/workflows/release-publish-package.yml
+++ b/.github/workflows/release-publish-package.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read # Checkout repository contents for the publish build.
       id-token: write # Request an OIDC token for npm provenance.
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
@@ -25,7 +25,7 @@ jobs:
           run_install: false
 
       - name: Install Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24'
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/release-publish-package.yml
+++ b/.github/workflows/release-publish-package.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read # Checkout repository contents for the publish build.
       id-token: write # Request an OIDC token for npm provenance.
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -25,7 +25,7 @@ jobs:
           run_install: false
 
       - name: Install Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@v6
         with:
           node-version: '24'
           registry-url: https://registry.npmjs.org

--- a/.github/workflows/release-typedoc.yml
+++ b/.github/workflows/release-typedoc.yml
@@ -27,7 +27,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -39,7 +39,7 @@ jobs:
           run_install: false
 
       - name: Install Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: 'pnpm'
@@ -61,7 +61,7 @@ jobs:
         run: find .gitignore docs/type dist/bundle.js -type f -print0 | tar --null --hard-dereference -czf typedoc-artifacts.tgz --files-from -
 
       - name: Upload generated artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@v7
         with:
           name: typedoc-artifacts
           path: typedoc-artifacts.tgz
@@ -75,12 +75,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 
       - name: Download generated artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        uses: actions/download-artifact@v8
         with:
           name: typedoc-artifacts
           path: ${{ runner.temp }}/typedoc-artifacts

--- a/.github/workflows/release-typedoc.yml
+++ b/.github/workflows/release-typedoc.yml
@@ -27,7 +27,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
@@ -39,7 +39,7 @@ jobs:
           run_install: false
 
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: 'pnpm'
@@ -61,7 +61,7 @@ jobs:
         run: find .gitignore docs/type dist/bundle.js -type f -print0 | tar --null --hard-dereference -czf typedoc-artifacts.tgz --files-from -
 
       - name: Upload generated artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: typedoc-artifacts
           path: typedoc-artifacts.tgz
@@ -75,12 +75,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
 
       - name: Download generated artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: typedoc-artifacts
           path: ${{ runner.temp }}/typedoc-artifacts


### PR DESCRIPTION
## チケットへのリンク

- N/A

## やったこと

GitHub Actions のワークフローで使用されているアクションを、コミットハッシュから主要バージョンタグ（v6、v7、v8）に更新しました。

更新対象：
- `actions/checkout`: `de0fac2e...` → `v6`
- `actions/setup-node`: `48b55a01...` → `v6`
- `actions/upload-artifact`: `043fb46d...` → `v7`
- `actions/download-artifact`: `3e5f45b2...` → `v8`、`974686ed...` → `v8`

対象ワークフロー：
- `.github/workflows/dev-build.yml`
- `.github/workflows/release-typedoc.yml`
- `.github/workflows/release-publish-package.yml`
- `.github/workflows/pr-test-playwright-comment.yml`

## やらないこと

無し

## できるようになること（ユーザ目線）

無し

## できなくなること（ユーザ目線）

無し

## 動作確認

- CI/CD パイプラインが正常に動作することを確認（GitHub Actions が自動実行）
- 各ワークフローが最新のアクションバージョンで実行されることを確認

## その他

- コミットハッシュの代わりにメジャーバージョンタグを使用することで、セキュリティアップデートと機能改善を自動的に取得できます
- GitHub Actions のベストプラクティスに従った更新です

https://claude.ai/code/session_01UtnJUEX8J3of8A89yyyLeD

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR refreshes GitHub Actions SHA pins across four workflows and adds human-readable version comments (`# v6`, `# v7`, `# v8`). Despite the title saying "major version tags", the implementation correctly keeps commit-SHA-pinned references — the version labels are comments only.

- `actions/checkout` is bumped from an earlier v6 patch (`de0fac2e…`) to a newer one (`df4cb1c0…`, aligned with v6.0.2 which fixes tag-annotation handling) across all four workflows.
- `actions/download-artifact` in `pr-test-playwright-comment.yml` is harmonised to the same v8 SHA already used in the other workflows (`3e5f45b2…`), eliminating a cross-workflow inconsistency.
- Version comments on `actions/setup-node`, `actions/upload-artifact`, and `actions/download-artifact` are updated or simplified (e.g. `# v7.0.1` → `# v7`); their underlying SHAs are unchanged.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all actions remain SHA-pinned; the only runtime-visible changes are a checkout patch bump and a download-artifact SHA harmonisation, both backward-compatible.

All four workflows still use full commit SHAs rather than mutable tags, so the supply-chain posture is unchanged. The checkout bump is a minor v6 patch with no breaking changes for the persist-credentials: false usage pattern found in every job. The download-artifact harmonisation brings a previously divergent workflow in line with the rest of the repo.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/dev-build.yml | Updates actions/checkout SHA (de0fac2e → df4cb1c0, v6.0.x → later v6 patch) and adds version comments to other actions; all references remain SHA-pinned |
| .github/workflows/pr-test-playwright-comment.yml | Harmonises actions/download-artifact SHA from 974686ed… to 3e5f45b2… (same v8 as other workflows) with a version comment; single-line change, no logic impact |
| .github/workflows/release-publish-package.yml | Updates actions/checkout SHA and adds version comments; actions still SHA-pinned; pnpm/action-setup and softprops/action-gh-release remain SHA-pinned and unchanged |
| .github/workflows/release-typedoc.yml | Same checkout SHA update plus simplification of version comments (v7.0.1 → v7, v8.0.1 → v8); all SHAs remain pinned |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR merge to develop/master] --> B{Workflow triggered}
    B --> C[dev-build.yml]
    B --> D[release-typedoc.yml]
    B --> E[release-publish-package.yml]
    B --> F[pr-test-playwright-comment.yml]

    C --> C1["actions/checkout@df4cb1c0 #v6 updated"]
    C --> C2["actions/setup-node@48b55a01 #v6 comment added"]
    C --> C3["actions/upload-artifact@043fb46d #v7 comment added"]
    C --> C4["actions/download-artifact@3e5f45b2 #v8 comment added"]

    D --> D1["actions/checkout@df4cb1c0 #v6 updated"]
    D --> D2["actions/setup-node@48b55a01 #v6 comment added"]
    D --> D3["actions/upload-artifact@043fb46d #v7 comment simplified"]
    D --> D4["actions/download-artifact@3e5f45b2 #v8 comment simplified"]

    E --> E1["actions/checkout@df4cb1c0 #v6 updated"]
    E --> E2["actions/setup-node@48b55a01 #v6 comment added"]

    F --> F1["actions/download-artifact@3e5f45b2 #v8 harmonised from 974686ed"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["ci: pin action references to full commit..."](https://github.com/xpadev-net/niconicomments/commit/64e6146d99ebf84cf0d3ea93f0be08164df128a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36210487)</sub>

<!-- /greptile_comment -->