### PR TITLE
fix: skip canvas allocation for visually blank comments

### DIFF
--- a/src/comments/BaseComment.ts
+++ b/src/comments/BaseComment.ts
@@ -15,6 +15,11 @@ import type { CommentInstanceContext } from "@/contexts";
 import { NotImplementedError } from "@/errors/";
 import { getPosX, isBanActive, isReverseActive, parseFont } from "@/utils";
 
+// Matches strings that contain no visible glyphs: JS \s (covers U+0020,
+// U+00A0, U+FEFF, U+3000, etc.) plus zero-width / Hangul filler codepoints
+// that \s does not include.
+const VISUALLY_BLANK_RE = /^(?:[\s­​‌⁠ᅟᅠㅤﾠ]|‍)*$/;
+
 const MAX_CACHE_KEY_CONTENT_LENGTH = 512;
 const MAX_CACHE_KEY_EDGE_LENGTH = 256;
 const MAX_IMAGE_CACHE_ENTRIES = 1024;
@@ -376,7 +381,8 @@ class BaseComment implements IComment {
       (this.comment.lineCount === 1 && this.comment.width === 0) ||
       this.comment.height - (this.comment.charSize - this.comment.lineHeight) <=
         0 ||
-      !this.canGenerateTextImage()
+      !this.canGenerateTextImage() ||
+      VISUALLY_BLANK_RE.test(this.comment.rawContent)
     )
       return null;
     const key = this.cacheKey;

--- a/src/comments/BaseComment.ts
+++ b/src/comments/BaseComment.ts
@@ -18,7 +18,8 @@ import { getPosX, isBanActive, isReverseActive, parseFont } from "@/utils";
 // Matches strings that contain no visible glyphs: JS \s (covers U+0020,
 // U+00A0, U+FEFF, U+3000, etc.) plus zero-width / Hangul filler codepoints
 // that \s does not include.
-const VISUALLY_BLANK_RE = /^(?:[\s­​‌⁠ᅟᅠㅤﾠ]|‍)*$/;
+const VISUALLY_BLANK_RE =
+  /^[\s\u00AD\u200B-\u200D\u2060\u115F\u1160\u3164\uFFA0]*$/;
 
 const MAX_CACHE_KEY_CONTENT_LENGTH = 512;
 const MAX_CACHE_KEY_EDGE_LENGTH = 256;


### PR DESCRIPTION
## Summary

- Add a `VISUALLY_BLANK_RE` guard in `BaseComment.getTextImage()` that returns `null` when `rawContent` consists entirely of whitespace, zero-width characters (U+200B–200D, U+2060, U+00AD), or Hangul filler codepoints (U+3164, U+FFA0, U+115F, U+1160).
- Collision detection is **unaffected**: `processMovableComment` / `processFixedComment` read `comment.width` / `comment.height`, which are still computed normally by `getCommentSize()`.
- The `_draw()` path already guards on `if (this.image)`, so a `null` return is a clean no-op — no crash risk.

## Why

As noted in #332, whitespace-only and Hangul-filler comments can produce a non-zero measured width, so neither the `invisible` guard nor the `width === 0` guard in `getTextImage()` catches them. This fix stops the unnecessary offscreen canvas allocation and stroke/fill passes for content that produces no visible output.

## What reviewers should know

- The fix is entirely in `getTextImage()` — `getCommentSize()` / `convertComment()` are left unchanged so dimensions and collision layout remain correct.
- Visual regression tests should run on CI to confirm no regressions (local runs are not reliable due to font-rendering differences).

Closes #332

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds a `VISUALLY_BLANK_RE` regex guard at the top of `getTextImage()` to return `null` early when `rawContent` consists entirely of whitespace, zero-width characters, or Hangul filler codepoints — preventing unnecessary offscreen canvas allocation and stroke/fill passes for comments that produce no visible output.

- Adds `VISUALLY_BLANK_RE` constant covering `\s`, `\u00AD`, `\u200B–\u200D`, `\u2060`, and Hangul fillers (`\u115F`, `\u1160`, `\u3164`, `\uFFA0`).
- Guard is placed after all existing early-exit conditions in `getTextImage()` and before the cache lookup, so blank comments never populate the image cache; collision detection (`width`/`height`) is intentionally left unchanged.
- The `_draw()` path distinguishes `null` from `undefined` on `this.image`, so a `null` return permanently stops future `getTextImage()` calls for that instance — a correct and efficient no-op.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change is conservative: it can only skip image generation when the entire raw content is provably blank, so no comment with visible output can be incorrectly skipped.

The guard returns null only when rawContent is composed exclusively of characters that have no visible glyph. The existing _draw() null/undefined distinction already handles a null return cleanly, and the cache/lifetime timeouts are unaffected for blank content. Collision detection reads width/height from getCommentSize(), which is left unchanged.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/comments/BaseComment.ts | Adds VISUALLY_BLANK_RE guard in getTextImage() to skip canvas allocation for whitespace/Hangul-filler-only comments; logic is conservative and correct, collision detection paths are untouched. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["_draw called"] --> B{image destroyed?}
    B -- yes --> C[image = undefined]
    B -- no --> D{image === undefined?}
    C --> D
    D -- no --> E{image truthy?}
    D -- yes --> F["getTextImage()"]
    F --> G{invisible / width==0 / height<=0}
    G -- yes --> H[return null]
    G -- no --> I{VISUALLY_BLANK_RE test rawContent}
    I -- yes --> H
    I -- no --> J{cache hit?}
    J -- yes --> K[return cached image]
    J -- no --> L[_generateTextImage + _cacheImage]
    L --> N[return new image]
    H --> O["image = null, skip draw on all future frames"]
    K --> E
    N --> E
    E -- yes --> P[drawImage to canvas]
    E -- no --> Q[no-op]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: use Unicode escape sequences i..."](https://github.com/xpadev-net/niconicomments/commit/ba8810e8e2ab8d11b740f54f4b0a97e6d346c91f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36617098)</sub>

<!-- /greptile_comment -->