### PR TITLE
Fix dev-build checkout without token

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -56,10 +56,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
-        with:
-          persist-credentials: false
-          token: ''
+      - name: Checkout source without credentials
+        run: |
+          git init
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git fetch --no-tags --depth=1 origin "${GITHUB_REF_NAME}"
+          git checkout --detach "${GITHUB_SHA}"
 
       - name: Download build artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8


### PR DESCRIPTION
## Summary
- replace the push-dev-build checkout action with an anonymous git fetch/checkout step
- keep GITHUB_TOKEN scoped to the final dev-build push step only

## Validation
- gh run view 27496039096 --log-failed confirmed actions/checkout v6 failed with: Input required and not supplied: token
- ruby YAML parse for .github/workflows/dev-build.yml
- static token-boundary script: only Push to dev-build branch receives GITHUB_TOKEN
- anonymous public git fetch/checkout simulation for xpadev-net/niconicomments develop
- git diff --check
- actionlint via go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/dev-build.yml
- independent subagent review: no required findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes the `push-dev-build` job's checkout step, which was broken because `actions/checkout@v6` started requiring a non-empty token even when `token: ''` was explicitly supplied.

- The broken `actions/checkout` call is replaced with four plain `git` commands (`init`, `remote add`, `fetch --depth=1`, `checkout --detach`) that work anonymously against the public repository.
- `GITHUB_TOKEN` continues to be injected only in the final \"Push to dev-build branch\" step, preserving the minimal-token-scope design.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, targeted fix to a broken CI step with no impact on library code or consumers.

The four git commands are a direct functional equivalent of the old checkout action for a public repo: git init on a fresh runner workspace, anonymous fetch of the exact triggering ref at depth 1, and a detached-HEAD checkout of the precise GITHUB_SHA. The concurrency cancel-in-progress setting on the workflow means the latest run always wins, so the depth-1 tip will equal GITHUB_SHA in practice. Token scoping is unchanged — GITHUB_TOKEN is still confined to the push step only.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/dev-build.yml | Replaces the broken actions/checkout v6 call (which required a token even when empty) with an equivalent anonymous git fetch/checkout sequence; GITHUB_TOKEN remains scoped only to the final push step. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Push to develop / workflow_dispatch] --> B[build job\ncontents: read]
    B --> B1[actions/checkout v6\npersist-credentials: false]
    B1 --> B2[Install pnpm + Node]
    B2 --> B3[pnpm install && pnpm build]
    B3 --> B4[Package dist/bundle.js → tgz]
    B4 --> B5[Upload artifact\nretention-days: 1]
    B5 --> C{github.ref ==\nrefs/heads/develop?}
    C -- No --> Z[push-dev-build skipped]
    C -- Yes --> D[push-dev-build job\ncontents: write]
    D --> D1[git init / remote add / fetch depth=1 / checkout detach - no token]
    D1 --> D2[Download artifact]
    D2 --> D3[Validate artifact Python allowlist check]
    D3 --> D4[Push to dev-build branch - GITHUB_TOKEN only here]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/dev..."](https://github.com/xpadev-net/niconicomments/commit/5f62870e42143d1ef4d08b635798be561eb75217) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37476989)</sub>

<!-- /greptile_comment -->