### PR TITLE
Allow workflow_dispatch from develop branch in release-typedoc.yml

### DIFF
--- a/.github/workflows/release-typedoc.yml
+++ b/.github/workflows/release-typedoc.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
+    if: github.ref == 'refs/heads/master' || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/develop')
     permissions:
       contents: read
       pages: write


### PR DESCRIPTION
https://claude.ai/code/session_0118izxVvbCwpgga9MDFS5zg

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the `release-typedoc.yml` workflow to allow a manual `workflow_dispatch` trigger from the `develop` branch to run the TypeDoc deployment job, which previously only ran on pushes to `master`.

- The job `if` condition is extended with `|| (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/develop')`, so manual dispatches from `develop` will build and deploy docs to GitHub Pages alongside the existing automatic deploys from `master`.
- A `workflow_dispatch` from any branch other than `master` or `develop` will still silently skip the job, which is the existing behavior for non-master branches.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-line condition extension that adds a well-scoped, intentional escape hatch for manual doc deployments from develop.

The change is minimal and surgical: it gates the new execution path behind both `workflow_dispatch` and an explicit branch check on `develop`, so it cannot be triggered accidentally by automated pushes. The existing push-to-master path is untouched. Deploying develop-branch docs to GitHub Pages via manual dispatch is a deliberate choice to preview pre-release documentation, and the logic correctly encodes that intent.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-typedoc.yml | Extends the job condition to allow manual workflow_dispatch runs from the develop branch in addition to push events on master. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Trigger]) --> B{Event type?}
    B -->|push| C{Branch?}
    B -->|workflow_dispatch| D{Branch?}
    C -->|refs/heads/master| E[Run deploy job]
    C -->|other| F[Job skipped]
    D -->|refs/heads/develop| E
    D -->|refs/heads/master| E
    D -->|other| F
    E --> G[Checkout]
    G --> H[Install pnpm + Node]
    H --> I[pnpm install]
    I --> J[Generate TypeDoc]
    J --> K[pnpm build]
    K --> L[Copy dist/bundle.js to docs/]
    L --> M[Upload Pages artifact]
    M --> N[Deploy to GitHub Pages]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Allow workflow\_dispatch from develop bra..."](https://github.com/xpadev-net/niconicomments/commit/90aa0338d324cafe4293aa5c7834568abf190ede) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36221253)</sub>

<!-- /greptile_comment -->