### PR TITLE
Fix renderer destroy and lazy addComments ordering

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -89,6 +89,20 @@ const hasNakaComment = (items: readonly IComment[]) => {
   return hasNaka;
 };
 
+const areCommentsSortedByVpos = (
+  items: readonly IComment[],
+  previous?: IComment,
+) => {
+  let previousComment = previous;
+  for (const item of items) {
+    if (previousComment && previousComment.vpos > item.vpos) {
+      return false;
+    }
+    previousComment = item;
+  }
+  return true;
+};
+
 const rendererHasVideoSurface = (renderer: IRenderer) =>
   "video" in renderer &&
   (renderer as IRenderer & { readonly video?: unknown }).video != null;
@@ -249,6 +263,7 @@ class NiconiComments {
 
   public destroy() {
     this.ctx.imageCache.reset();
+    this.renderer.destroy();
   }
 
   private _rebuildCommentArrayIndex(comments: IComment[]) {
@@ -315,16 +330,7 @@ class NiconiComments {
     }
 
     this.plugins = plugins;
-    this.lazyCommentOrderSortedByVpos = instances.every(
-      (comment, index, comments) => {
-        const previousComment = comments[index - 1];
-        return (
-          index === 0 ||
-          previousComment === undefined ||
-          previousComment.vpos <= comment.vpos
-        );
-      },
-    );
+    this.lazyCommentOrderSortedByVpos = areCommentsSortedByVpos(instances);
     if (!this.ctx.options.lazy || !this.lazyCommentOrderSortedByVpos) {
       // Non-lazy rendering and lazy fallback both need final plugin output.
       this.getCommentPos(instances, instances.length);
@@ -464,6 +470,12 @@ class NiconiComments {
       } catch (e) {
         console.error("Failed to add comments", e);
       }
+    }
+    if (this.lazyCommentOrderSortedByVpos) {
+      this.lazyCommentOrderSortedByVpos = areCommentsSortedByVpos(
+        comments,
+        this.comments.at(-1),
+      );
     }
     for (const comment of comments) {
       if (comment.invisible) continue;

--- a/src/main.ts
+++ b/src/main.ts
@@ -95,6 +95,7 @@ const areCommentsSortedByVpos = (
 ) => {
   let previousComment = previous;
   for (const item of items) {
+    if (!item) continue;
     if (previousComment && previousComment.vpos > item.vpos) {
       return false;
     }
@@ -474,7 +475,7 @@ class NiconiComments {
     if (this.lazyCommentOrderSortedByVpos) {
       this.lazyCommentOrderSortedByVpos = areCommentsSortedByVpos(
         comments,
-        this.comments.at(-1),
+        this.comments[this.comments.length - 1],
       );
     }
     for (const comment of comments) {

--- a/tests/unit/duration-lazy.spec.ts
+++ b/tests/unit/duration-lazy.spec.ts
@@ -403,6 +403,23 @@ describe("duration bounds and lazy timeline expansion", () => {
     expect(state.timeline[0]).toBeDefined();
   });
 
+  test("addComments disables sorted lazy scanning for out-of-order appends", () => {
+    const instance = new NiconiComments(
+      new FakeRenderer(),
+      [createComment({ id: 1, vpos: 1000, mail: ["ue"] })],
+      { format: "formatted", lazy: true, mode: "html5" },
+    );
+    const state = instance as unknown as {
+      lazyCommentOrderSortedByVpos: boolean;
+    };
+
+    expect(state.lazyCommentOrderSortedByVpos).toBe(true);
+
+    instance.addComments(createComment({ id: 2, vpos: 100, mail: ["ue"] }));
+
+    expect(state.lazyCommentOrderSortedByVpos).toBe(false);
+  });
+
   test("non-lazy constructor builds timeline from plugin-transformed comments", () => {
     const renderer = new FakeRenderer();
     const instance = new NiconiComments(

--- a/tests/unit/timeline.spec.ts
+++ b/tests/unit/timeline.spec.ts
@@ -25,10 +25,13 @@ const emptyTextMetrics = (width: number): TextMetrics =>
 class FakeRenderer implements IRenderer {
   public readonly rendererName = "FakeRenderer";
   public readonly canvas = {} as HTMLCanvasElement;
+  public destroyCalls = 0;
   private font = "";
   private size = { width: 1920, height: 1080 };
 
-  destroy() {}
+  destroy() {
+    this.destroyCalls++;
+  }
   drawVideo() {}
   getFont() {
     return this.font;
@@ -188,6 +191,20 @@ describe("timeline construction", () => {
 
     expect(includesCalls).toBe(0);
     expect(timeline[200]).toHaveLength(500);
+  });
+});
+
+describe("destroy", () => {
+  test("propagates lifecycle cleanup to the renderer", () => {
+    ensureCanvasElement();
+    const renderer = new FakeRenderer();
+    const niconiComments = new NiconiComments(renderer, [], {
+      format: "formatted",
+    });
+
+    niconiComments.destroy();
+
+    expect(renderer.destroyCalls).toBe(1);
   });
 });
 


### PR DESCRIPTION
## Summary
- propagate NiconiComments.destroy() to the active renderer so HTML5CSSRenderer can release DOM and ResizeObserver resources
- keep the lazy vpos-order flag accurate after dynamically appended comments
- add focused unit coverage for renderer destroy propagation and out-of-order lazy appends

## Validation
- pnpm exec vitest run tests/unit/timeline.spec.ts tests/unit/duration-lazy.spec.ts
- pnpm exec biome check src/main.ts tests/unit/timeline.spec.ts tests/unit/duration-lazy.spec.ts
- pnpm run check-types
- pnpm run test:unit

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR addresses two independent bugs and refactors a helper function for reuse. The `destroy()` method now propagates cleanup to the active renderer so that `HTML5CSSRenderer` properly releases its DOM elements and `ResizeObserver`. The lazy vpos-sorted flag in `addComments` is now updated so that dynamically appended out-of-order comments correctly disable the early-exit optimization in `resolveLazyCommentWindow`.

- **Renderer destroy propagation**: `NiconiComments.destroy()` now calls `this.renderer.destroy()`, allowing `HTML5CSSRenderer` to disconnect its `ResizeObserver`, remove DOM nodes, and restore original root styles; previously, these resources were silently leaked on teardown.
- **Lazy order flag on `addComments`**: A new `areCommentsSortedByVpos` helper replaces the inline `every` callback in `preRendering` and is reused in `addComments` to flip `lazyCommentOrderSortedByVpos` to `false` when appended comments break ascending vpos order, preventing `resolveLazyCommentWindow` from early-exiting and missing out-of-band comments.
- **Tests**: Focused unit tests are added to `timeline.spec.ts` (renderer destroy propagation) and `duration-lazy.spec.ts` (out-of-order addComments flag check).
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — both fixes are narrow, well-contained, and fully covered by the new unit tests.

The destroy propagation is a one-liner with no side effects beyond what HTML5CSSRenderer.destroy() already does correctly. The lazy-order flag fix only transitions the flag in one direction (true to false) and is gated behind the existing flag check, so it cannot introduce regressions on the non-lazy path or on already-unsorted comment sets. The extracted areCommentsSortedByVpos helper is logically equivalent to the removed every callback for the preRendering call site.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/main.ts | Adds areCommentsSortedByVpos helper (behaviorally equivalent to removed every callback), propagates destroy() to renderer, and checks lazy-sort flag after each addComments call — all correct. |
| tests/unit/timeline.spec.ts | Adds destroyCalls counter to FakeRenderer and a new 'destroy' describe block that verifies the call propagates exactly once; straightforward and correct coverage. |
| tests/unit/duration-lazy.spec.ts | Adds test confirming lazyCommentOrderSortedByVpos flips to false when addComments receives a comment with a lower vpos than existing comments; exercises the exact new code path. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["Address review feedback for lazy orderin..."](https://github.com/xpadev-net/niconicomments/commit/06a7c80e6a307252066946dd18aff355391efa81) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36923914)</sub>

<!-- /greptile_comment -->