### PR TITLE
Keep lazy scan sorted after live comments

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -472,12 +472,6 @@ class NiconiComments {
         console.error("Failed to add comments", e);
       }
     }
-    if (this.lazyCommentOrderSortedByVpos) {
-      this.lazyCommentOrderSortedByVpos = areCommentsSortedByVpos(
-        comments,
-        this.comments[this.comments.length - 1],
-      );
-    }
     for (const comment of comments) {
       if (comment.invisible) continue;
       if (comment.loc === "naka") {

--- a/tests/unit/duration-lazy.spec.ts
+++ b/tests/unit/duration-lazy.spec.ts
@@ -418,21 +418,40 @@ describe("duration bounds and lazy timeline expansion", () => {
     expect(state.timeline[0]).toBeDefined();
   });
 
-  test("addComments disables sorted lazy scanning for out-of-order appends", () => {
+  test("lazy addComments keeps sorted tail early break for out-of-order live appends", () => {
+    const farVpos = MAX_LAZY_COMMENT_LOOKAHEAD + MAX_COMMENT_LONG + 500;
     const instance = new NiconiComments(
       new FakeRenderer(),
-      [createComment({ id: 1, vpos: 1000, mail: ["ue"] })],
+      [
+        createComment({ id: 1, vpos: 0, mail: ["ue"] }),
+        createComment({
+          id: 2,
+          vpos: MAX_LAZY_COMMENT_LOOKAHEAD,
+          mail: ["ue"],
+        }),
+        createComment({ id: 3, vpos: farVpos, mail: ["ue"] }),
+      ],
       { format: "formatted", lazy: true, mode: "html5" },
     );
     const state = instance as unknown as {
+      comments: { posY: number }[];
       lazyCommentOrderSortedByVpos: boolean;
+      processedCommentIndex: number;
+      timeline: Record<number, IComment[]>;
     };
 
     expect(state.lazyCommentOrderSortedByVpos).toBe(true);
 
-    instance.addComments(createComment({ id: 2, vpos: 100, mail: ["ue"] }));
+    instance.addComments(createComment({ id: 4, vpos: 100, mail: ["ue"] }));
+    instance.drawCanvas(0, true);
 
-    expect(state.lazyCommentOrderSortedByVpos).toBe(false);
+    expect(state.lazyCommentOrderSortedByVpos).toBe(true);
+    expect(state.processedCommentIndex).toBe(1);
+    expect(state.comments[2]?.posY).toBe(-1);
+    expect(state.comments[3]?.posY).not.toBe(-1);
+    expect(state.timeline[100]?.map((comment) => comment.comment.id)).toContain(
+      4,
+    );
   });
 
   test("non-lazy constructor builds timeline from plugin-transformed comments", () => {


### PR DESCRIPTION
## Summary
- keep lazy sorted-tail scanning enabled when addComments() appends already-placed live comments out of vpos order
- add a regression covering immediate live timeline placement while the far initial tail remains unresolved

## Validation
- pnpm vitest run tests/unit/duration-lazy.spec.ts
- pnpm exec tsc --noEmit --pretty false

## Review
- deep-review local pass: no findings
- independent subagent review: no findings; confirmed lazy scan keeps early break and does not become every-frame full-tail traversal

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a regression where `addComments()` incorrectly disabled the lazy scan's early-break optimization (`lazyCommentOrderSortedByVpos`) when live comments arrived out-of-order — a normal occurrence in live comment streams. The fix removes the premature flag invalidation; since live comments are processed eagerly (posY is set synchronously in `addComments`), they never participate in the lazy scan and their vpos order is irrelevant to the initial dataset's sort guarantee.

- **`src/main.ts`**: Removes the 6-line block that flipped `lazyCommentOrderSortedByVpos` to `false` when `addComments` received out-of-order comments, preserving the early-break optimization for the lazy scan of the initial dataset.
- **`tests/unit/duration-lazy.spec.ts`**: Replaces the old regression test (which asserted the flag *became* false) with a richer test covering the live-append scenario: verifies the flag stays `true`, the lazy window only processes comments within the lookahead boundary, and the live comment is immediately visible in the timeline.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change removes a flag invalidation that incorrectly disabled a scan optimization, and the fix is narrowly scoped with no public API impact.

Live comments added via addComments() have their posY set synchronously before being appended to this.comments, so they never appear as unprocessed entries in the lazy scan. Clearing lazyCommentOrderSortedByVpos based on their arrival order was therefore unnecessary and harmful. The removal is provably safe, the updated test covers the critical invariants, and no external API contracts change.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/main.ts | Removes premature invalidation of `lazyCommentOrderSortedByVpos` in `addComments()`; the fix is correct because live comments are processed eagerly and never enter the lazy scan path. |
| tests/unit/duration-lazy.spec.ts | Updated regression test asserts the flag stays `true` after an out-of-order live append, with additional coverage of timeline placement and processedCommentIndex boundary. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["addComments(rawComments)"] --> B["createCommentInstance for each comment"]
    B --> C["plugin.addComments?(comments)"]
    C --> D{"comment.invisible?"}
    D -- No --> E["processMovableComment / processFixedComment\n(sets posY >= 0 eagerly)"]
    D -- Yes --> F["skip"]
    E --> G["comments.push to this.comments"]
    F --> G
    G --> H["reset nextUnprocessedCommentIndex"]
    H --> I["_advanceNextUnprocessedCommentIndex()\nskips posY>=0 and invisible entries"]
    I --> J["sortTimelineComment(touchedTimeline)"]

    subgraph "Lazy scan (resolveLazyCommentWindow)"
      K["iterate comments with posY < 0"] --> L{"comment.vpos > resolveUntil?"}
      L -- "lazyCommentOrderSortedByVpos=true" --> M["break early"]
      L -- No --> N["schedule for getCommentPos"]
    end

    J -.->|"live comments already posY>=0\nnever reached by lazy scan"| K
```
</details>

<sub>Reviews (5): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/dev..."](https://github.com/xpadev-net/niconicomments/commit/f059773ef139362909284f084bedf94a20d2da1f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37475925)</sub>

<!-- /greptile_comment -->