### PR TITLE
Bound HTML5CSS external canvas copies per frame

### DIFF
--- a/src/__tests__/html5css-renderer.spec.ts
+++ b/src/__tests__/html5css-renderer.spec.ts
@@ -767,6 +767,65 @@ test("HTML5CSSRenderer bounds duplicate owned canvas clones per frame", async ({
     externalImage.destroy();
     externalCase.renderer.destroy();
     externalCase.root.remove();
+
+    const externalManySourceCountCase = createRenderer();
+    const externalManySourceCountImages: InstanceType<
+      typeof global.NiconiComments.internal.renderer.CanvasRenderer
+    >[] = [];
+    for (let i = 0; i < 1200; i++) {
+      const element = document.createElement("canvas");
+      const image = new global.NiconiComments.internal.renderer.CanvasRenderer(
+        element,
+      );
+      image.setSize(10, 10);
+      externalManySourceCountImages.push(image);
+      externalManySourceCountCase.renderer.drawImage(
+        image,
+        i % 200,
+        Math.floor(i / 200) * 12,
+      );
+    }
+    externalManySourceCountCase.renderer.flush();
+    const externalManySourceCountVisibleCanvases = countVisibleLayerCanvases(
+      externalManySourceCountCase.layer,
+    );
+    const externalManySourceCountConnectedCanvases = countLayerCanvases(
+      externalManySourceCountCase.layer,
+    );
+
+    for (const image of externalManySourceCountImages) image.destroy();
+    externalManySourceCountCase.renderer.destroy();
+    externalManySourceCountCase.root.remove();
+
+    const externalManySourceByteCase = createRenderer();
+    const externalManySourceByteImages: InstanceType<
+      typeof global.NiconiComments.internal.renderer.CanvasRenderer
+    >[] = [];
+    withVirtualCreatedCanvases(() => {
+      for (let i = 0; i < 40; i++) {
+        const element = document.createElement("canvas");
+        const image =
+          new global.NiconiComments.internal.renderer.CanvasRenderer(element);
+        image.setSize(2048, 2048);
+        externalManySourceByteImages.push(image);
+        externalManySourceByteCase.renderer.drawImage(
+          image,
+          i % 200,
+          Math.floor(i / 200) * 12,
+        );
+      }
+    });
+    externalManySourceByteCase.renderer.flush();
+    const externalManySourceByteVisibleCanvases = countVisibleLayerCanvases(
+      externalManySourceByteCase.layer,
+    );
+    const externalManySourceByteConnectedCanvases = countLayerCanvases(
+      externalManySourceByteCase.layer,
+    );
+
+    for (const image of externalManySourceByteImages) image.destroy();
+    externalManySourceByteCase.renderer.destroy();
+    externalManySourceByteCase.root.remove();
     return {
       countCappedFrameVisibleCanvases,
       countCappedFrameConnectedCanvases,
@@ -776,6 +835,10 @@ test("HTML5CSSRenderer bounds duplicate owned canvas clones per frame", async ({
       byteCappedFrameConnectedCanvases,
       externalByteCappedFrameVisibleCanvases,
       externalByteCappedFrameConnectedCanvases,
+      externalManySourceCountVisibleCanvases,
+      externalManySourceCountConnectedCanvases,
+      externalManySourceByteVisibleCanvases,
+      externalManySourceByteConnectedCanvases,
     };
   });
 
@@ -787,11 +850,16 @@ test("HTML5CSSRenderer bounds duplicate owned canvas clones per frame", async ({
   // the source canvas plus 32 duplicate clones.
   expect(result.byteCappedFrameVisibleCanvases).toBe(33);
   expect(result.byteCappedFrameConnectedCanvases).toBe(33);
-  // External canvases are copied instead of reparented. The first copy of a
-  // source is allowed, then repeated copies of that source consume the same
-  // 512 MiB budget, allowing 32 more copied canvases.
-  expect(result.externalByteCappedFrameVisibleCanvases).toBe(33);
-  expect(result.externalByteCappedFrameConnectedCanvases).toBe(33);
+  // External canvases are copied instead of reparented. The first copy also
+  // consumes the 512 MiB budget, allowing 32 copied canvases total.
+  expect(result.externalByteCappedFrameVisibleCanvases).toBe(32);
+  expect(result.externalByteCappedFrameConnectedCanvases).toBe(32);
+  // Many distinct external source canvases share the same per-frame copy count
+  // and byte budgets instead of each getting an independent first copy.
+  expect(result.externalManySourceCountVisibleCanvases).toBe(1024);
+  expect(result.externalManySourceCountConnectedCanvases).toBe(1024);
+  expect(result.externalManySourceByteVisibleCanvases).toBe(32);
+  expect(result.externalManySourceByteConnectedCanvases).toBe(32);
   expect(result.recoveredFrameVisibleCanvases).toBe(2);
   expect(result.recoveredFrameConnectedCanvases).toBe(2);
 });

--- a/src/renderer/html5css.ts
+++ b/src/renderer/html5css.ts
@@ -79,7 +79,10 @@ class HTML5CSSRenderer implements IRenderer {
     HTMLCanvasElement,
     DuplicateCloneBudget
   >();
-  private externalCanvasSet = new WeakSet<HTMLCanvasElement>();
+  private externalCanvasCopyFrameBudget: DuplicateCloneBudget = {
+    bytes: 0,
+    count: 0,
+  };
   // Canvases created by this renderer's getCanvas() — safe to reparent in drawImage.
   // External canvases are never reparented; pixels are copied instead.
   private readonly ownedCanvases = new WeakSet<HTMLCanvasElement>();
@@ -573,23 +576,20 @@ class HTML5CSSRenderer implements IRenderer {
     // occurrences to be independently positioned.
     let element: HTMLCanvasElement;
     if (!this.ownedCanvases.has(source)) {
-      const cloneBytes = this.getCanvasByteSize(source);
-      const seenExternalCanvas = this.externalCanvasSet.has(source);
-      if (seenExternalCanvas && !this.reserveDuplicateClone(source, cloneBytes))
-        return;
+      const copyBytes = this.getCanvasByteSize(source);
+      if (!this.reserveExternalCanvasCopy(source, copyBytes)) return;
       element = this.root.ownerDocument.createElement("canvas");
       element.width = source.width;
       element.height = source.height;
       const ctx = element.getContext("2d");
       if (!ctx) {
-        if (seenExternalCanvas) this.releaseDuplicateClone(source, cloneBytes);
+        this.releaseExternalCanvasCopy(source, copyBytes);
         console.warn(
           "HTML5CSSRenderer: failed to acquire 2D context for canvas copy.",
         );
         return;
       }
       ctx.drawImage(source, 0, 0);
-      this.externalCanvasSet.add(source);
     } else if (this.activeCanvasSet.has(source)) {
       const cloneBytes = this.getCanvasByteSize(source);
       if (!this.reserveDuplicateClone(source, cloneBytes)) return;
@@ -928,6 +928,32 @@ class HTML5CSSRenderer implements IRenderer {
       : 0;
   }
 
+  private canReserveCanvasCopyBudget(
+    budget: DuplicateCloneBudget,
+    bytes: number,
+  ): boolean {
+    return (
+      budget.count < MAX_DUPLICATE_CANVAS_CLONES_PER_FRAME &&
+      budget.bytes + bytes <= MAX_DUPLICATE_CANVAS_CLONE_BYTES_PER_FRAME
+    );
+  }
+
+  private incrementCanvasCopyBudget(
+    budget: DuplicateCloneBudget,
+    bytes: number,
+  ): void {
+    budget.count++;
+    budget.bytes += bytes;
+  }
+
+  private decrementCanvasCopyBudget(
+    budget: DuplicateCloneBudget,
+    bytes: number,
+  ): void {
+    budget.count = Math.max(0, budget.count - 1);
+    budget.bytes = Math.max(0, budget.bytes - bytes);
+  }
+
   private reserveDuplicateClone(
     source: HTMLCanvasElement,
     bytes: number,
@@ -936,15 +962,34 @@ class HTML5CSSRenderer implements IRenderer {
       bytes: 0,
       count: 0,
     };
+    if (!this.canReserveCanvasCopyBudget(budget, bytes)) {
+      return false;
+    }
+    this.incrementCanvasCopyBudget(budget, bytes);
+    this.duplicateCloneBudgetMap.set(source, budget);
+    return true;
+  }
+
+  private reserveExternalCanvasCopy(
+    source: HTMLCanvasElement,
+    bytes: number,
+  ): boolean {
+    const sourceBudget = this.duplicateCloneBudgetMap.get(source) ?? {
+      bytes: 0,
+      count: 0,
+    };
     if (
-      budget.count >= MAX_DUPLICATE_CANVAS_CLONES_PER_FRAME ||
-      budget.bytes + bytes > MAX_DUPLICATE_CANVAS_CLONE_BYTES_PER_FRAME
+      !this.canReserveCanvasCopyBudget(sourceBudget, bytes) ||
+      !this.canReserveCanvasCopyBudget(
+        this.externalCanvasCopyFrameBudget,
+        bytes,
+      )
     ) {
       return false;
     }
-    budget.count++;
-    budget.bytes += bytes;
-    this.duplicateCloneBudgetMap.set(source, budget);
+    this.incrementCanvasCopyBudget(sourceBudget, bytes);
+    this.incrementCanvasCopyBudget(this.externalCanvasCopyFrameBudget, bytes);
+    this.duplicateCloneBudgetMap.set(source, sourceBudget);
     return true;
   }
 
@@ -954,16 +999,26 @@ class HTML5CSSRenderer implements IRenderer {
   ): void {
     const budget = this.duplicateCloneBudgetMap.get(source);
     if (!budget) return;
-    budget.count = Math.max(0, budget.count - 1);
-    budget.bytes = Math.max(0, budget.bytes - bytes);
+    this.decrementCanvasCopyBudget(budget, bytes);
     if (budget.count === 0 && budget.bytes === 0) {
       this.duplicateCloneBudgetMap.delete(source);
     }
   }
 
+  private releaseExternalCanvasCopy(
+    source: HTMLCanvasElement,
+    bytes: number,
+  ): void {
+    this.releaseDuplicateClone(source, bytes);
+    this.decrementCanvasCopyBudget(this.externalCanvasCopyFrameBudget, bytes);
+  }
+
   private resetDuplicateCloneAccounting(): void {
     this.duplicateCloneBudgetMap.clear();
-    this.externalCanvasSet = new WeakSet();
+    this.externalCanvasCopyFrameBudget = {
+      bytes: 0,
+      count: 0,
+    };
   }
 
   private trimHelperSurfaces(): void {


### PR DESCRIPTION
## Summary
- Count every external canvas copy, including the first copy, against per-source and frame-wide copy budgets
- Preserve owned canvas reuse/duplicate clone behavior while sharing external copy count/byte limits across sources
- Add regression coverage for same-source and many-source external copy caps

## Validation
- pnpm vitest run src/__tests__/html5css-renderer.spec.ts (exit 0; repo vitest config reports no matching test files)
- pnpm playwright test src/__tests__/html5css-renderer.spec.ts --config=/tmp/niconicomments-playwright-8081.config.mjs --project=firefox -g "HTML5CSSRenderer bounds duplicate owned canvas clones per frame"
- pnpm exec biome check src/renderer/html5css.ts src/__tests__/html5css-renderer.spec.ts
- pnpm run check-types

## Review
- deep-review self pass: no findings
- Independent resource/lifecycle subagent: no findings; confirmed shared per-frame external copy cap
- Independent tests/regression subagent: no findings; confirmed distinct-source tests fail without frame-wide cap

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes external canvas copy accounting in `HTML5CSSRenderer` so that the **first** copy of an external canvas also consumes from the per-frame count and byte budgets, instead of only subsequent copies of the same source being gated. It also switches from a per-source `WeakSet` to a shared frame-wide `DuplicateCloneBudget` object so that many distinct external sources collectively share the same budget cap.

- The old `externalCanvasSet: WeakSet` (which gave the first copy of each source a free pass) is replaced by `externalCanvasCopyFrameBudget`, a flat budget object that is decremented for every external copy and reset each frame.
- `reserveExternalCanvasCopy` now checks both a per-source budget (in `duplicateCloneBudgetMap`) and the new frame-wide budget, so a burst of many distinct 1-copy-each external sources is capped the same way as a single source copied many times.
- Tests add two new sub-cases: 1 200 distinct count-capped sources (expects 1 024 visible) and 40 distinct byte-capped large sources (expects 32 visible), along with updated assertions for the existing single-source byte-capped external case (33 → 32).
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change tightens an existing resource guard without introducing new failure modes or data loss paths.

The diff is a focused refactor of the external-canvas copy guard. The old WeakSet free-first-copy exemption is cleanly replaced by a shared frame budget that increments and decrements symmetrically. The release path (ctx acquisition failure) correctly rolls back both the per-source and frame-wide counters. Budget accounting is reset every frame via resetDuplicateCloneAccounting. New regression tests cover the two changed edge cases and the updated single-source byte expectation. No pre-existing behaviour for owned canvas clones is altered.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/renderer/html5css.ts | Replaces externalCanvasSet WeakSet with a shared DuplicateCloneBudget for external copies; adds reserveExternalCanvasCopy, releaseExternalCanvasCopy, canReserveCanvasCopyBudget, incrementCanvasCopyBudget, and decrementCanvasCopyBudget helpers; logic and rollback paths are consistent. |
| src/__tests__/html5css-renderer.spec.ts | Adds two new sub-cases (many-source count cap, many-source byte cap) and updates the single-source external byte-cap assertion from 33 to 32 to reflect that the first copy now counts against the budget. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[drawImage source] --> B{owned canvas?}
    B -- No --> C[reserveExternalCanvasCopy]
    C --> D{per-source budget ok?}
    D -- No --> E[drop / return]
    D -- Yes --> F{frame-wide budget ok?}
    F -- No --> E
    F -- Yes --> G[increment both budgets]
    G --> H[create canvas element and copy pixels]
    H --> I{ctx acquired?}
    I -- No --> J[releaseExternalCanvasCopy - decrement both budgets]
    I -- Yes --> K[append to layer]
    B -- Yes, first draw --> L[reparent source element]
    L --> K
    B -- Yes, already active --> M[reserveDuplicateClone]
    M --> N{per-source budget ok?}
    N -- No --> E
    N -- Yes --> O[increment per-source budget and track in cloneMap]
    O --> K
    subgraph reset per frame
        P[duplicateCloneBudgetMap.clear]
        Q[externalCanvasCopyFrameBudget reset to 0]
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/dev..."](https://github.com/xpadev-net/niconicomments/commit/f57f1921b9bfb8c9b88224e87d63ee50adfaefac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37476107)</sub>

<!-- /greptile_comment -->