### PR TITLE
docs: clarify WKWebView canvas font matching cause

### DIFF
--- a/src/@types/renderer.ts
+++ b/src/@types/renderer.ts
@@ -21,17 +21,20 @@ export interface IRenderer {
   getSize(): { width: number; height: number };
   measureText(text: string): TextMetrics;
   /**
-   * Measure text on a canvas with the given draw scale applied.
+   * Measure text in the same canvas context class used for comment rendering.
    *
-   * In some environments (e.g. WKWebView on macOS), `measureText()` returns
-   * different values depending on the canvas transform because font fallback
-   * resolution depends on the effective physical glyph size.  niconicomments
-   * renders comment text on an offscreen canvas at `drawScale`, so measuring
-   * at that same scale avoids the mismatch that causes clipping.
+   * In WKWebView on macOS, font matching can depend on whether the canvas was
+   * connected to the document when its context first resolved the font. The
+   * main renderer is connected, while comment text is rendered on detached
+   * offscreen canvases. Implementations can use this hook to measure with a
+   * detached canvas as well, avoiding connected-vs-detached font metric
+   * mismatches that cause clipping. `drawScale` is supplied so implementations
+   * can mirror render-time state, although WKWebView's observed mismatch is
+   * caused by canvas connection state rather than the transform itself.
    *
    * Optional — implementations that return identical metrics regardless of
-   * scale (Chrome, Firefox, Node-canvas) may omit it.  Callers fall back to
-   * `measureText()` when the method is absent.
+   * context state (Chrome, Firefox, Node-canvas) may omit it. Callers fall
+   * back to `measureText()` when the method is absent.
    */
   measureTextAtDrawScale?(text: string, drawScale: number): TextMetrics;
   beginPath(): void;

--- a/src/renderer/canvas.ts
+++ b/src/renderer/canvas.ts
@@ -49,13 +49,13 @@ class CanvasRenderer implements IRenderer {
   /**
    * measureText 結果のキャッシュ
    * キー: "font\0text" → 値: TextMetrics (主レンダラースケール)
-   * キー: "@drawScale\0font\0text" → 値: TextMetrics (drawScaleスケール)
+   * キー: "@drawScale\0font\0text" → 値: TextMetrics (detached 計測キャンバス)
    * エントリ数が _MT_CACHE_MAX_SIZE に達した場合はそれ以上追加しない（既存エントリは維持）
    */
   private static readonly _MT_CACHE_MAX_SIZE = 5000;
   private static _mtCache = new Map<string, TextMetrics>();
 
-  /** measureTextAtDrawScale 用の専用キャンバス (スケール依存計測用) */
+  /** measureTextAtDrawScale 用の専用 detached キャンバス */
   private static _dsCanvas: HTMLCanvasElement | null = null;
   private static _dsCtx: CanvasRenderingContext2D | null = null;
   private static _dsScale = 0;
@@ -225,13 +225,12 @@ class CanvasRenderer implements IRenderer {
   }
 
   /**
-   * Measure text on a dedicated canvas with `drawScale` applied as the
-   * transform, so font fallback resolution matches the offscreen render canvas.
+   * Measure text on a dedicated detached canvas, so WKWebView resolves fonts
+   * like the offscreen render canvas instead of the connected main canvas.
    *
-   * In WKWebView (macOS), `measureText()` resolves font fallbacks based on the
-   * effective physical glyph size, which varies with the canvas transform.
-   * Measuring at `drawScale` (= commentScale × fontScale × layerScale) returns
-   * the same metrics the offscreen canvas will produce, preventing clipping.
+   * The `drawScale` transform is still applied to mirror render-time state and
+   * keep cache keys distinct, but the WKWebView mismatch observed for #323 is
+   * caused by connected-vs-detached canvas font matching, not by the transform.
    */
   measureTextAtDrawScale(text: string, drawScale: number): TextMetrics {
     const font = this.context.font;


### PR DESCRIPTION
## Summary

- Corrects `measureTextAtDrawScale` comments to describe the actual WKWebView root cause: connected vs detached canvas font matching
- Clarifies that `drawScale` is still mirrored for render-state/cache consistency, but the observed mismatch is not caused by the transform itself
- Updates cache/static canvas comments to describe detached measurement instead of scale-dependent measurement

## Validation

- `npx biome check src/@types/renderer.ts src/renderer/canvas.ts`
- `git diff --check`
- `rg` check confirmed the old effective-physical-glyph-size explanation no longer remains in `src`
- Harness reviewer subagent: APPROVED, no findings

Related: #323, #329

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR is a documentation-only update to comments in `src/@types/renderer.ts` and `src/renderer/canvas.ts`. It corrects the stated root cause of the WKWebView text-clipping bug: the existing comments blamed the canvas transform (`drawScale`) for producing different `measureText` results, whereas the real cause is whether the canvas was connected to the document when the browser resolved its font — the detached offscreen render canvas uses different font metrics than the connected main renderer canvas.

- Updates the `measureTextAtDrawScale` JSDoc in both the `IRenderer` interface and `CanvasRenderer` implementation to describe the connected-vs-detached canvas font-matching root cause rather than effective physical glyph size.
- Revises cache key and static canvas field comments in `canvas.ts` to reflect "detached measurement canvas" rather than "scale-dependent measurement."
- No functional code is changed; the `drawScale` transform is still applied to mirror render-time state and keep cache keys distinct, but the comments now correctly attribute it as a consistency aid rather than the bug fix.
</details>

<h3>Confidence Score: 5/5</h3>

Documentation-only change with no functional code modifications; safe to merge.

Both changed files contain only comment/JSDoc edits. The new descriptions accurately reflect the existing _measureAtScale implementation — the canvas is created via document.createElement and never inserted into the DOM, making it genuinely detached, exactly as the updated comments now describe. No logic, types, exports, or runtime behaviour is altered.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/@types/renderer.ts | JSDoc for measureTextAtDrawScale rewritten to describe connected-vs-detached canvas font matching as the WKWebView root cause; Optional note updated from scale to context state; no functional changes. |
| src/renderer/canvas.ts | Cache key comment, static _dsCanvas field comment, and measureTextAtDrawScale method JSDoc updated to describe detached canvas and the WKWebView connection-state root cause; no functional changes. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller as Comment renderer
    participant Renderer as CanvasRenderer (connected main canvas)
    participant DS as _dsCanvas (detached static canvas)

    Caller->>Renderer: measureTextAtDrawScale(text, drawScale)
    Note over Renderer: check _mtCache
    alt cache hit
        Renderer-->>Caller: cached TextMetrics
    else cache miss
        Renderer->>DS: _measureAtScale(text, font, drawScale)
        Note over DS: createElement canvas, never appended to DOM
        Note over DS: setTransform(drawScale), ctx.font = font
        DS-->>Renderer: ctx.measureText(text)
        Note over Renderer: detached canvas matches offscreen render canvas font metrics
        Renderer->>Renderer: store in _mtCache
        Renderer-->>Caller: TextMetrics
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/dev..."](https://github.com/xpadev-net/niconicomments/commit/bd8b017a0995535039abd5468e87d6f3481be930) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36890285)</sub>

<!-- /greptile_comment -->