### PR TITLE
fix: allow Playwright comment workflow to post PR comments

### DIFF
--- a/.github/workflows/pr-test-playwright-comment.yml
+++ b/.github/workflows/pr-test-playwright-comment.yml
@@ -3,7 +3,7 @@ permissions:
   actions: read
   contents: write
   issues: write
-  pull-requests: read
+  pull-requests: write
 on:
   workflow_run:
     workflows: ["Playwright Tests"]


### PR DESCRIPTION
## Summary
- grant the Playwright screenshot comment workflow pull-requests write permission
- fixes the 403 Resource not accessible by integration failure when syncing failure screenshots to a PR comment

## Validation
- inspected failed run 27325303596 with gh run view --log-failed
- confirmed GitHub API required issues=write and pull_requests=write
- ruby YAML parser loaded .github/workflows/pr-test-playwright-comment.yml successfully
- subagent review: APPROVED, no findings

## Notes
- contents: write remains required because the workflow writes screenshot artifacts to the _playwright-artifacts branch

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a 403 error that prevented the Playwright screenshot comment workflow from posting PR comments by upgrading `pull-requests` from `read` to `write`. The workflow runs in a `workflow_run` context and posts visual regression failure screenshots as PR comments after validating a trusted PR context.

- The single-line permission change in `.github/workflows/pr-test-playwright-comment.yml` unblocks the workflow's ability to create, update, and delete PR comments when Playwright tests fail on a PR.
- All actions remain pinned to specific SHAs, the trusted PR context validation (base repo, head repo, SHA, artifact limits) is unchanged, and `contents: write` + `issues: write` were already present before this change.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — a single permission line change that unblocks a broken CI workflow with no impact on application code or deployed artifacts.

The change is one line in a CI workflow file. The trusted PR context validation, artifact safety checks, and pinned action SHAs are all unchanged. The broader permission grant is necessary (confirmed against a real failed run) and the additional capability it unlocks is not exercised by the workflow beyond what `issues: write` already permitted.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/pr-test-playwright-comment.yml | One-line permission bump: `pull-requests: read` → `pull-requests: write`; fixes confirmed 403 error on the PR comment posting step; all other security controls unchanged. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant PT as Playwright Tests workflow
    participant WR as workflow_run trigger
    participant PC as Playwright Screenshots Comment job
    participant GH as GitHub API
    participant ART as _playwright-artifacts branch

    PT->>WR: completes (success/failure)
    WR->>PC: "trigger (if event==pull_request)"
    PC->>GH: pulls.get(prNumber) [pull-requests: read]
    GH-->>PC: PR metadata (state, repos, SHA)
    PC->>PC: Validate trusted context
    alt "trusted & failure & artifacts to download"
        PC->>GH: actions.listWorkflowRunArtifacts [actions: read]
        GH-->>PC: artifact list
        PC->>GH: git.createBlob/createTree/createCommit/updateRef [contents: write]
        GH-->>ART: push screenshot PNGs
        PC->>GH: issues.listComments [issues: read]
        GH-->>PC: existing comments
        alt existing managed comment found
            PC->>GH: issues.updateComment [issues: write + pull-requests: write]
        else no existing comment
            PC->>GH: issues.createComment [issues: write + pull-requests: write]
        end
    else "trusted & success"
        PC->>GH: issues.deleteComment stale [issues: write]
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: allow playwright comment workflow t..."](https://github.com/xpadev-net/niconicomments/commit/eb43223ce3013d73949d9dbd811e4c9b3269b5dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36900897)</sub>

<!-- /greptile_comment -->