### PR TITLE
ci: replace typedoc branch push with GitHub Pages direct deployment

### DIFF
--- a/.github/workflows/release-typedoc.yml
+++ b/.github/workflows/release-typedoc.yml
@@ -1,36 +1,29 @@
-# This is a basic workflow to help you get started with Actions
-
 name: TypeDoc
 
 concurrency:
   group: ${{ github.repository }}-typedoc
   cancel-in-progress: true
 
-# Controls when the workflow will run
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
   push:
     branches: [master]
 
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  typedoc:
-    # The type of runner that the job will run on
+  deploy:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pages: write
+      id-token: write
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          persist-credentials: false
-
 
       - uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a
         name: Install pnpm
@@ -47,113 +40,20 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
-      # Runs a set of commands using the runners shell
-      - name: clear output dir
-        run: rm ./docs/type/* -rf
-      - name: update .gitignore
-        run: sed -i -e '/\/docs\/type/d' .gitignore
-      - name: generate typedoc
+      - name: Generate TypeDoc
         run: pnpm typedoc
-      - name: generate dev build
+
+      - name: Build
         run: pnpm build
 
-      - name: Package generated artifacts
-        run: find .gitignore docs dist/bundle.js -type f -print0 | tar --null --hard-dereference -czf typedoc-artifacts.tgz --files-from -
+      - name: Copy bundle to docs
+        run: cp dist/bundle.js docs/
 
-      - name: Upload generated artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
-          name: typedoc-artifacts
-          path: typedoc-artifacts.tgz
-          if-no-files-found: error
-          retention-days: 1
+          path: docs/
 
-  push-typedoc:
-    needs: typedoc
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/develop')
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          persist-credentials: false
-
-      - name: Download generated artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: typedoc-artifacts
-          path: ${{ runner.temp }}/typedoc-artifacts
-
-      - name: Validate generated artifacts
-        run: |
-          archive="${RUNNER_TEMP}/typedoc-artifacts/typedoc-artifacts.tgz"
-          validated_dir="${RUNNER_TEMP}/validated-artifacts"
-          rm -rf "$validated_dir"
-          mkdir -p "$validated_dir"
-          python3 - "$archive" "$validated_dir" <<'PY'
-          import pathlib
-          import shutil
-          import sys
-          import tarfile
-
-          archive = sys.argv[1]
-          destination = pathlib.Path(sys.argv[2])
-          required = {".gitignore", "dist/bundle.js"}
-          seen = set()
-
-          def is_allowed(name):
-              return name in required or name.startswith("docs/")
-
-          with tarfile.open(archive, "r:gz") as tar:
-              for member in tar.getmembers():
-                  name = member.name
-                  normalized_name = pathlib.PurePosixPath(name).as_posix()
-                  parts = pathlib.PurePosixPath(name).parts
-                  if (
-                      pathlib.PurePosixPath(name).is_absolute()
-                      or name != normalized_name
-                      or ".." in parts
-                      or ".git" in parts
-                      or not is_allowed(normalized_name)
-                      or normalized_name in seen
-                      or not member.isfile()
-                  ):
-                      raise SystemExit(f"Unexpected artifact entry: {name!r}")
-                  seen.add(normalized_name)
-
-              missing = required - seen
-              if missing:
-                  raise SystemExit(f"Missing artifact entry: {', '.join(sorted(missing))}")
-              if not any(name.startswith("docs/type/") for name in seen):
-                  raise SystemExit("Missing artifact entry: docs/type/ (no TypeDoc files found)")
-
-              for member in tar.getmembers():
-                  target = destination / member.name
-                  target.parent.mkdir(parents=True, exist_ok=True)
-                  source = tar.extractfile(member)
-                  if source is None:
-                      raise SystemExit(f"Unable to read artifact entry: {member.name!r}")
-                  with source, target.open("wb") as output:
-                      shutil.copyfileobj(source, output)
-          PY
-
-      - name: Create new Branch
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config user.email "github-actions@xpadev.net"
-          git config user.name "github-actions"
-          git checkout -b typedoc
-          git rm -rf . --quiet || true
-          mkdir -p dist docs
-          cp "${RUNNER_TEMP}/validated-artifacts/.gitignore" .gitignore
-          cp "${RUNNER_TEMP}/validated-artifacts/dist/bundle.js" dist/bundle.js
-          if [ -d "${RUNNER_TEMP}/validated-artifacts/docs" ]; then
-            cp -a "${RUNNER_TEMP}/validated-artifacts/docs/." docs/
-          fi
-          cp -f dist/bundle.js docs/
-          git add .
-          git -c core.hooksPath=/dev/null commit -m "auto generate"
-          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-          git push -f origin typedoc
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/release-typedoc.yml
+++ b/.github/workflows/release-typedoc.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
     permissions:
       contents: read
       pages: write
@@ -24,6 +25,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a
         name: Install pnpm


### PR DESCRIPTION
https://claude.ai/code/session_01CioacjchLCQf1D8nDbna5i

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR migrates TypeDoc documentation deployment from a bespoke two-job pipeline (build → tar artifact → validate → `git push -f` to a `typedoc` branch) to the official GitHub Pages deployment actions (`upload-pages-artifact` + `deploy-pages`), eliminating the need to write back to the repository.

- The old `push-typedoc` job with its custom Python tarball validator and forced branch push is removed; the single `deploy` job now uploads `docs/` directly via the official GitHub Pages actions, adding the required `pages: write` and `id-token: write` permissions and a `github-pages` environment block.
- The master-only guard (`if: github.ref == 'refs/heads/master'`) is moved to the job level, correctly preventing `workflow_dispatch` from deploying non-master branches, and `persist-credentials: false` is retained on the checkout step.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — replaces a custom git-push deployment pattern with the official GitHub Pages actions, with no change in access scope or deployment trigger logic.

The refactoring is straightforward: the branch restriction and least-privilege credential settings carried over correctly from the old workflow, and the official GitHub Pages actions handle security and artifact integrity that the previous custom Python validator was managing manually.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-typedoc.yml | Replaces custom two-job typedoc-branch-push pipeline with the official GitHub Pages deployment actions; adds proper Pages permissions and environment block; retains master-only guard and persist-credentials: false from the original. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GH as GitHub (push/dispatch)
    participant Runner as Actions Runner
    participant TypeDoc as pnpm typedoc
    participant Build as pnpm build
    participant UPA as upload-pages-artifact
    participant DP as deploy-pages

    GH->>Runner: Trigger (push to master OR workflow_dispatch from master)
    Runner->>Runner: checkout (persist-credentials: false)
    Runner->>Runner: pnpm install
    Runner->>TypeDoc: generate docs → docs/
    Runner->>Build: build → dist/bundle.js
    Runner->>Runner: cp dist/bundle.js docs/
    Runner->>UPA: upload docs/ as github-pages artifact
    UPA-->>Runner: artifact id
    Runner->>DP: deploy artifact to GitHub Pages
    DP-->>Runner: page_url output
    Runner-->>GH: environment URL updated
```
</details>

<sub>Reviews (2): Last reviewed commit: ["ci: restrict workflow\_dispatch to master..."](https://github.com/xpadev-net/niconicomments/commit/054602c79cc4da61dc8835107affec86dcad7f76) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36218424)</sub>

<!-- /greptile_comment -->