### PR TITLE
chore: avoid checkout token in dev build push job

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -59,6 +59,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
+          token: ''
 
       - name: Download build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8


### PR DESCRIPTION
## Summary
- Set the push-dev-build checkout token input to an empty string
- Keep persist-credentials: false on checkout
- Leave GITHUB_TOKEN scoped only to the Push to dev-build branch step

## Validation
- git diff --check
- static workflow validation: checkout token input line, persist-credentials lines, and GITHUB_TOKEN env binding verified

## Review
- deep-review local pass: no findings
- independent subagent review: no findings; confirmed checkout token input and push step env boundary

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR tightens credential scoping in the `push-dev-build` job by explicitly passing `token: ''` to the `actions/checkout` step, preventing the default `GITHUB_TOKEN` from being made available to git during checkout. The existing `persist-credentials: false` flag is retained, and the token is still injected into only the "Push to dev-build branch" step via `env: GITHUB_TOKEN`.

- `token: ''` on checkout removes the implicit token injection that `actions/checkout` would otherwise perform using `github.token`, so no credential is available to git between the checkout and the push step.
- `GITHUB_TOKEN` remains bound only to the final push step, consistent with least-privilege scoping.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge. The one-line change explicitly removes the implicit token from the checkout step, narrowing credential exposure to only the push step where it is needed.

The change is minimal and correct: token: '' overrides the default github.token injection by actions/checkout, so no credential is available to git between checkout and the push step. Combined with the already-present persist-credentials: false, this closes the window where a leaked or compromised intermediate step could access repository write credentials. The repository is public, so an unauthenticated checkout continues to work without issue.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/dev-build.yml | Adds `token: ''` to the checkout step in `push-dev-build`, ensuring no GitHub token is passed to (or persisted by) the checkout action; the GITHUB_TOKEN remains scoped solely to the push step via `env:`. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions Runner
    participant CO as actions/checkout
    participant DL as download-artifact
    participant VA as Validate artifact (Python)
    participant GIT as git / remote

    GH->>CO: "checkout (token='', persist-credentials=false)"
    Note over CO: No token stored in git config
    GH->>DL: download dev-build-artifacts
    GH->>VA: validate tarball entries
    Note over VA: Allowlist check, path traversal guard
    GH->>GIT: Push to dev-build branch
    Note over GIT: GITHUB_TOKEN injected only here via env:
```
</details>

<sub>Reviews (2): Last reviewed commit: ["chore: refresh review state for checkout..."](https://github.com/xpadev-net/niconicomments/commit/7dec0b7c7e4e8d360605512401885003d1afb43c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37475809)</sub>

<!-- /greptile_comment -->