### PR TITLE
Fix HTML5 offscreen comment padding

### DIFF
--- a/src/comments/HTML5Comment.ts
+++ b/src/comments/HTML5Comment.ts
@@ -8,6 +8,7 @@ import type {
   MeasureInput,
   MeasureTextInput,
   MeasureTextResult,
+  Position,
 } from "@/@types/";
 import type { CommentInstanceContext } from "@/contexts/";
 import { TypeGuardError } from "@/errors/TypeGuardError";
@@ -465,7 +466,29 @@ class HTML5Comment extends BaseComment {
   }
 
   protected override canGenerateTextImage(): boolean {
-    return isWithinImageBounds(this.comment.width, this.comment.height);
+    return isWithinImageBounds(this.comment.width, this.getTextImageHeight());
+  }
+
+  private getTextImagePaddingTop() {
+    const { scale } = getFontSizeAndScale(this.comment.charSize, this.config);
+    const paddingTop =
+      (10 - scale * 10) *
+      ((this.comment.lineCount + 1) / this.config.html5HiResCommentCorrection);
+    const layerScale = this.comment.layer === -1 ? this.ctx.options.scale : 1;
+    return (
+      this.comment.lineHeight *
+      paddingTop *
+      getConfig(this.config.commentScale, false) *
+      layerScale
+    );
+  }
+
+  private getTextImageHeight() {
+    return this.comment.height + this.getTextImagePaddingTop();
+  }
+
+  protected override _draw(posX: number, posY: number, cursor?: Position) {
+    super._draw(posX, posY - this.getTextImagePaddingTop(), cursor);
   }
 
   override _generateTextImage(): IRenderer {
@@ -481,7 +504,7 @@ class HTML5Comment extends BaseComment {
       scale *
       (this.comment.layer === -1 ? this.ctx.options.scale : 1);
     const image = this.renderer.getCanvas(HTML5_COMMENT_IMAGE_PADDING);
-    image.setSize(this.comment.width, this.comment.height);
+    image.setSize(this.comment.width, this.getTextImageHeight());
     image.setStrokeStyle(getStrokeColor(this.comment, this.config));
     image.setFillStyle(this.comment.color);
     image.setLineWidth(getConfig(this.config.contextLineWidth, false));

--- a/src/comments/HTML5Comment.ts
+++ b/src/comments/HTML5Comment.ts
@@ -38,6 +38,11 @@ const MAX_HTML5_COMMENT_IMAGE_WIDTH = 8192 - HTML5_COMMENT_IMAGE_PADDING * 2;
 const MAX_HTML5_COMMENT_IMAGE_HEIGHT = 8192 - HTML5_COMMENT_IMAGE_PADDING * 2;
 const MAX_HTML5_COMMENT_IMAGE_AREA = MAX_CANVAS_AREA;
 
+type TextImageBounds = {
+  height: number;
+  paddingTop: number;
+};
+
 const clampHTML5Content = (input: string) => {
   let lineCount = 1;
   let end = 0;
@@ -72,6 +77,11 @@ const isWithinImageBounds = (width: number, height: number) => {
 
 class HTML5Comment extends BaseComment {
   override readonly pluginName: string = "HTML5Comment";
+  private readonly textImageBoundsCache = new WeakMap<
+    object,
+    TextImageBounds
+  >();
+
   constructor(
     comment: FormattedComment,
     context: IRenderer,
@@ -466,29 +476,35 @@ class HTML5Comment extends BaseComment {
   }
 
   protected override canGenerateTextImage(): boolean {
-    return isWithinImageBounds(this.comment.width, this.getTextImageHeight());
+    return isWithinImageBounds(
+      this.comment.width,
+      this.getTextImageBounds().height,
+    );
   }
 
-  private getTextImagePaddingTop() {
+  private getTextImageBounds() {
+    const cached = this.textImageBoundsCache.get(this.comment);
+    if (cached !== undefined) return cached;
     const { scale } = getFontSizeAndScale(this.comment.charSize, this.config);
     const paddingTop =
       (10 - scale * 10) *
       ((this.comment.lineCount + 1) / this.config.html5HiResCommentCorrection);
     const layerScale = this.comment.layer === -1 ? this.ctx.options.scale : 1;
-    return (
+    const paddingTopHeight =
       this.comment.lineHeight *
       paddingTop *
       getConfig(this.config.commentScale, false) *
-      layerScale
-    );
-  }
-
-  private getTextImageHeight() {
-    return this.comment.height + this.getTextImagePaddingTop();
+      layerScale;
+    const bounds = {
+      height: this.comment.height + paddingTopHeight,
+      paddingTop: paddingTopHeight,
+    };
+    this.textImageBoundsCache.set(this.comment, bounds);
+    return bounds;
   }
 
   protected override _draw(posX: number, posY: number, cursor?: Position) {
-    super._draw(posX, posY - this.getTextImagePaddingTop(), cursor);
+    super._draw(posX, posY - this.getTextImageBounds().paddingTop, cursor);
   }
 
   override _generateTextImage(): IRenderer {
@@ -504,7 +520,7 @@ class HTML5Comment extends BaseComment {
       scale *
       (this.comment.layer === -1 ? this.ctx.options.scale : 1);
     const image = this.renderer.getCanvas(HTML5_COMMENT_IMAGE_PADDING);
-    image.setSize(this.comment.width, this.getTextImageHeight());
+    image.setSize(this.comment.width, this.getTextImageBounds().height);
     image.setStrokeStyle(getStrokeColor(this.comment, this.config));
     image.setFillStyle(this.comment.color);
     image.setLineWidth(getConfig(this.config.contextLineWidth, false));

--- a/tests/unit/html5-resource-bounds.spec.ts
+++ b/tests/unit/html5-resource-bounds.spec.ts
@@ -28,6 +28,13 @@ class RecordingRenderer implements IRenderer {
   public readonly rendererName = "RecordingRenderer";
   public readonly canvas = {} as HTMLCanvasElement;
   public readonly children: RecordingRenderer[] = [];
+  public readonly drawImageCalls: { image: IRenderer; x: number; y: number }[] =
+    [];
+  public readonly fillTextCallsByPosition: {
+    text: string;
+    x: number;
+    y: number;
+  }[] = [];
   public measureCalls = 0;
   public fillTextCalls = 0;
   public strokeTextCalls = 0;
@@ -48,8 +55,9 @@ class RecordingRenderer implements IRenderer {
   setScale() {}
   fillRect() {}
   strokeRect() {}
-  fillText() {
+  fillText(text: string, x: number, y: number) {
     this.fillTextCalls++;
+    this.fillTextCallsByPosition.push({ text, x, y });
   }
   strokeText() {
     this.strokeTextCalls++;
@@ -86,7 +94,9 @@ class RecordingRenderer implements IRenderer {
     this.children.push(child);
     return child;
   }
-  drawImage() {}
+  drawImage(image: IRenderer, x: number, y: number) {
+    this.drawImageCalls.push({ image, x, y });
+  }
   flush() {}
   invalidateImage() {}
 }
@@ -352,6 +362,34 @@ describe("HTML5 comment resource bounds", () => {
     expect(image).not.toBeNull();
     expect(image?.getSize().width).toBeLessThanOrEqual(widthLimit);
     expect(image?.getSize().height).toBeGreaterThan(0);
+  });
+
+  test.each([
+    "ue",
+    "shita",
+  ] as const)("reserves and offsets HTML5 offscreen top padding for long %s comments", (loc) => {
+    const renderer = new RecordingRenderer();
+    const comment = new TestHTML5Comment(
+      formattedComment(1, "x".repeat(5000), [loc]),
+      renderer,
+      0,
+      createContext(),
+    );
+
+    const image = comment.exposeTextImage() as RecordingRenderer | null;
+
+    expect(image).not.toBeNull();
+    const paddingHeight =
+      (image?.getSize().height ?? 0) - comment.comment.height;
+    expect(paddingHeight).toBeGreaterThan(0);
+    expect(image?.fillTextCallsByPosition[0]?.y).toBeGreaterThan(0);
+
+    comment.drawBodyForTest();
+
+    expect(renderer.drawImageCalls).toHaveLength(1);
+    expect(renderer.drawImageCalls[0]?.image).toBe(image);
+    expect(renderer.drawImageCalls[0]?.x).toBe(0);
+    expect(renderer.drawImageCalls[0]?.y).toBeCloseTo(-paddingHeight, 5);
   });
 
   test("keeps fixed-comment resize measurement bounded at max content length", () => {


### PR DESCRIPTION
## Summary
- include HTML5 hi-res paddingTop in offscreen comment image bounds/allocation
- offset cached image drawing upward so measured layout/collision bounds stay unchanged
- add resource-bounds regression coverage for long ue/shita fixed comments

## Validation
- pnpm test:unit tests/unit/html5-resource-bounds.spec.ts
- pnpm check-types
- pnpm lint
- pnpm test:unit
- pre-commit hook: lint, typecheck

## Review
- deep-review checklist pass for rendering bounds/resource limits/tests
- independent subagent review: no actionable findings; residual ue-only test gap addressed by adding shita coverage

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes HTML5 offscreen comment rendering by including the hi-res top-padding (`paddingTop`) in the image allocation size, then compensating at draw time by shifting the image upward so that layout/collision bounds remain unchanged.

- **`getTextImageBounds()`** (new, cached): computes `paddingTopHeight` from the `(10 - scale * 10)` formula and caches it on `this.comment` via a `WeakMap`. `canGenerateTextImage()` and `_generateTextImage()` now both use this taller image height.
- **`_draw()` override**: calls `super._draw(posX, posY - paddingTopHeight)` so the image is drawn above its logical box by exactly the added padding, keeping text at the visually correct position without moving collision/background rectangles.
- **New tests**: verify `image.height > comment.height`, the first fill-text call is at `y > 0` inside the image, and `drawImage` is called at `y ≈ -paddingHeight`.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge. The fix is scoped to HTML5 hi-res padding allocation and draw offset; collision/layout bounds are untouched and the new tests validate the full round-trip.

The `getTextImageBounds` cache is keyed on `this.comment`, which is always replaced (never mutated in place), so stale values are impossible. The `_draw` override only adjusts the Y of the image blit, leaving every other drawing call at the original `posY`, which preserves existing layout, collision, and background behaviour. The raw `paddingTop` formula is duplicated, but that is a future-risk style note, not a present defect.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/comments/HTML5Comment.ts | Adds `TextImageBounds` type, WeakMap-cached `getTextImageBounds()`, `_draw()` offset override, and updates `canGenerateTextImage()`/`_generateTextImage()` to use the taller padded height. The raw `paddingTop` formula is duplicated verbatim in both `getTextImageBounds()` and `_generateTextImage()`. |
| tests/unit/html5-resource-bounds.spec.ts | Adds `drawImageCalls` and `fillTextCallsByPosition` recording to `RecordingRenderer`, and a new parameterised test covering both `ue` and `shita` to assert image height, text Y offset, and draw position. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["Cache HTML5 offscreen image bounds"](https://github.com/xpadev-net/niconicomments/commit/aff36616f572154b9a4ddab0cf355214d064d749) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37476070)</sub>

<!-- /greptile_comment -->