### PR TITLE
Fix zero-duration optional NicoScript ranges

### DIFF
--- a/src/utils/comment.ts
+++ b/src/utils/comment.ts
@@ -108,7 +108,7 @@ const normalizeParsedCommandLong = (value: number | undefined) => {
   if (value === undefined) {
     return undefined;
   }
-  if (!Number.isFinite(value) || value <= 0) {
+  if (!Number.isFinite(value) || value < 0) {
     return undefined;
   }
   return value;
@@ -117,6 +117,9 @@ const normalizeParsedCommandLong = (value: number | undefined) => {
 const normalizeOptionalNicoscriptLong = (value: number | undefined) => {
   if (value === undefined) {
     return undefined;
+  }
+  if (value === 0) {
+    return 0;
   }
   return (
     normalizeLongCentiseconds(value * 100, MAX_NICOSCRIPT_LONG) || undefined

--- a/tests/unit/duration-lazy.spec.ts
+++ b/tests/unit/duration-lazy.spec.ts
@@ -323,12 +323,27 @@ describe("duration bounds and lazy timeline expansion", () => {
     parseCommandAndNicoScript(
       createComment({
         owner: true,
-        content: "@ジャンプ sm9",
+        content: "@ジャンプ sm9 test",
         mail: ["@0.005"],
       }),
       subCentisecondJumpContext,
     );
+    expect(subCentisecondJumpContext.nicoScripts.jump[0]).toBeDefined();
     expect(subCentisecondJumpContext.nicoScripts.jump[0]?.end).toBeUndefined();
+
+    const zeroJumpContext = createContext();
+    parseCommandAndNicoScript(
+      createComment({
+        owner: true,
+        content: "@ジャンプ sm9 test",
+        mail: ["@0"],
+      }),
+      zeroJumpContext,
+    );
+    expect(zeroJumpContext.nicoScripts.jump[0]).toBeDefined();
+    expect(zeroJumpContext.nicoScripts.jump[0]?.end).toBe(
+      zeroJumpContext.nicoScripts.jump[0]?.start,
+    );
   });
 
   test("widens lazy lookahead for narrower canvas widths", () => {


### PR DESCRIPTION
## Summary
- Preserve explicit @0 command durations through parsed-command normalization
- Normalize optional NicoScript @0 ranges to zero length instead of open-ended ranges
- Add a parse-level regression test for @ジャンプ with @0 and strengthen the sub-centisecond jump assertion

## Validation
- pnpm vitest run tests/unit/duration-lazy.spec.ts
- pnpm biome check src/utils/comment.ts tests/unit/duration-lazy.spec.ts
- pnpm tsc --noEmit --jsx react --types node --project tsconfig.json
- pnpm vitest run

## Review
- Subagent reviewer pass: initial MAJOR findings fixed
- Subagent reviewer re-review: NO_FINDINGS

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two related bugs: `@0` durations on parsed commands were being discarded before reaching the NicoScript normalizer, and `normalizeOptionalNicoscriptLong` was collapsing explicit `@0` to `undefined` (open-ended) rather than to a zero-length range. Together the two changes make `@ジャンプ @0`, `@デフォルト @0`, and `@置換 @0` expire immediately instead of persisting indefinitely.

- `normalizeParsedCommandLong` now lets the value `0` pass through (change `<= 0` → `< 0`), preserving the explicit zero so it can reach the optional NicoScript normalizer.
- `normalizeOptionalNicoscriptLong` gains an early-return for `value === 0` → `return 0`, preventing the `normalizeLongCentiseconds(0) || undefined` short-circuit that silently promoted zero-duration commands to open-ended ranges.
- The regression test is strengthened: the sub-centisecond `@ジャンプ` case fixes an accidentally no-op test (the jump command was never registered because `RE_JUMP` requires content after the video ID), adds a `toBeDefined()` guard, and adds a new `@0` case asserting `end === start`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge. Both changes are minimal, mutually required, and directly address the stated bug. No regressions were introduced to existing comment duration paths.

Both source changes are tiny and tightly scoped: one guard flip in normalizeParsedCommandLong and one early-return in normalizeOptionalNicoscriptLong. The regular-comment long path is unaffected because normalizeCommentLong already falls back to DEFAULT_COMMENT_LONG for zero. The ban/reverse path is unaffected because those use normalizeNicoscriptLong (always provides a default). The jump/default/replace optional path now correctly distinguishes explicit @0 (zero-duration, immediately expires) from sub-centisecond values like @0.005 (open-ended, as before). The fixed test correctly exercises the code path that the prior test accidentally bypassed.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/utils/comment.ts | Two targeted fixes: normalizeParsedCommandLong now passes 0 through (was discarding it), and normalizeOptionalNicoscriptLong gets an early-return for value===0 to produce a zero-duration range rather than collapsing to undefined (open-ended). |
| tests/unit/duration-lazy.spec.ts | Existing sub-centisecond jump test fixed (was silently a no-op due to RE_JUMP requiring content after the video ID); adds toBeDefined() guard and a new @0 case asserting end===start. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["parseCommand\n@0 → result.long = 0"] --> B["normalizeParsedCommandLong(0)"]
    B -->|"OLD: value <= 0 → undefined"| C1["commands.long = undefined"]
    B -->|"NEW: value < 0 → undefined\n(0 now passes through)"| C2["commands.long = 0"]

    C1 --> D1["normalizeOptionalNicoscriptLong(undefined)\n→ return undefined (open-ended)"]
    C2 --> D2["normalizeOptionalNicoscriptLong(0)"]

    D2 -->|"OLD: normalizeLongCentiseconds(0×100)\n= 0, then 0 || undefined → undefined"| E1["open-ended range\nend = undefined"]
    D2 -->|"NEW: early return value===0\n→ return 0"| E2["long = 0\nend = vpos + 0 = vpos"]

    D1 --> E1
    E1 --> F1["@ジャンプ @0 persists\nindefinitely (BUG)"]
    E2 --> F2["@ジャンプ @0 immediately\nexpires (FIXED)"]

    style F1 fill:#f88,stroke:#c00
    style F2 fill:#8f8,stroke:#080
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Fix zero-duration optional NicoScript ra..."](https://github.com/xpadev-net/niconicomments/commit/3b5791a4256a7d66d84a549972bc8e0046931689) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37018372)</sub>

<!-- /greptile_comment -->