### PR TITLE
Fix benchmark resets and CSS canvas invalidation

### DIFF
--- a/src/__tests__/html5css-renderer.spec.ts
+++ b/src/__tests__/html5css-renderer.spec.ts
@@ -531,6 +531,46 @@ test("HTML5CSSRenderer refreshes drawImage snapshots after sub-renderer resize",
   expect(metrics.height).toBe("5px");
 });
 
+test("HTML5CSSRenderer does not detach external canvases on invalidation", async ({
+  page,
+}) => {
+  await loadBundle(page);
+
+  const metrics = await page.evaluate(() => {
+    const host = document.createElement("div");
+    const root = document.createElement("div");
+    root.dataset.width = "100";
+    root.dataset.height = "100";
+    const externalCanvas = document.createElement("canvas");
+    externalCanvas.style.display = "block";
+    host.appendChild(externalCanvas);
+    document.body.append(host, root);
+    const global = window as typeof window & {
+      NiconiComments: typeof import("@/main").default;
+    };
+    const renderer =
+      new global.NiconiComments.internal.renderer.HTML5CSSRenderer(root);
+    const externalImage =
+      new global.NiconiComments.internal.renderer.CanvasRenderer(
+        externalCanvas,
+      );
+    externalImage.setSize(20, 20);
+    renderer.drawImage(externalImage, 0, 0);
+    renderer.flush();
+    renderer.invalidateImage(externalImage);
+    const attachedAfterInvalidation = host.contains(externalCanvas);
+    const displayAfterInvalidation = externalCanvas.style.display;
+    externalImage.destroy();
+    renderer.destroy();
+    root.remove();
+    host.remove();
+    return { attachedAfterInvalidation, displayAfterInvalidation };
+  });
+
+  expect(metrics.attachedAfterInvalidation).toBe(true);
+  expect(metrics.displayAfterInvalidation).toBe("block");
+});
+
 test("HTML5CSSRenderer bounds duplicate owned canvas clones per frame", async ({
   page,
 }) => {

--- a/src/__tests__/html5css-renderer.spec.ts
+++ b/src/__tests__/html5css-renderer.spec.ts
@@ -571,6 +571,44 @@ test("HTML5CSSRenderer does not detach external canvases on invalidation", async
   expect(metrics.displayAfterInvalidation).toBe("block");
 });
 
+test("HTML5CSSRenderer detaches owned canvases on sub-renderer destroy", async ({
+  page,
+}) => {
+  await loadBundle(page);
+
+  const metrics = await page.evaluate(() => {
+    const root = document.createElement("div");
+    root.dataset.width = "100";
+    root.dataset.height = "100";
+    document.body.appendChild(root);
+    const global = window as typeof window & {
+      NiconiComments: typeof import("@/main").default;
+    };
+    const renderer =
+      new global.NiconiComments.internal.renderer.HTML5CSSRenderer(root);
+    const image = renderer.getCanvas();
+    image.setSize(20, 20);
+    renderer.drawImage(image, 0, 0);
+    renderer.flush();
+    const source = image.canvas;
+    const attachedBeforeDestroy = root.contains(source);
+    image.destroy();
+    const attachedAfterDestroy = root.contains(source);
+    const displayAfterDestroy = source.style.display;
+    renderer.destroy();
+    root.remove();
+    return {
+      attachedBeforeDestroy,
+      attachedAfterDestroy,
+      displayAfterDestroy,
+    };
+  });
+
+  expect(metrics.attachedBeforeDestroy).toBe(true);
+  expect(metrics.attachedAfterDestroy).toBe(false);
+  expect(metrics.displayAfterDestroy).toBe("none");
+});
+
 test("HTML5CSSRenderer bounds duplicate owned canvas clones per frame", async ({
   page,
 }) => {

--- a/src/definition/config.ts
+++ b/src/definition/config.ts
@@ -10,6 +10,8 @@ const updateConfig = (config: BaseConfig) => {
   defaultConfig = config;
 };
 
+const setConfig = updateConfig;
+
 /**
  * 既定の設定
  */
@@ -30,4 +32,8 @@ const defaultOptions: BaseOptions = {
   lazy: false,
 };
 
-export { defaultConfig, defaultOptions, updateConfig };
+const setOptions = (options: BaseOptions) => {
+  Object.assign(defaultOptions, options);
+};
+
+export { defaultConfig, defaultOptions, setConfig, setOptions, updateConfig };

--- a/src/definition/config.ts
+++ b/src/definition/config.ts
@@ -15,7 +15,7 @@ const setConfig = updateConfig;
 /**
  * 既定の設定
  */
-const defaultOptions: BaseOptions = {
+const createDefaultOptions = (): BaseOptions => ({
   config: {},
   debug: false,
   enableLegacyPiP: false,
@@ -30,16 +30,16 @@ const defaultOptions: BaseOptions = {
   useLegacy: false,
   video: undefined,
   lazy: false,
-};
+});
 
-const initialOptions: BaseOptions = { ...defaultOptions };
+const defaultOptions: BaseOptions = createDefaultOptions();
 
 const setOptions = (options: BaseOptions) => {
   Object.assign(defaultOptions, options);
 };
 
 const resetOptions = () => {
-  Object.assign(defaultOptions, initialOptions);
+  Object.assign(defaultOptions, createDefaultOptions());
 };
 
 export {

--- a/src/definition/config.ts
+++ b/src/definition/config.ts
@@ -32,8 +32,21 @@ const defaultOptions: BaseOptions = {
   lazy: false,
 };
 
+const initialOptions: BaseOptions = { ...defaultOptions };
+
 const setOptions = (options: BaseOptions) => {
   Object.assign(defaultOptions, options);
 };
 
-export { defaultConfig, defaultOptions, setConfig, setOptions, updateConfig };
+const resetOptions = () => {
+  Object.assign(defaultOptions, initialOptions);
+};
+
+export {
+  defaultConfig,
+  defaultOptions,
+  resetOptions,
+  setConfig,
+  setOptions,
+  updateConfig,
+};

--- a/src/renderer/html5css.ts
+++ b/src/renderer/html5css.ts
@@ -673,8 +673,10 @@ class HTML5CSSRenderer implements IRenderer {
   }
 
   invalidateImage(image: IRenderer): void {
-    // Eagerly drop and detach the canvas so flush() never touches it again
+    // Eagerly drop and detach owned canvases so flush() never touches them again
     // and a pooled re-acquisition by another renderer finds no ghost in the DOM.
+    // External canvases remain caller-owned; drawImage() copies them instead of
+    // reparenting, so invalidation must not detach the caller's DOM node.
     const source = image.canvas;
     const clones = this.cloneMap.get(source);
     if (clones) {
@@ -688,8 +690,10 @@ class HTML5CSSRenderer implements IRenderer {
     }
     this.prevCanvasSet.delete(source);
     this.activeCanvasSet.delete(source);
-    source.style.display = "none";
-    source.remove();
+    if (this.ownedCanvases.has(source)) {
+      source.style.display = "none";
+      source.remove();
+    }
   }
 
   private getNode(tagName: "div"): HTMLElement {

--- a/src/renderer/html5css.ts
+++ b/src/renderer/html5css.ts
@@ -507,8 +507,8 @@ class HTML5CSSRenderer implements IRenderer {
       typeof WeakRef === "undefined"
         ? () => {
             if (inner) {
-              this.ownedCanvases.delete(inner.canvas);
               this.invalidateImage(inner);
+              this.ownedCanvases.delete(inner.canvas);
             }
           }
         : (() => {
@@ -517,8 +517,8 @@ class HTML5CSSRenderer implements IRenderer {
               if (inner) {
                 const parent = parentRef.deref();
                 if (parent) {
-                  parent.ownedCanvases.delete(inner.canvas);
                   parent.invalidateImage(inner);
+                  parent.ownedCanvases.delete(inner.canvas);
                 }
               }
             };

--- a/tests/bench/helpers.ts
+++ b/tests/bench/helpers.ts
@@ -11,8 +11,8 @@ import { createNicoScripts, ImageCacheContext } from "@/contexts";
 import {
   defaultConfig,
   defaultOptions,
+  resetOptions,
   setConfig,
-  setOptions,
 } from "@/definition/config";
 import { initConfig } from "@/definition/initConfig";
 import { RangeCacheContext } from "@/utils/rangeCache";
@@ -108,7 +108,7 @@ const mulberry32 = (seed: number) => {
 const resetBenchState = () => {
   initConfig();
   setConfig(defaultConfig);
-  setOptions(defaultOptions);
+  resetOptions();
 };
 
 const createBenchContext = (): CommentInstanceContext => ({

--- a/tests/bench/helpers.ts
+++ b/tests/bench/helpers.ts
@@ -6,7 +6,8 @@ import type {
   Timeline,
 } from "@/@types";
 import { HTML5Comment } from "@/comments/HTML5Comment";
-import { resetNicoScripts } from "@/contexts/nicoscript";
+import type { CommentInstanceContext } from "@/contexts";
+import { createNicoScripts, ImageCacheContext } from "@/contexts";
 import {
   defaultConfig,
   defaultOptions,
@@ -14,6 +15,7 @@ import {
   setOptions,
 } from "@/definition/config";
 import { initConfig } from "@/definition/initConfig";
+import { RangeCacheContext } from "@/utils/rangeCache";
 
 const emptyTextMetrics = (width: number): TextMetrics =>
   ({
@@ -33,7 +35,7 @@ const emptyTextMetrics = (width: number): TextMetrics =>
 
 class FakeRenderer implements IRenderer {
   public readonly rendererName = "FakeRenderer";
-  public readonly canvas = document.createElement("canvas");
+  public readonly canvas = { height: 1080, width: 1920 } as HTMLCanvasElement;
   private font = "";
   private size = { width: 1920, height: 1080 };
 
@@ -61,6 +63,8 @@ class FakeRenderer implements IRenderer {
   setGlobalAlpha() {}
   setSize(width: number, height: number) {
     this.size = { width, height };
+    this.canvas.width = width;
+    this.canvas.height = height;
   }
   getSize() {
     return this.size;
@@ -105,8 +109,15 @@ const resetBenchState = () => {
   initConfig();
   setConfig(defaultConfig);
   setOptions(defaultOptions);
-  resetNicoScripts();
 };
+
+const createBenchContext = (): CommentInstanceContext => ({
+  config: defaultConfig,
+  options: defaultOptions,
+  nicoScripts: createNicoScripts(),
+  imageCache: new ImageCacheContext(),
+  rangeCache: new RangeCacheContext(),
+});
 
 /**
  * Generate deterministic FormattedComment array
@@ -142,6 +153,7 @@ const generateCommentInstances = (
   seed = 42,
 ): IComment[] => {
   const rng = mulberry32(seed);
+  const ctx = createBenchContext();
   const instances: IComment[] = [];
   for (let i = 0; i < count; i++) {
     const base: FormattedComment = {
@@ -157,7 +169,7 @@ const generateCommentInstances = (
       layer: -1,
       is_my_post: false,
     };
-    const instance = new HTML5Comment(base, renderer, i);
+    const instance = new HTML5Comment(base, renderer, i, ctx);
     instance.posY = -1;
     if (loc === "naka") {
       instance.comment.loc = "naka";


### PR DESCRIPTION
## チケットへのリンク

- 無し

## やったこと

- ベンチマーク用 reset helper が現在の config/comment context API で動くように修正
- CSS renderer の invalidateImage が caller-owned external canvas を DOM から detach しないように修正
- external canvas invalidation の回帰テストを追加

## やらないこと

- 無し

## できるようになること（ユーザ目線）

- npm run bench が起動時に落ちず、既存 benchmark を実行できる
- plugin/caller 所有の canvas が CSS renderer の invalidation でページから取り外されない

## できなくなること（ユーザ目線）

- 無し

## 動作確認

- pnpm run build: pass
- pnpm run lint: pass
- pnpm run check-types: pass
- pnpm run test:unit: pass
- pnpm run bench: pass
- pnpm exec biome check tests/bench/helpers.ts: pass
- Direct Firefox Playwright probe on alternate static server: external canvas remains attached and display=block after invalidateImage

## その他

- Local Playwright config on port 8080 could not be used because another local service returned 401 Unauthorized; validation used an alternate temporary static server instead.
- Subagent review status: APPROVED, no actionable findings.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two regressions: benchmark resets were broken because `setConfig`/`setOptions`/`resetOptions` weren't exported from `config.ts`, and `HTML5CSSRenderer.invalidateImage` unconditionally removed its source canvas from the DOM, detaching caller-owned external canvases when a plugin signalled texture updates.

- **`html5css.ts`**: Swap the call order in the `getCanvas()` destroy callback so `invalidateImage` runs before `ownedCanvases.delete`, ensuring `ownedCanvases.has(source)` is `true` when the guard is checked; add the guard in `invalidateImage` so only renderer-owned canvases are detached.
- **`config.ts`**: Extract `createDefaultOptions()` factory, add `setOptions`/`resetOptions`/`setConfig` exports so the bench helpers can compile and reset state correctly.
- **`helpers.ts`**: Replace broken imports and the self-assign `setOptions(defaultOptions)` no-op with `resetOptions()`; drop `resetNicoScripts()` in favour of per-run `createBenchContext()`; fix `FakeRenderer.canvas` to be a plain object instead of a real DOM canvas; thread the new `ctx` argument through `HTML5Comment` construction.
</details>


<h3>Confidence Score: 5/5</h3>

Safe to merge — both targeted bugs are correctly fixed and covered by new tests.

The call-order swap restores owned-canvas DOM cleanup on destroy, and the ownership guard in invalidateImage prevents external canvases from ever being detached. The config.ts factory + resetOptions fix the benchmark self-assign no-op. All four changed files are self-consistent, the Playwright tests validate the exact DOM-state transitions, and the previous findings from the prior review are fully addressed.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/renderer/html5css.ts | Call-order swap and ownership guard in invalidateImage correctly fix both the external-canvas detach bug and the owned-canvas ghost-DOM regression flagged in the previous review. |
| src/definition/config.ts | New factory + resetOptions correctly fixes the self-assign no-op; setConfig and setOptions exports are clean additions with no unintended mutations. |
| tests/bench/helpers.ts | Broken imports replaced, reset logic corrected, per-run context factory introduced; FakeRenderer canvas stub is appropriate for headless bench use. |
| src/__tests__/html5css-renderer.spec.ts | Two new Playwright tests cover the external-canvas and owned-canvas destruction paths accurately; assertions correctly model expected DOM state. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `tests/bench/helpers.ts`, line 108-112 ([link](https://github.com/xpadev-net/niconicomments/blob/368f6dc6a5ba51c365bacf2704257b3a41e4e7cc/tests/bench/helpers.ts#L108-L112)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`setOptions(defaultOptions)` is a self-assign no-op**

   `setOptions` is implemented as `Object.assign(defaultOptions, options)`. Calling it with `defaultOptions` itself — the same object — mutates nothing. This means `resetBenchState` never actually resets `defaultOptions` to its original values. As long as no benchmark calls `setOptions({debug: true, ...})` (or similar) before the reset, this is harmless; but if one ever does, subsequent benchmark runs will silently inherit the modified options even after calling `resetBenchState`. Consider seeding the reset from a snapshot of the original literal, or exporting a dedicated `resetOptions` that restores known defaults.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: tests/bench/helpers.ts
   Line: 108-112

   Comment:
   **`setOptions(defaultOptions)` is a self-assign no-op**

   `setOptions` is implemented as `Object.assign(defaultOptions, options)`. Calling it with `defaultOptions` itself — the same object — mutates nothing. This means `resetBenchState` never actually resets `defaultOptions` to its original values. As long as no benchmark calls `setOptions({debug: true, ...})` (or similar) before the reset, this is harmless; but if one ever does, subsequent benchmark runs will silently inherit the modified options even after calling `resetBenchState`. Consider seeding the reset from a snapshot of the original literal, or exporting a dedicated `resetOptions` that restores known defaults.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tests%2Fbench%2Fhelpers.ts%0ALine%3A%20108-112%0A%0AComment%3A%0A**%60setOptions%28defaultOptions%29%60%20is%20a%20self-assign%20no-op**%0A%0A%60setOptions%60%20is%20implemented%20as%20%60Object.assign%28defaultOptions%2C%20options%29%60.%20Calling%20it%20with%20%60defaultOptions%60%20itself%20%E2%80%94%20the%20same%20object%20%E2%80%94%20mutates%20nothing.%20This%20means%20%60resetBenchState%60%20never%20actually%20resets%20%60defaultOptions%60%20to%20its%20original%20values.%20As%20long%20as%20no%20benchmark%20calls%20%60setOptions%28%7Bdebug%3A%20true%2C%20...%7D%29%60%20%28or%20similar%29%20before%20the%20reset%2C%20this%20is%20harmless%3B%20but%20if%20one%20ever%20does%2C%20subsequent%20benchmark%20runs%20will%20silently%20inherit%20the%20modified%20options%20even%20after%20calling%20%60resetBenchState%60.%20Consider%20seeding%20the%20reset%20from%20a%20snapshot%20of%20the%20original%20literal%2C%20or%20exporting%20a%20dedicated%20%60resetOptions%60%20that%20restores%20known%20defaults.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=xpadev-net%2Fniconicomments&pr=348&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

2. `src/renderer/html5css.ts`, line 506-525 ([link](https://github.com/xpadev-net/niconicomments/blob/1172ba704a6516a4e4d8923308520592ca99927e/src/renderer/html5css.ts#L506-L525)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> Owned sub-renderer canvas stays in DOM after destroy. `ownedCanvases.delete` is called before `invalidateImage`, so when `invalidateImage` runs the guard `this.ownedCanvases.has(source)` is already `false` and the canvas is never detached. The canvas then lingers in the layer with stale content until the parent renderer itself is destroyed — it is removed from `prevCanvasSet`/`activeCanvasSet` so `flush()` never cleans it up either. If the pooled canvas is re-acquired and drawn by a different renderer, `appendChild` will move it out, but the window between destroy and re-acquisition leaves ghost content visible. Swapping the call order restores the old behaviour: `invalidateImage` sees `has(source) = true` → detaches the canvas, then `delete` cleans up the set.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/renderer/html5css.ts
   Line: 506-525

   Comment:
   Owned sub-renderer canvas stays in DOM after destroy. `ownedCanvases.delete` is called before `invalidateImage`, so when `invalidateImage` runs the guard `this.ownedCanvases.has(source)` is already `false` and the canvas is never detached. The canvas then lingers in the layer with stale content until the parent renderer itself is destroyed — it is removed from `prevCanvasSet`/`activeCanvasSet` so `flush()` never cleans it up either. If the pooled canvas is re-acquired and drawn by a different renderer, `appendChild` will move it out, but the window between destroy and re-acquisition leaves ghost content visible. Swapping the call order restores the old behaviour: `invalidateImage` sees `has(source) = true` → detaches the canvas, then `delete` cleans up the set.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Frenderer%2Fhtml5css.ts%0ALine%3A%20506-525%0A%0AComment%3A%0AOwned%20sub-renderer%20canvas%20stays%20in%20DOM%20after%20destroy.%20%60ownedCanvases.delete%60%20is%20called%20before%20%60invalidateImage%60%2C%20so%20when%20%60invalidateImage%60%20runs%20the%20guard%20%60this.ownedCanvases.has%28source%29%60%20is%20already%20%60false%60%20and%20the%20canvas%20is%20never%20detached.%20The%20canvas%20then%20lingers%20in%20the%20layer%20with%20stale%20content%20until%20the%20parent%20renderer%20itself%20is%20destroyed%20%E2%80%94%20it%20is%20removed%20from%20%60prevCanvasSet%60%2F%60activeCanvasSet%60%20so%20%60flush%28%29%60%20never%20cleans%20it%20up%20either.%20If%20the%20pooled%20canvas%20is%20re-acquired%20and%20drawn%20by%20a%20different%20renderer%2C%20%60appendChild%60%20will%20move%20it%20out%2C%20but%20the%20window%20between%20destroy%20and%20re-acquisition%20leaves%20ghost%20content%20visible.%20Swapping%20the%20call%20order%20restores%20the%20old%20behaviour%3A%20%60invalidateImage%60%20sees%20%60has%28source%29%20%3D%20true%60%20%E2%86%92%20detaches%20the%20canvas%2C%20then%20%60delete%60%20cleans%20up%20the%20set.%0A%0A%60%60%60suggestion%0A%20%20%20%20const%20invalidate%20%3D%0A%20%20%20%20%20%20typeof%20WeakRef%20%3D%3D%3D%20%22undefined%22%0A%20%20%20%20%20%20%20%20%3F%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20%28inner%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20this.invalidateImage%28inner%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20this.ownedCanvases.delete%28inner.canvas%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%3A%20%28%28%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20const%20parentRef%20%3D%20new%20WeakRef%28this%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20return%20%28%29%20%3D%3E%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20%28inner%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20const%20parent%20%3D%20parentRef.deref%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20%28parent%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20parent.invalidateImage%28inner%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20parent.ownedCanvases.delete%28inner.canvas%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%3B%0A%20%20%20%20%20%20%20%20%20%20%7D%29%28%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=xpadev-net%2Fniconicomments&pr=348&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Clean up owned CSS canvases on destroy"](https://github.com/xpadev-net/niconicomments/commit/bc87e354788567933dd04ceb98b14008741597fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36969702)</sub>

<!-- /greptile_comment -->