### PR TITLE
fix: measure text on detached canvas to prevent WKWebView clipping

### DIFF
--- a/src/@types/renderer.ts
+++ b/src/@types/renderer.ts
@@ -20,6 +20,20 @@ export interface IRenderer {
   setSize(width: number, height: number): void;
   getSize(): { width: number; height: number };
   measureText(text: string): TextMetrics;
+  /**
+   * Measure text on a canvas with the given draw scale applied.
+   *
+   * In some environments (e.g. WKWebView on macOS), `measureText()` returns
+   * different values depending on the canvas transform because font fallback
+   * resolution depends on the effective physical glyph size.  niconicomments
+   * renders comment text on an offscreen canvas at `drawScale`, so measuring
+   * at that same scale avoids the mismatch that causes clipping.
+   *
+   * Optional — implementations that return identical metrics regardless of
+   * scale (Chrome, Firefox, Node-canvas) may omit it.  Callers fall back to
+   * `measureText()` when the method is absent.
+   */
+  measureTextAtDrawScale?(text: string, drawScale: number): TextMetrics;
   beginPath(): void;
   closePath(): void;
   moveTo(x: number, y: number): void;

--- a/src/comments/HTML5Comment.ts
+++ b/src/comments/HTML5Comment.ts
@@ -239,7 +239,7 @@ class HTML5Comment extends BaseComment {
       comment.full ? "fullWidth" : "width"
     ];
     if (!typeGuard.internal.MeasureInput(comment)) throw new TypeGuardError();
-    const layerScale = this.comment.layer === -1 ? this.ctx.options.scale : 1;
+    const layerScale = comment.layer === -1 ? this.ctx.options.scale : 1;
     const measureResult = measure(
       comment,
       this.renderer,

--- a/src/comments/HTML5Comment.ts
+++ b/src/comments/HTML5Comment.ts
@@ -239,14 +239,24 @@ class HTML5Comment extends BaseComment {
       comment.full ? "fullWidth" : "width"
     ];
     if (!typeGuard.internal.MeasureInput(comment)) throw new TypeGuardError();
-    const measureResult = measure(comment, this.renderer, this.config);
+    const layerScale = this.comment.layer === -1 ? this.ctx.options.scale : 1;
+    const measureResult = measure(
+      comment,
+      this.renderer,
+      this.config,
+      layerScale,
+    );
     if (comment.loc !== "naka" && measureResult.width > widthLimit) {
-      return this._processResizeX(comment, measureResult.width);
+      return this._processResizeX(comment, measureResult.width, layerScale);
     }
     return measureResult;
   }
 
-  private _processResizeX(comment: MeasureTextInput, width: number) {
+  private _processResizeX(
+    comment: MeasureTextInput,
+    width: number,
+    layerScale = 1,
+  ) {
     const widthLimit = getConfig(this.config.commentStageSize, false)[
       comment.full ? "fullWidth" : "width"
     ];
@@ -287,7 +297,7 @@ class HTML5Comment extends BaseComment {
       workComment.lineHeight =
         legacyBaseLineHeight * (nextCharSize / legacyBaseCharSize);
       workComment.fontSize = nextCharSize * 0.8;
-      return measure(workComment, this.renderer, this.config);
+      return measure(workComment, this.renderer, this.config, layerScale);
     };
 
     if (baseCharSize >= 1) {
@@ -349,6 +359,7 @@ class HTML5Comment extends BaseComment {
         comment as MeasureTextInput & MeasureInput,
         this.renderer,
         this.config,
+        layerScale,
       );
     }
 
@@ -363,7 +374,7 @@ class HTML5Comment extends BaseComment {
         workComment.lineHeight = baseLineHeight * (nextCharSize / baseCharSize);
       }
       workComment.fontSize = (workComment.charSize ?? 0) * 0.8;
-      return measure(workComment, this.renderer, this.config);
+      return measure(workComment, this.renderer, this.config, layerScale);
     };
 
     let best = baseCharSize;
@@ -414,6 +425,7 @@ class HTML5Comment extends BaseComment {
       comment as MeasureTextInput & MeasureInput,
       this.renderer,
       this.config,
+      layerScale,
     );
   }
 

--- a/src/renderer/canvas.ts
+++ b/src/renderer/canvas.ts
@@ -48,12 +48,18 @@ class CanvasRenderer implements IRenderer {
 
   /**
    * measureText 結果のキャッシュ
-   * キー: "font\0text" → 値: TextMetrics
-   * Canvas2D の measureText() は同じ (font, text) ペアに対して決定論的なので安全にキャッシュできる
+   * キー: "font\0text" → 値: TextMetrics (主レンダラースケール)
+   * キー: "@drawScale\0font\0text" → 値: TextMetrics (drawScaleスケール)
    * エントリ数が _MT_CACHE_MAX_SIZE に達した場合はそれ以上追加しない（既存エントリは維持）
    */
   private static readonly _MT_CACHE_MAX_SIZE = 5000;
   private static _mtCache = new Map<string, TextMetrics>();
+
+  /** measureTextAtDrawScale 用の専用キャンバス (スケール依存計測用) */
+  private static _dsCanvas: HTMLCanvasElement | null = null;
+  private static _dsCtx: CanvasRenderingContext2D | null = null;
+  private static _dsScale = 0;
+  private static _dsFont = "";
 
   /** プールから取得した canvas かどうか (destroy 時にプールに返却するため) */
   private readonly pooled: boolean;
@@ -218,8 +224,66 @@ class CanvasRenderer implements IRenderer {
     return result;
   }
 
+  /**
+   * Measure text on a dedicated canvas with `drawScale` applied as the
+   * transform, so font fallback resolution matches the offscreen render canvas.
+   *
+   * In WKWebView (macOS), `measureText()` resolves font fallbacks based on the
+   * effective physical glyph size, which varies with the canvas transform.
+   * Measuring at `drawScale` (= commentScale × fontScale × layerScale) returns
+   * the same metrics the offscreen canvas will produce, preventing clipping.
+   */
+  measureTextAtDrawScale(text: string, drawScale: number): TextMetrics {
+    const font = this.context.font;
+    if (text.length > MAX_MEASURE_TEXT_CACHE_TEXT_LENGTH) {
+      return CanvasRenderer._measureAtScale(text, font, drawScale);
+    }
+    const key = `@${drawScale}\0${font}\0${text}`;
+    const cached = CanvasRenderer._mtCache.get(key);
+    if (cached !== undefined) return cached;
+    const result = CanvasRenderer._measureAtScale(text, font, drawScale);
+    if (CanvasRenderer._mtCache.size < CanvasRenderer._MT_CACHE_MAX_SIZE) {
+      CanvasRenderer._mtCache.set(key, result);
+    }
+    return result;
+  }
+
+  private static _measureAtScale(
+    text: string,
+    font: string,
+    drawScale: number,
+  ): TextMetrics {
+    if (!CanvasRenderer._dsCanvas) {
+      CanvasRenderer._dsCanvas = document.createElement("canvas");
+      CanvasRenderer._dsCanvas.width = 1;
+      CanvasRenderer._dsCanvas.height = 1;
+      CanvasRenderer._dsCtx = CanvasRenderer._dsCanvas.getContext("2d");
+    }
+    const ctx = CanvasRenderer._dsCtx;
+    if (!ctx) {
+      const tmp = document.createElement("canvas");
+      const tCtx = tmp.getContext("2d");
+      if (!tCtx) throw new CanvasRenderingContext2DError();
+      tCtx.setTransform(drawScale, 0, 0, drawScale, 0, 0);
+      tCtx.font = font;
+      return tCtx.measureText(text);
+    }
+    if (CanvasRenderer._dsScale !== drawScale) {
+      ctx.setTransform(drawScale, 0, 0, drawScale, 0, 0);
+      CanvasRenderer._dsScale = drawScale;
+      CanvasRenderer._dsFont = "";
+    }
+    if (CanvasRenderer._dsFont !== font) {
+      ctx.font = font;
+      CanvasRenderer._dsFont = font;
+    }
+    return ctx.measureText(text);
+  }
+
   static resetMeasureTextCache(): void {
     CanvasRenderer._mtCache.clear();
+    CanvasRenderer._dsScale = 0;
+    CanvasRenderer._dsFont = "";
   }
   beginPath(): void {
     this.context.beginPath();

--- a/src/renderer/canvas.ts
+++ b/src/renderer/canvas.ts
@@ -236,23 +236,26 @@ class CanvasRenderer implements IRenderer {
   measureTextAtDrawScale(text: string, drawScale: number): TextMetrics {
     const font = this.context.font;
     if (text.length > MAX_MEASURE_TEXT_CACHE_TEXT_LENGTH) {
-      return CanvasRenderer._measureAtScale(text, font, drawScale);
+      return this._measureAtScale(text, font, drawScale);
     }
     const key = `@${drawScale}\0${font}\0${text}`;
     const cached = CanvasRenderer._mtCache.get(key);
     if (cached !== undefined) return cached;
-    const result = CanvasRenderer._measureAtScale(text, font, drawScale);
+    const result = this._measureAtScale(text, font, drawScale);
     if (CanvasRenderer._mtCache.size < CanvasRenderer._MT_CACHE_MAX_SIZE) {
       CanvasRenderer._mtCache.set(key, result);
     }
     return result;
   }
 
-  private static _measureAtScale(
+  private _measureAtScale(
     text: string,
     font: string,
     drawScale: number,
   ): TextMetrics {
+    if (typeof document === "undefined") {
+      return this.context.measureText(text);
+    }
     if (!CanvasRenderer._dsCanvas) {
       CanvasRenderer._dsCanvas = document.createElement("canvas");
       CanvasRenderer._dsCanvas.width = 1;
@@ -261,12 +264,7 @@ class CanvasRenderer implements IRenderer {
     }
     const ctx = CanvasRenderer._dsCtx;
     if (!ctx) {
-      const tmp = document.createElement("canvas");
-      const tCtx = tmp.getContext("2d");
-      if (!tCtx) throw new CanvasRenderingContext2DError();
-      tCtx.setTransform(drawScale, 0, 0, drawScale, 0, 0);
-      tCtx.font = font;
-      return tCtx.measureText(text);
+      return this.context.measureText(text);
     }
     if (CanvasRenderer._dsScale !== drawScale) {
       ctx.setTransform(drawScale, 0, 0, drawScale, 0, 0);

--- a/src/utils/niconico.ts
+++ b/src/utils/niconico.ts
@@ -69,8 +69,9 @@ const measure = (
   comment: MeasureInput,
   renderer: IRenderer,
   config: BaseConfig,
+  layerScale = 1,
 ) => {
-  const width = measureWidth(comment, renderer, config);
+  const width = measureWidth(comment, renderer, config, layerScale);
   return {
     ...width,
     height: comment.lineHeight * (comment.lineCount - 1) + comment.charSize,
@@ -128,8 +129,10 @@ const measureWidth = (
   comment: MeasureInput,
   renderer: IRenderer,
   config: BaseConfig,
+  layerScale = 1,
 ) => {
   const { fontSize, scale } = getFontSizeAndScale(comment.charSize, config);
+  const drawScale = getConfig(config.commentScale, false) * scale * layerScale;
   const lineWidth: number[] = [];
   const itemWidth: number[][] = [];
   const initialFont = parseFont(comment.font, fontSize, config);
@@ -153,9 +156,11 @@ const measureWidth = (
     for (let j = 0, n = lines.length; j < n; j++) {
       const line = lines[j];
       if (line === undefined) throw new TypeGuardError();
-      const measure = renderer.measureText(line);
-      currentWidth += measure.width;
-      width.push(measure.width);
+      const m =
+        renderer.measureTextAtDrawScale?.(line, drawScale) ??
+        renderer.measureText(line);
+      currentWidth += m.width;
+      width.push(m.width);
       if (j < lines.length - 1) {
         lineWidth.push(Math.ceil(currentWidth * scale));
         currentWidth = 0;


### PR DESCRIPTION
## Summary

- Adds optional `IRenderer.measureTextAtDrawScale?(text, drawScale)` method to the renderer interface
- Implements it in `CanvasRenderer` using a dedicated detached 1x1 canvas
- `measureWidth()` now calls this method and falls back to `measureText()` when unavailable, preserving behavior for WebGL2, HTML5CSS, and browsers whose canvas font metrics are consistent

## Root cause

Follow-up investigation corrected the original analysis: the fix is valid, but the root cause is **not** WKWebView changing `measureText()` metrics based on the canvas transform or effective physical glyph size.

In WKWebView on macOS, when `ctx.font` includes a user-installed font such as `Noto Sans JP`, font matching can differ depending on whether the canvas was connected to `document` when the context first resolved the font:

| Context | User-installed "Noto Sans JP" | Observed width (600 20px) | fontBoundingBox ascent / descent |
|---|---|---|---|
| Connected canvas, including `display:none` or iframe | Matches | 490.365 | 23 / 6 |
| Detached canvas / OffscreenCanvas / detached Document | Skipped; falls back | 500.340 | 18 / 3 |

niconicomments measured text on the connected main canvas, but rendered comment images on detached offscreen canvases from the canvas pool. In the affected environment, the connected canvas resolved the user-installed Noto Sans JP face while the detached render canvas fell back to Hiragino. The measured width was therefore about 2% narrower than the rendered text, so the offscreen canvas was allocated too small and the right edge clipped.

The old draw-scale explanation looked plausible because the existing pipeline correlated the two variables: the main canvas was connected and near scale 1, while the offscreen canvas was detached and rendered around drawScale 2.811. Controlled tests that changed only the transform showed identical measurements; changing only the canvas connection state reproduced the mismatch.

## Why this fix still works

`measureTextAtDrawScale` measures using a dedicated canvas created with `document.createElement("canvas")` and kept detached. The render-side canvas pool also uses detached canvases, so both measurement and rendering now resolve the same font face in WKWebView.

The method still accepts and applies `drawScale` so the measurement context mirrors render-time state and existing cache separation remains conservative, but the observed effective factor is the detached canvas connection state rather than the transform itself.

## Validation

This bug cannot be reproduced in the CI visual-regression suite because it depends on WKWebView on macOS plus a locally installed user font. Validation requires Re-NNDD running in WKWebView on macOS. Follow-up probes verified that:

1. Connected and detached canvases resolve different font faces in the affected WKWebView environment
2. Detached canvas measurements match the detached offscreen render canvas
3. Changing only `setTransform()` does not change the measurement result
4. Normal browsers remain effectively unchanged because the optional method falls back or returns consistent metrics

Closes #323