### PR TITLE
chore(ci): pin workflow actions to commit hashes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore
+      include: scope

--- a/.github/workflows/cleanup-playwright-artifacts.yml
+++ b/.github/workflows/cleanup-playwright-artifacts.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Cleanup stale artifacts
-        uses: actions/github-script@v9
+        uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
         with:
           script: |
             const owner = context.repo.owner;

--- a/.github/workflows/playwright-update.yml
+++ b/.github/workflows/playwright-update.yml
@@ -9,15 +9,15 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a # v6
         name: Install pnpm
         with:
           version: 11
           run_install: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "24"
           cache: 'pnpm'

--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -14,15 +14,15 @@ jobs:
       matrix:
         node-version: [22, 24, 26]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a # v6
         name: Install pnpm
         with:
           version: 11
           run_install: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           cache: 'pnpm'
           node-version: "${{ matrix.node-version }}"

--- a/.github/workflows/pr-test-codeql-analysis.yml
+++ b/.github/workflows/pr-test-codeql-analysis.yml
@@ -57,7 +57,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -67,7 +67,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -95,6 +95,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/pr-test-linter.yml
+++ b/.github/workflows/pr-test-linter.yml
@@ -14,15 +14,15 @@ jobs:
       matrix:
         node-version: [22, 24, 26]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a # v6
         name: Install pnpm
         with:
           version: 11
           run_install: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           cache: 'pnpm'
           node-version: "${{ matrix.node-version }}"

--- a/.github/workflows/pr-test-playwright.yml
+++ b/.github/workflows/pr-test-playwright.yml
@@ -15,15 +15,15 @@ jobs:
       matrix:
         node-version: [22, 24, 26]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a # v6
         name: Install pnpm
         with:
           version: 11
           run_install: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           cache: 'pnpm'
           node-version: "${{ matrix.node-version }}"
@@ -41,7 +41,7 @@ jobs:
           pnpm build
       - name: Run Playwright tests
         run: pnpm playwright test
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !cancelled() }}
         with:
           name: test-results-node-${{ matrix.node-version }}

--- a/.github/workflows/release-create-release.yml
+++ b/.github/workflows/release-create-release.yml
@@ -23,19 +23,19 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
           ref: develop
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@ac6db6d3c1f721f886538a378a2d73e85697340a # v6
         with:
           version: 11
           run_install: false
 
       - name: Install Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: 'pnpm'


### PR DESCRIPTION
## Summary\n- Pin all non-hash action refs in .github/workflows to commit SHAs (while keeping human-readable tag comments).\n- Targets include checkout, pnpm/action-setup, setup-node, upload-artifact, github-script, and codeql-action usages.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens the CI supply-chain by replacing mutable tag refs with immutable commit SHAs across all eight workflow files, and adds a `dependabot.yml` so Dependabot will open weekly PRs to keep those SHAs current.

- All six action types (`actions/checkout`, `pnpm/action-setup`, `actions/setup-node`, `actions/upload-artifact`, `actions/github-script`, `github/codeql-action`) are pinned to a specific SHA with a human-readable `# vN` comment alongside every usage.
- `.github/dependabot.yml` is added with weekly scheduling, a `chore`-prefixed commit message, and an `open-pull-requests-limit: 5` cap to keep noise manageable.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a pure CI hardening change with no modifications to build logic or application code.

All action references across eight workflow files are pinned to immutable commit SHAs with human-readable tag comments. The newly added dependabot.yml closes the loop by scheduling weekly SHA-bump PRs. No application code, tests, or workflow logic was altered.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/dependabot.yml | New file; adds weekly Dependabot tracking for the github-actions ecosystem with a 5-PR limit and chore-scoped commit messages. |
| .github/workflows/pr-test-codeql-analysis.yml | Pins checkout, codeql-action/init, and codeql-action/analyze; init and analyze correctly share the same SHA since they live in the same repo. |
| .github/workflows/pr-test-playwright.yml | Pins checkout, pnpm/action-setup, setup-node, and upload-artifact to commit SHAs; no logic changes. |
| .github/workflows/release-create-release.yml | Pins checkout, pnpm/action-setup, and setup-node to commit SHAs; no logic changes. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/pr-test-playwright.yml`, line 1 ([link](https://github.com/xpadev-net/niconicomments/blob/397bdb148e5ed863381ef32c0b278bae390c1c44/.github/workflows/pr-test-playwright.yml#L1)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **No Dependabot config for GitHub Actions ecosystem**

   Now that all action refs are pinned to commit SHAs, updates will never be proposed automatically unless a Dependabot entry for the `github-actions` ecosystem is added. Without it, the pinned SHAs will silently drift behind released patch/minor versions — including security fixes — until someone manually re-pins them. Adding a `.github/dependabot.yml` with `package-ecosystem: "github-actions"` would let Dependabot open PRs that bump each SHA and update the inline tag comment automatically.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/pr-test-playwright.yml
   Line: 1

   Comment:
   **No Dependabot config for GitHub Actions ecosystem**

   Now that all action refs are pinned to commit SHAs, updates will never be proposed automatically unless a Dependabot entry for the `github-actions` ecosystem is added. Without it, the pinned SHAs will silently drift behind released patch/minor versions — including security fixes — until someone manually re-pins them. Adding a `.github/dependabot.yml` with `package-ecosystem: "github-actions"` would let Dependabot open PRs that bump each SHA and update the inline tag comment automatically.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fpr-test-playwright.yml%0ALine%3A%201%0A%0AComment%3A%0A**No%20Dependabot%20config%20for%20GitHub%20Actions%20ecosystem**%0A%0ANow%20that%20all%20action%20refs%20are%20pinned%20to%20commit%20SHAs%2C%20updates%20will%20never%20be%20proposed%20automatically%20unless%20a%20Dependabot%20entry%20for%20the%20%60github-actions%60%20ecosystem%20is%20added.%20Without%20it%2C%20the%20pinned%20SHAs%20will%20silently%20drift%20behind%20released%20patch%2Fminor%20versions%20%E2%80%94%20including%20security%20fixes%20%E2%80%94%20until%20someone%20manually%20re-pins%20them.%20Adding%20a%20%60.github%2Fdependabot.yml%60%20with%20%60package-ecosystem%3A%20%22github-actions%22%60%20would%20let%20Dependabot%20open%20PRs%20that%20bump%20each%20SHA%20and%20update%20the%20inline%20tag%20comment%20automatically.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=xpadev-net%2Fniconicomments&pr=336&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/dev..."](https://github.com/xpadev-net/niconicomments/commit/8df6a0ce9891d8fd5b04181f2fc22e96d20eae18) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36890122)</sub>

<!-- /greptile_comment -->