### PR TITLE
Fix scaled CanvasRenderer public clear

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ import { initConfig } from "@/definition/initConfig";
 import { InvalidOptionError } from "@/errors/";
 import { EventHandler } from "@/eventHandler";
 import convert2formattedComment from "@/inputParser";
-import { CanvasRenderer, createRenderer } from "@/renderer";
+import { createRenderer } from "@/renderer";
 import typeGuard from "@/typeGuard";
 import {
   arrayEqual,
@@ -107,6 +107,9 @@ const areCommentsSortedByVpos = (
 const rendererHasVideoSurface = (renderer: IRenderer) =>
   "video" in renderer &&
   (renderer as IRenderer & { readonly video?: unknown }).video != null;
+
+const getRendererClear = (renderer: IRenderer) =>
+  (renderer as IRenderer & { clear?: () => void }).clear;
 
 const removeUndefinedConfigValues = (
   config: NonNullable<Options["config"]>,
@@ -875,8 +878,9 @@ class NiconiComments {
    * キャンバスを消去する
    */
   public clear() {
-    if (this.renderer instanceof CanvasRenderer) {
-      this.renderer.clear();
+    const clear = getRendererClear(this.renderer);
+    if (clear) {
+      clear.call(this.renderer);
     } else {
       const size = this.renderer.getSize();
       this.renderer.clearRect(0, 0, size.width, size.height);

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ import { initConfig } from "@/definition/initConfig";
 import { InvalidOptionError } from "@/errors/";
 import { EventHandler } from "@/eventHandler";
 import convert2formattedComment from "@/inputParser";
-import { createRenderer } from "@/renderer";
+import { CanvasRenderer, createRenderer } from "@/renderer";
 import typeGuard from "@/typeGuard";
 import {
   arrayEqual,
@@ -875,8 +875,12 @@ class NiconiComments {
    * キャンバスを消去する
    */
   public clear() {
-    const size = this.renderer.getSize();
-    this.renderer.clearRect(0, 0, size.width, size.height);
+    if (this.renderer instanceof CanvasRenderer) {
+      this.renderer.clear();
+    } else {
+      const size = this.renderer.getSize();
+      this.renderer.clearRect(0, 0, size.width, size.height);
+    }
     this.renderer.flush();
   }
 

--- a/src/renderer/canvas.ts
+++ b/src/renderer/canvas.ts
@@ -192,6 +192,16 @@ class CanvasRenderer implements IRenderer {
     }
   }
 
+  clear(): void {
+    this.context.save();
+    try {
+      this.context.setTransform(1, 0, 0, 1, 0, 0);
+      this.context.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    } finally {
+      this.context.restore();
+    }
+  }
+
   setFont(font: string): void {
     this.context.font = font;
   }

--- a/tests/unit/canvas-renderer-clear.spec.ts
+++ b/tests/unit/canvas-renderer-clear.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test, vi } from "vitest";
 
+import NiconiComments from "@/main";
 import { CanvasRenderer } from "@/renderer/canvas";
 
 type Transform = {
@@ -161,6 +162,31 @@ describe("CanvasRenderer.clearRect", () => {
       "save",
       "setTransform(1,0,0,1,0,0)",
       "clearRect(0,0,1280,720)",
+      "restore",
+    ]);
+  });
+
+  test("clears the entire backing canvas through NiconiComments.clear when renderer scale is reduced", () => {
+    if (!("HTMLCanvasElement" in globalThis)) {
+      Object.defineProperty(globalThis, "HTMLCanvasElement", {
+        configurable: true,
+        value: class HTMLCanvasElement {},
+      });
+    }
+    const { context, renderer } = createRenderer();
+
+    renderer.setSize(320, 180);
+    const niconiComments = new NiconiComments(renderer, [], {
+      format: "formatted",
+    });
+    context.calls = [];
+
+    niconiComments.clear();
+
+    expect(context.calls).toEqual([
+      "save",
+      "setTransform(1,0,0,1,0,0)",
+      "clearRect(0,0,320,180)",
       "restore",
     ]);
   });

--- a/tests/unit/canvas-renderer-clear.spec.ts
+++ b/tests/unit/canvas-renderer-clear.spec.ts
@@ -179,6 +179,7 @@ describe("CanvasRenderer.clearRect", () => {
     const niconiComments = new NiconiComments(renderer, [], {
       format: "formatted",
     });
+    renderer.setScale(0.5);
     context.calls = [];
 
     niconiComments.clear();


### PR DESCRIPTION
## Summary
- Add a CanvasRenderer full-canvas clear that clears backing pixels under an identity transform
- Route public NiconiComments.clear() through that full clear for CanvasRenderer while preserving other renderers
- Add a regression test for reduced-scale CanvasRenderer public clear

## Validation
- pnpm vitest run tests/unit/canvas-renderer-clear.spec.ts
- pnpm check-types
- pre-commit hook: lint, typecheck

## Review
- deep-review self-review: no findings
- independent subagent review: no findings; confirmed physical backing clear, drawCanvas logical clear unchanged, padded renderer expectations intact

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a bug where `NiconiComments.clear()` failed to erase the full backing canvas when `CanvasRenderer` had a reduced scale applied — only the top-left sub-region was cleared because the old path routed through the scale-aware `clearRect` shim.

- **`CanvasRenderer.clear()`** (new method): saves context state, resets to identity transform, calls `clearRect` with the physical canvas dimensions, then restores — guaranteeing the entire backing store is erased regardless of the active scale.
- **`NiconiComments.clear()`** (updated): uses a type-cast helper `getRendererClear` (modelled on the existing `rendererHasVideoSurface` pattern) to dispatch through the new `clear()` when available, falling back to the original `clearRect`-based path for other renderers.
- **Regression test** added: verifies that calling `niconiComments.clear()` on a 0.5-scaled `CanvasRenderer` records the identity-transform sequence over the full 320×180 canvas, not a clipped region.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, well-scoped bug fix with no regressions to internal rendering paths.

The new CanvasRenderer.clear() method is logically correct: it saves state, resets to identity, clears the full physical canvas, and restores. The dispatch in main.ts follows the existing cast pattern for optional renderer capabilities and falls back cleanly for other renderers. flush() on CanvasRenderer is a no-op so the call order is harmless. The regression test directly covers the previously broken scenario.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/renderer/canvas.ts | Adds `clear(): void` that resets to identity transform, clears full backing canvas, then restores — correctly targets physical `canvas.width`/`canvas.height` rather than logical size. |
| src/main.ts | Adds `getRendererClear` helper following the existing `rendererHasVideoSurface` cast pattern; routes `NiconiComments.clear()` through it when available, preserving the original fallback for non-CanvasRenderer backends. |
| tests/unit/canvas-renderer-clear.spec.ts | Adds a regression test that creates a scaled CanvasRenderer via `NiconiComments`, calls `clear()`, and asserts the identity-transform + full-canvas `clearRect` sequence is emitted. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["NiconiComments.clear()"] --> B{getRendererClear\nreturns a method?}
    B -- Yes\nCanvasRenderer --> C["clear.call(renderer)"]
    B -- No\nother IRenderer --> D["renderer.clearRect(0, 0, size.width, size.height)"]
    C --> E["context.save()"]
    E --> F["context.setTransform(1,0,0,1,0,0)\n(identity — resets scale)"]
    F --> G["context.clearRect(0, 0,\ncanvas.width, canvas.height)\n(full backing canvas)"]
    G --> H["context.restore()"]
    D --> I["renderer.flush()"]
    H --> I
```
</details>

<sub>Reviews (2): Last reviewed commit: ["Address clear dispatch review"](https://github.com/xpadev-net/niconicomments/commit/6d56c4bc60b31262168001876ea6633a1932680a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37477107)</sub>

<!-- /greptile_comment -->