### PR TITLE
fix: measure FlashComment text at drawScale to prevent WKWebView clipping

### DIFF
--- a/src/comments/FlashComment.ts
+++ b/src/comments/FlashComment.ts
@@ -251,7 +251,9 @@ class FlashComment extends BaseComment {
     const defaultFontSize = configFontSize.default;
     comment.lineHeight ??= configLineHeight[comment.size].default;
     const widthLimit = configStageSize[comment.full ? "fullWidth" : "width"];
-    const { scaleX, width, height } = this._measureContent(comment);
+    const layerScale = comment.layer === -1 ? this.ctx.options.scale : 1;
+    const drawScale = this._globalScale * layerScale;
+    const { scaleX, width, height } = this._measureContent(comment, drawScale);
     let scale = 1;
     if (isLineBreakResize(comment, this.config)) {
       comment.resized = true;
@@ -338,7 +340,7 @@ class FlashComment extends BaseComment {
     return widthLimit < width;
   }
 
-  private _measureContent(comment: MeasureTextInput) {
+  private _measureContent(comment: MeasureTextInput, drawScale: number) {
     let currentWidth = 0;
     let spacedWidth = 0;
     let leadLineWidth = 1;
@@ -367,7 +369,9 @@ class FlashComment extends BaseComment {
       for (let i = 0, n = lines.length; i < n; i++) {
         const value = lines[i];
         if (value === undefined) continue;
-        const meas = this.renderer.measureText(value);
+        const meas =
+          this.renderer.measureTextAtDrawScale?.(value, drawScale) ??
+          this.renderer.measureText(value);
         currentWidth += meas.width;
         spacedWidth +=
           meas.width +

--- a/src/comments/FlashComment.ts
+++ b/src/comments/FlashComment.ts
@@ -341,6 +341,9 @@ class FlashComment extends BaseComment {
   }
 
   private _measureContent(comment: MeasureTextInput, drawScale: number) {
+    const measureText = this.renderer.measureTextAtDrawScale
+      ? (val: string) => this.renderer.measureTextAtDrawScale!(val, drawScale)
+      : (val: string) => this.renderer.measureText(val);
     let currentWidth = 0;
     let spacedWidth = 0;
     let leadLineWidth = 1;
@@ -369,9 +372,7 @@ class FlashComment extends BaseComment {
       for (let i = 0, n = lines.length; i < n; i++) {
         const value = lines[i];
         if (value === undefined) continue;
-        const meas =
-          this.renderer.measureTextAtDrawScale?.(value, drawScale) ??
-          this.renderer.measureText(value);
+        const meas = measureText(value);
         currentWidth += meas.width;
         spacedWidth +=
           meas.width +


### PR DESCRIPTION
## Summary

- `FlashComment._measureContent()` was calling `measureText()` at the main renderer scale (~0.8), while `_setupCanvas()` renders the offscreen canvas at `drawScale` (~2.811)
- In WKWebView on macOS, `measureText()` results are font-fallback-dependent and vary with the canvas transform scale, so this mismatch causes measured width < actual draw width → right-edge text clipping
- Mirrors the fix applied to `HTML5Comment` in PR #329

## Changes

**`src/comments/FlashComment.ts`**

- `measureText()`: computes `drawScale = _globalScale * layerScale` before calling `_measureContent()` (`comment.scale` is excluded because it is derived from the measurement result)
- `_measureContent()`: accepts `drawScale: number` as a new parameter
- Uses `renderer.measureTextAtDrawScale?.(value, drawScale) ?? renderer.measureText(value)` — falls back for renderers that don't implement the optional method (WebGL2, html5css, etc.)

## Related

Closes #330
See also: #329 (same fix for HTML5Comment)

## Testing

CI visual regression tests (Linux + Playwright) do not reproduce this bug due to different font rendering. Requires manual verification on WKWebView + macOS (Re-NNDD). TypeScript type check and Biome lint pass cleanly.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR ports the `measureTextAtDrawScale` fix — previously applied to `HTML5Comment` in #329 — to `FlashComment`, correcting a text measurement/draw-scale mismatch that causes right-edge clipping in WKWebView. The single changed file, `FlashComment.ts`, computes `drawScale = _globalScale * layerScale` before calling `_measureContent`, then wires up the optional `measureTextAtDrawScale` method with a fallback to `measureText`.

- `measureText()` now pre-computes `drawScale` from `_globalScale` and `layerScale`, intentionally excluding `comment.scale` since that value is derived from the measurement result itself (circular dependency), matching the same design used in `niconico.ts` for HTML5Comment.
- `_measureContent()` accepts `drawScale` as a new parameter and uses the local `measureText` closure that calls `renderer.measureTextAtDrawScale?.(val, drawScale) ?? renderer.measureText(val)`, leaving non-WKWebView renderers unchanged.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to measurement within FlashComment and has no impact on renderers that do not implement the optional method.

The fix is a clean, one-file port of an already-merged pattern (PR #329 / HTML5Comment). The drawScale computation correctly excludes comment.scale to avoid a circular dependency, and the optional-method guard ensures backward compatibility with all existing renderers. No logic paths are removed or altered for non-WKWebView environments.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/comments/FlashComment.ts | Adds drawScale-aware text measurement to _measureContent, mirroring the HTML5Comment fix; logic is correct and the optional-method fallback is properly guarded. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GCS as getCommentSize()
    participant MT as measureText()
    participant MC as _measureContent()
    participant R as renderer

    GCS->>MT: comment (scale:1)
    MT->>MT: "layerScale = layer==-1 ? options.scale : 1"
    MT->>MT: "drawScale = _globalScale x layerScale"
    MT->>MC: comment, drawScale
    MC->>MC: build measureText closure
    Note over MC: uses measureTextAtDrawScale(val, drawScale) if available, else measureText(val)
    loop each text segment
        MC->>R: setFont(...)
        MC->>R: measureTextAtDrawScale(value, drawScale)
        R-->>MC: TextMetrics (WKWebView-accurate width)
    end
    MC-->>MT: "{ scaleX, width, height }"
    MT->>MT: compute comment.scale (overflow resize)
    MT-->>GCS: MeasureTextResult
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: extract measureText helper out..."](https://github.com/xpadev-net/niconicomments/commit/875842187f8e17fe5accc9b335d0a38d9efba5ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36612718)</sub>

<!-- /greptile_comment -->