### PR TITLE
Restrict sample dev build version selection

### DIFF
--- a/docs/sample/sample.js
+++ b/docs/sample/sample.js
@@ -91,6 +91,7 @@ let video = Number(urlParams.get("video") || 0),
   noVideo = !!urlParams.get("novideo"),
   time = Number(urlParams.get("time") || -1);
 const ncVersion = readVersionParam("ncVersion");
+const selectedNcVersion = USE_LOCAL_NC_DEV_BUILD ? "dev" : ncVersion;
 const pluginVersion = readVersionParam("pluginVersion");
 const niwangoVersion = readVersionParam("niwangoVersion");
 
@@ -131,15 +132,15 @@ const scriptsLoaded = new Promise((resolve) => {
   resolveScripts = resolve;
 });
 Promise.all([
-  loadScript(getNCUrl(ncVersion)),
+  loadScript(getNCUrl(selectedNcVersion)),
   loadScript(getPluginUrl(pluginVersion)),
   loadScript(getNiwangoUrl(niwangoVersion)),
 ])
   .then(resolveScripts)
   .catch((err) => {
     console.error("Failed to load scripts:", err, {
-      ncVersion,
-      ncUrl: getNCUrl(ncVersion),
+      ncVersion: selectedNcVersion,
+      ncUrl: getNCUrl(selectedNcVersion),
       pluginVersion,
       pluginUrl: getPluginUrl(pluginVersion),
       niwangoVersion,
@@ -447,7 +448,10 @@ const ensureVersionOption = (selectEl, version) => {
   selectEl.value = version;
 };
 
-ensureVersionOption(ncVersionElement, ncVersion);
+if (!USE_LOCAL_NC_DEV_BUILD) {
+  ncVersionElement.querySelector('option[value="dev"]')?.remove();
+}
+ensureVersionOption(ncVersionElement, selectedNcVersion);
 ensureVersionOption(pluginVersionElement, pluginVersion);
 ensureVersionOption(niwangoVersionElement, niwangoVersion);
 controlRendererElement.value = rendererType;
@@ -485,7 +489,7 @@ Promise.all([
   fetchVersions("@xpadev-net/niconicomments-plugin-niwango"),
   fetchVersions("@xpadev-net/niwango"),
 ]).then(([ncVersions, pluginVersions, niwangoVersions]) => {
-  appendVersionOptions(ncVersionElement, ncVersions, ncVersion);
+  appendVersionOptions(ncVersionElement, ncVersions, selectedNcVersion);
   appendVersionOptions(pluginVersionElement, pluginVersions, pluginVersion);
   appendVersionOptions(niwangoVersionElement, niwangoVersions, niwangoVersion);
 });
@@ -511,7 +515,7 @@ const showScriptError = (message) => {
     "color:#fff;padding:12px 16px;font-family:monospace;font-size:13px;";
   el.textContent =
     message ||
-    `Script load failed (ncVersion=${ncVersion}, pluginVersion=${pluginVersion}, niwangoVersion=${niwangoVersion}). Check version selectors.`;
+    `Script load failed (ncVersion=${selectedNcVersion}, pluginVersion=${pluginVersion}, niwangoVersion=${niwangoVersion}). Check version selectors.`;
   document.body.appendChild(el);
 };
 

--- a/docs/sample/sample.js
+++ b/docs/sample/sample.js
@@ -1,12 +1,14 @@
 const DEFAULT_NC_VERSION = "0.2.78";
 const DEFAULT_PLUGIN_VERSION = "0.0.13";
 const DEFAULT_NIWANGO_VERSION = "0.0.1-canary.20231002-1";
+// Manual local-development switch; do not derive this from URL query params.
+const USE_LOCAL_NC_DEV_BUILD = false;
 const NC_DEV_URL =
   "https://cdn.jsdelivr.net/gh/xpadev-net/niconicomments@dev-build/dist/bundle.js";
 const MAX_VERSION_LENGTH = 64;
 const VERSION_PARAM_CONFIG = {
   ncVersion: {
-    aliases: new Set(["dev"]),
+    aliases: new Set(),
     defaultValue: DEFAULT_NC_VERSION,
   },
   pluginVersion: {
@@ -115,7 +117,7 @@ const loadScript = (src) =>
 
 const encodeVersionForUrl = (value) => encodeURIComponent(value);
 const getNCUrl = (v) =>
-  v === "dev"
+  USE_LOCAL_NC_DEV_BUILD
     ? NC_DEV_URL
     : `https://cdn.jsdelivr.net/npm/@xpadev-net/niconicomments@${encodeVersionForUrl(v)}/dist/bundle.min.js`;
 const getPluginUrl = (v) =>


### PR DESCRIPTION
## Summary
- Remove the sample page URL alias that let `ncVersion=dev` select the mutable dev-build CDN script
- Keep the dev-build URL only behind a manual local-development flag in `docs/sample/sample.js`
- Preserve normal semver `ncVersion` query handling through the npm jsDelivr URL

## Validation
- `pnpm test:unit`
- Static VM harness: verified `?ncVersion=dev` sanitizes to default npm URL and `?ncVersion=0.2.79` keeps the semver npm URL

## Review
- Deep-review local pass: no findings
- Independent subagent review: no actionable findings; confirmed `NC_DEV_URL` / aliases `["dev"]` are not reachable through public URL query path

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR closes the path that let the public sample page load the mutable `dev-build` CDN script by passing `?ncVersion=dev` in the URL. Access to the dev CDN is now controlled exclusively by a hard-coded `USE_LOCAL_NC_DEV_BUILD` constant that must be flipped manually in source.

- Removes `\"dev\"` from the `aliases` set in `VERSION_PARAM_CONFIG`, causing `readVersionParam` to reject it as an invalid version and fall back to the default semver.
- Introduces `USE_LOCAL_NC_DEV_BUILD = false` and derives `selectedNcVersion` from it; `getNCUrl` now tests the flag rather than comparing the version string to `\"dev\"`.
- Strips the `<option value=\"dev\">` from the NC version `<select>` at runtime unless the local-dev flag is set, and routes all downstream uses (`loadScript`, error reporting, `appendVersionOptions`) through `selectedNcVersion`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change tightens access to the dev CDN build without altering any library code or public API.

The only file changed is the sample page script. The sanitization logic already in place correctly rejects 'dev' now that the alias is removed, and all downstream consumers of the version value have been updated to use selectedNcVersion. No library code, tests, or public-facing types were touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/sample/sample.js | Replaces URL-driven dev-build selection with a compile-time flag; all changed call sites (script loading, error messages, dropdown population) consistently use the new `selectedNcVersion` variable. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["Hide sample dev option unless local flag..."](https://github.com/xpadev-net/niconicomments/commit/a26bec22f84b5ceaf9c41c08daf4ffa2d2d7b99a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37475880)</sub>

<!-- /greptile_comment -->