### PR TITLE
Fix renderer resource cleanup on failures

### DIFF
--- a/src/comments/FlashComment.ts
+++ b/src/comments/FlashComment.ts
@@ -439,57 +439,63 @@ class FlashComment extends BaseComment {
 
   override _generateTextImage(): IRenderer {
     const renderer = this.renderer.getCanvas();
-    this._setupCanvas(renderer);
-    const atButtonPadding = getConfig(this.config.atButtonPadding, true);
-    const lineOffset = this.comment.lineOffset;
-    const lineHeight = this.comment.fontSize * this.comment.lineHeight;
-    const offsetKey = this.comment.resizedY ? "resized" : "default";
-    const offsetY =
-      this.config.flashCommentYPaddingTop[offsetKey] +
-      this.comment.fontSize *
-        this.comment.lineHeight *
-        this.config.flashCommentYOffset[this.comment.size][offsetKey];
-    let lastFont = this.comment.font;
-    let leftOffset = 0;
-    let lineCount = 0;
-    let isLastButton = false;
-    for (const item of this.comment.content) {
-      if (item.type === "spacer") {
-        leftOffset += item.count * item.charWidth * this.comment.fontSize;
-        isLastButton = !!item.isButton;
-        continue;
-      }
-      const font = item.font ?? this.comment.font;
-      if (lastFont !== font) {
-        lastFont = font;
-        renderer.setFont(parseFont(font, this.comment.fontSize, this.config));
-      }
-      const lines = item.slicedContent;
-      for (
-        let lineIndex = 0, lineLength = lines.length;
-        lineIndex < lineLength;
-        lineIndex++
-      ) {
-        const line = lines[lineIndex];
-        if (line === undefined) continue;
-        const posY = (lineOffset + lineCount + 1) * lineHeight + offsetY;
-        const partWidth = item.width[lineIndex] ?? 0;
-        if (
-          this.comment.button &&
-          !this.comment.button.hidden &&
-          ((!isLastButton && item.isButton) || (isLastButton && !item.isButton))
+    try {
+      this._setupCanvas(renderer);
+      const atButtonPadding = getConfig(this.config.atButtonPadding, true);
+      const lineOffset = this.comment.lineOffset;
+      const lineHeight = this.comment.fontSize * this.comment.lineHeight;
+      const offsetKey = this.comment.resizedY ? "resized" : "default";
+      const offsetY =
+        this.config.flashCommentYPaddingTop[offsetKey] +
+        this.comment.fontSize *
+          this.comment.lineHeight *
+          this.config.flashCommentYOffset[this.comment.size][offsetKey];
+      let lastFont = this.comment.font;
+      let leftOffset = 0;
+      let lineCount = 0;
+      let isLastButton = false;
+      for (const item of this.comment.content) {
+        if (item.type === "spacer") {
+          leftOffset += item.count * item.charWidth * this.comment.fontSize;
+          isLastButton = !!item.isButton;
+          continue;
+        }
+        const font = item.font ?? this.comment.font;
+        if (lastFont !== font) {
+          lastFont = font;
+          renderer.setFont(parseFont(font, this.comment.fontSize, this.config));
+        }
+        const lines = item.slicedContent;
+        for (
+          let lineIndex = 0, lineLength = lines.length;
+          lineIndex < lineLength;
+          lineIndex++
         ) {
-          leftOffset += atButtonPadding * 2;
+          const line = lines[lineIndex];
+          if (line === undefined) continue;
+          const posY = (lineOffset + lineCount + 1) * lineHeight + offsetY;
+          const partWidth = item.width[lineIndex] ?? 0;
+          if (
+            this.comment.button &&
+            !this.comment.button.hidden &&
+            ((!isLastButton && item.isButton) ||
+              (isLastButton && !item.isButton))
+          ) {
+            leftOffset += atButtonPadding * 2;
+          }
+          renderer.strokeText(line, leftOffset, posY);
+          renderer.fillText(line, leftOffset, posY);
+          leftOffset += partWidth;
+          if (lineIndex < lineLength - 1) {
+            leftOffset = 0;
+            lineCount += 1;
+          }
         }
-        renderer.strokeText(line, leftOffset, posY);
-        renderer.fillText(line, leftOffset, posY);
-        leftOffset += partWidth;
-        if (lineIndex < lineLength - 1) {
-          leftOffset = 0;
-          lineCount += 1;
-        }
+        isLastButton = !!item.isButton;
       }
-      isLastButton = !!item.isButton;
+    } catch (e) {
+      renderer.destroy();
+      throw e;
     }
     return renderer;
   }

--- a/src/comments/FlashComment.ts
+++ b/src/comments/FlashComment.ts
@@ -494,7 +494,9 @@ class FlashComment extends BaseComment {
         isLastButton = !!item.isButton;
       }
     } catch (e) {
-      renderer.destroy();
+      if (typeof renderer.destroy === "function") {
+        renderer.destroy();
+      }
       throw e;
     }
     return renderer;

--- a/src/comments/HTML5Comment.ts
+++ b/src/comments/HTML5Comment.ts
@@ -520,35 +520,40 @@ class HTML5Comment extends BaseComment {
       scale *
       (this.comment.layer === -1 ? this.ctx.options.scale : 1);
     const image = this.renderer.getCanvas(HTML5_COMMENT_IMAGE_PADDING);
-    image.setSize(this.comment.width, this.getTextImageBounds().height);
-    image.setStrokeStyle(getStrokeColor(this.comment, this.config));
-    image.setFillStyle(this.comment.color);
-    image.setLineWidth(getConfig(this.config.contextLineWidth, false));
-    image.setFont(parseFont(this.comment.font, fontSize, this.config));
-    image.setScale(drawScale);
-    let lineCount = 0;
-    if (!typeGuard.internal.HTML5Fonts(this.comment.font))
-      throw new TypeGuardError();
-    const offsetY =
-      (this.comment.charSize - this.comment.lineHeight) / 2 +
-      this.comment.lineHeight * -0.16 +
-      (this.config.fonts.html5[this.comment.font]?.offset || 0);
-    for (const item of this.comment.content) {
-      if (item?.type === "spacer") {
-        lineCount += item.count * item.charWidth * this.comment.fontSize;
-        continue;
+    try {
+      image.setSize(this.comment.width, this.getTextImageBounds().height);
+      image.setStrokeStyle(getStrokeColor(this.comment, this.config));
+      image.setFillStyle(this.comment.color);
+      image.setLineWidth(getConfig(this.config.contextLineWidth, false));
+      image.setFont(parseFont(this.comment.font, fontSize, this.config));
+      image.setScale(drawScale);
+      let lineCount = 0;
+      if (!typeGuard.internal.HTML5Fonts(this.comment.font))
+        throw new TypeGuardError();
+      const offsetY =
+        (this.comment.charSize - this.comment.lineHeight) / 2 +
+        this.comment.lineHeight * -0.16 +
+        (this.config.fonts.html5[this.comment.font]?.offset || 0);
+      for (const item of this.comment.content) {
+        if (item?.type === "spacer") {
+          lineCount += item.count * item.charWidth * this.comment.fontSize;
+          continue;
+        }
+        const lines = item.slicedContent;
+        for (let j = 0, n = lines.length; j < n; j++) {
+          const line = lines[j];
+          if (line === undefined) continue;
+          const posY =
+            (this.comment.lineHeight * (lineCount + 1 + paddingTop) + offsetY) /
+            scale;
+          image.strokeText(line, 0, posY);
+          image.fillText(line, 0, posY);
+          lineCount += 1;
+        }
       }
-      const lines = item.slicedContent;
-      for (let j = 0, n = lines.length; j < n; j++) {
-        const line = lines[j];
-        if (line === undefined) continue;
-        const posY =
-          (this.comment.lineHeight * (lineCount + 1 + paddingTop) + offsetY) /
-          scale;
-        image.strokeText(line, 0, posY);
-        image.fillText(line, 0, posY);
-        lineCount += 1;
-      }
+    } catch (e) {
+      image.destroy();
+      throw e;
     }
     return image;
   }

--- a/src/comments/HTML5Comment.ts
+++ b/src/comments/HTML5Comment.ts
@@ -552,7 +552,9 @@ class HTML5Comment extends BaseComment {
         }
       }
     } catch (e) {
-      image.destroy();
+      if (typeof image.destroy === "function") {
+        image.destroy();
+      }
       throw e;
     }
     return image;

--- a/src/renderer/webgl2.ts
+++ b/src/renderer/webgl2.ts
@@ -390,19 +390,25 @@ class WebGL2Renderer implements IRenderer {
     const gl = this.gl;
     const tex = gl.createTexture();
     if (!tex) throw new Error("Failed to create texture");
-    gl.bindTexture(gl.TEXTURE_2D, tex);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
-    gl.texImage2D(
-      gl.TEXTURE_2D,
-      0,
-      gl.RGBA,
-      gl.RGBA,
-      gl.UNSIGNED_BYTE,
-      uploadSource,
-    );
+    try {
+      gl.bindTexture(gl.TEXTURE_2D, tex);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+      gl.texImage2D(
+        gl.TEXTURE_2D,
+        0,
+        gl.RGBA,
+        gl.RGBA,
+        gl.UNSIGNED_BYTE,
+        uploadSource,
+      );
+    } catch (e) {
+      gl.bindTexture(gl.TEXTURE_2D, null);
+      gl.deleteTexture(tex);
+      throw e;
+    }
     return tex;
   }
 

--- a/tests/unit/flash-resource-bounds.spec.ts
+++ b/tests/unit/flash-resource-bounds.spec.ts
@@ -45,12 +45,17 @@ class RecordingRenderer implements IRenderer {
   public readonly children: RecordingRenderer[] = [];
   public measureCalls = 0;
   public fillTextCalls = 0;
+  public fillTextFailuresRemaining = 0;
   public setSizeCalls = 0;
   public strokeTextCalls = 0;
+  public destroyCalls = 0;
   private font = "10px sans-serif";
   private size = { width: 0, height: 0 };
+  public nextChildFillTextFailuresRemaining = 0;
 
-  destroy() {}
+  destroy() {
+    this.destroyCalls++;
+  }
   drawVideo() {}
   getFont() {
     return this.font;
@@ -63,6 +68,10 @@ class RecordingRenderer implements IRenderer {
   strokeRect() {}
   fillText() {
     this.fillTextCalls++;
+    if (this.fillTextFailuresRemaining > 0) {
+      this.fillTextFailuresRemaining--;
+      throw new Error("fillText failed");
+    }
   }
   strokeText() {
     this.strokeTextCalls++;
@@ -97,6 +106,8 @@ class RecordingRenderer implements IRenderer {
   restore() {}
   getCanvas() {
     const child = new RecordingRenderer();
+    child.fillTextFailuresRemaining = this.nextChildFillTextFailuresRemaining;
+    this.nextChildFillTextFailuresRemaining = 0;
     this.children.push(child);
     return child;
   }
@@ -239,6 +250,26 @@ describe("Flash and at-button resource bounds", () => {
     );
 
     expect(comment.flash).toBe(true);
+  });
+
+  test("destroys allocated Flash text images when drawing fails", () => {
+    const renderer = new RecordingRenderer();
+    const comment = new TestFlashComment(
+      formattedComment("draw failure"),
+      renderer,
+      0,
+      createContext(),
+    );
+
+    renderer.nextChildFillTextFailuresRemaining = 1;
+    expect(() => comment.exposeTextImage()).toThrow("fillText failed");
+    renderer.nextChildFillTextFailuresRemaining = 1;
+    expect(() => comment.exposeTextImage()).toThrow("fillText failed");
+
+    expect(renderer.children).toHaveLength(2);
+    expect(renderer.children.map((child) => child.destroyCalls)).toEqual([
+      1, 1,
+    ]);
   });
 
   test("does not allocate Flash text images outside bounded dimensions", () => {

--- a/tests/unit/html5-resource-bounds.spec.ts
+++ b/tests/unit/html5-resource-bounds.spec.ts
@@ -37,12 +37,16 @@ class RecordingRenderer implements IRenderer {
   }[] = [];
   public measureCalls = 0;
   public fillTextCalls = 0;
+  public fillTextFailuresRemaining = 0;
   public strokeTextCalls = 0;
+  public destroyCalls = 0;
   public destroyed = false;
+  public nextChildFillTextFailuresRemaining = 0;
   private font = "10px sans-serif";
   private size = { width: 0, height: 0 };
 
   destroy() {
+    this.destroyCalls++;
     this.destroyed = true;
   }
   drawVideo() {}
@@ -57,6 +61,10 @@ class RecordingRenderer implements IRenderer {
   strokeRect() {}
   fillText(text: string, x: number, y: number) {
     this.fillTextCalls++;
+    if (this.fillTextFailuresRemaining > 0) {
+      this.fillTextFailuresRemaining--;
+      throw new Error("fillText failed");
+    }
     this.fillTextCallsByPosition.push({ text, x, y });
   }
   strokeText() {
@@ -91,6 +99,8 @@ class RecordingRenderer implements IRenderer {
   restore() {}
   getCanvas() {
     const child = new RecordingRenderer();
+    child.fillTextFailuresRemaining = this.nextChildFillTextFailuresRemaining;
+    this.nextChildFillTextFailuresRemaining = 0;
     this.children.push(child);
     return child;
   }
@@ -180,6 +190,10 @@ class TestHTML5Comment extends HTML5Comment {
   }
   drawBodyForTest() {
     this._draw(0, 0);
+  }
+  forceInvalidFontForTest() {
+    (this.comment as { font: unknown }).font = "invalid-font";
+    this.image = undefined;
   }
 }
 
@@ -308,6 +322,25 @@ describe("HTML5 comment resource bounds", () => {
         slicedContent: expect.arrayContaining(["line-256"]),
       }),
     );
+  });
+
+  test("destroys allocated HTML5 text images when type validation fails", () => {
+    const renderer = new RecordingRenderer();
+    const comment = new TestHTML5Comment(
+      formattedComment(1, "invalid font after allocation"),
+      renderer,
+      0,
+      createContext(),
+    );
+    comment.forceInvalidFontForTest();
+
+    expect(() => comment.exposeTextImage()).toThrow();
+    expect(() => comment.exposeTextImage()).toThrow();
+
+    expect(renderer.children).toHaveLength(2);
+    expect(renderer.children.map((child) => child.destroyCalls)).toEqual([
+      1, 1,
+    ]);
   });
 
   test("clamps over-limit HTML5 lines after preserving the final allowed line", () => {

--- a/tests/unit/renderer-draw-robustness.spec.ts
+++ b/tests/unit/renderer-draw-robustness.spec.ts
@@ -8,6 +8,7 @@ import type {
 import { BaseComment } from "@/comments";
 import { initConfig } from "@/definition/initConfig";
 import NiconiComments from "@/main";
+import { WebGL2Renderer } from "@/renderer/webgl2";
 
 class HTMLCanvasElementMock {}
 
@@ -109,6 +110,28 @@ class VideoSurfaceRenderer extends RecordingRenderer {
 class NullVideoRenderer extends RecordingRenderer {
   public readonly video = null;
 }
+
+type WebGLTextureSetupMock = {
+  readonly TEXTURE_2D: number;
+  readonly TEXTURE_MIN_FILTER: number;
+  readonly TEXTURE_MAG_FILTER: number;
+  readonly TEXTURE_WRAP_S: number;
+  readonly TEXTURE_WRAP_T: number;
+  readonly LINEAR: number;
+  readonly CLAMP_TO_EDGE: number;
+  readonly RGBA: number;
+  readonly UNSIGNED_BYTE: number;
+  createTexture: ReturnType<typeof vi.fn<() => WebGLTexture>>;
+  bindTexture: ReturnType<typeof vi.fn>;
+  texParameteri: ReturnType<typeof vi.fn>;
+  texImage2D: ReturnType<typeof vi.fn>;
+  deleteTexture: ReturnType<typeof vi.fn>;
+};
+
+type WebGL2RendererTexturePrivate = {
+  gl: WebGLTextureSetupMock;
+  _createTexture(uploadSource: HTMLCanvasElement): WebGLTexture;
+};
 
 class BaseStyleCommentWithoutButtons extends BaseComment {
   protected override convertComment(
@@ -392,5 +415,42 @@ describe("renderer draw robustness", () => {
     expect(() => instance.click(0, { x: 50, y: 10 })).not.toThrow();
     expect(state.comments).toHaveLength(1);
     expect(state.comments[0]?.comment.button?.limit).toBe(1);
+  });
+
+  test("deletes and unbinds a new WebGL texture when upload fails", () => {
+    const texture = {} as WebGLTexture;
+    const uploadError = new Error("upload failed");
+    const gl: WebGLTextureSetupMock = {
+      TEXTURE_2D: 1,
+      TEXTURE_MIN_FILTER: 2,
+      TEXTURE_MAG_FILTER: 3,
+      TEXTURE_WRAP_S: 4,
+      TEXTURE_WRAP_T: 5,
+      LINEAR: 6,
+      CLAMP_TO_EDGE: 7,
+      RGBA: 8,
+      UNSIGNED_BYTE: 9,
+      createTexture: vi.fn(() => texture),
+      bindTexture: vi.fn(),
+      texParameteri: vi.fn(),
+      texImage2D: vi.fn(() => {
+        throw uploadError;
+      }),
+      deleteTexture: vi.fn(),
+    };
+    const renderer = Object.create(
+      WebGL2Renderer.prototype,
+    ) as WebGL2RendererTexturePrivate;
+    renderer.gl = gl;
+
+    expect(() => renderer._createTexture({} as HTMLCanvasElement)).toThrow(
+      uploadError,
+    );
+
+    expect(gl.bindTexture).toHaveBeenNthCalledWith(1, gl.TEXTURE_2D, texture);
+    expect(gl.bindTexture).toHaveBeenNthCalledWith(2, gl.TEXTURE_2D, null);
+    expect(gl.bindTexture).toHaveBeenCalledTimes(2);
+    expect(gl.deleteTexture).toHaveBeenCalledTimes(1);
+    expect(gl.deleteTexture).toHaveBeenCalledWith(texture);
   });
 });


### PR DESCRIPTION
## Summary
- delete and unbind newly-created WebGL textures when upload/setup throws
- destroy HTML5 and Flash text-image sub-renderers when generation fails after allocation
- add regression coverage for WebGL upload failure and repeated sub-renderer generation failures

## Validation
- npm run test:unit -- tests/unit/renderer-draw-robustness.spec.ts tests/unit/html5-resource-bounds.spec.ts tests/unit/flash-resource-bounds.spec.ts: pass (3 files, 54 tests)
- npm run check-types: pass
- npm run lint: pass
- npm run test:unit: pass when run alone (9 files, 104 tests); one earlier parallel run with build timed out two heavy cache tests under load
- npm run build: pass
- git diff --check: pass

## Review
- deep-review self-review completed locally: no actionable findings
- independent lifecycle subagent review: no actionable findings
- independent type/test coverage subagent review: no actionable findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds resource cleanup guards to three rendering paths — WebGL2 texture upload, HTML5 text image generation, and Flash text image generation — so that allocated GPU/canvas resources are freed when setup throws, preventing leaks on repeated failures. Three new regression test files verify each cleanup path directly.

- **`src/renderer/webgl2.ts`**: Wraps texture parameter setup and `texImage2D` upload in try/catch; on failure unbinds and deletes the texture before re-throwing.
- **`src/comments/HTML5Comment.ts` / `FlashComment.ts`**: Wrap the drawing body in try/catch; on failure call `renderer.destroy()` / `image.destroy()` (with a `typeof` guard for legacy renderers) before re-throwing.
- **`tests/unit/`**: Three spec files add targeted unit tests covering upload failure, type-guard failure, and repeated-failure teardown for each renderer path.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — the cleanup paths are narrowly scoped to failure branches and do not touch the successful rendering flows.

Each catch block only runs when setup already failed, so the new cleanup calls cannot interfere with normal rendering. The typeof guards on destroy() preserve compatibility with legacy renderers. All three cleanup paths have dedicated unit tests that verify the exact calls made on failure, including repeated-failure scenarios. No existing tests were modified in a way that weakens their coverage.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/renderer/webgl2.ts | Wraps `_createTexture` texture-setup body in try/catch; on failure unbinds and deletes the texture before re-throwing — correct and well-scoped. |
| src/comments/HTML5Comment.ts | Adds try/catch to `_generateTextImage`; calls `image.destroy()` on failure with a typeof guard for legacy renderers, then re-throws. |
| src/comments/FlashComment.ts | Adds try/catch to `_generateTextImage`; calls `renderer.destroy()` on failure with a typeof guard, then re-throws — mirrors the HTML5 fix correctly. |
| tests/unit/renderer-draw-robustness.spec.ts | Adds a unit test that exercises `_createTexture` directly with a mock GL object, verifying bindTexture(null) and deleteTexture are called on upload failure. |
| tests/unit/html5-resource-bounds.spec.ts | Adds `forceInvalidFontForTest` helper and a test verifying that each failed HTML5 `_generateTextImage` call destroys its allocated child renderer exactly once. |
| tests/unit/flash-resource-bounds.spec.ts | Adds `fillTextFailuresRemaining` / `nextChildFillTextFailuresRemaining` machinery and verifies repeated Flash `_generateTextImage` failures each destroy their allocated child renderer. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[_generateTextImage / _createTexture called] --> B[Allocate resource\ngetCanvas / createTexture]
    B --> C{Setup succeeds?}
    C -- Yes --> D[Return resource to caller]
    C -- No: throws --> E[catch block]
    E --> F{HTML5 / Flash}
    E --> G{WebGL2}
    F --> H[image.destroy / renderer.destroy\nwith typeof guard]
    G --> I[gl.bindTexture TEXTURE_2D null\ngl.deleteTexture tex]
    H --> J[re-throw original error]
    I --> J
    D --> K[Caller uses resource normally]
    J --> L[Resource freed — no leak]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[_generateTextImage / _createTexture called] --> B[Allocate resource\ngetCanvas / createTexture]
    B --> C{Setup succeeds?}
    C -- Yes --> D[Return resource to caller]
    C -- No: throws --> E[catch block]
    E --> F{HTML5 / Flash}
    E --> G{WebGL2}
    F --> H[image.destroy / renderer.destroy\nwith typeof guard]
    G --> I[gl.bindTexture TEXTURE_2D null\ngl.deleteTexture tex]
    H --> J[re-throw original error]
    I --> J
    D --> K[Caller uses resource normally]
    J --> L[Resource freed — no leak]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Guard text image cleanup for legacy rend..."](https://github.com/xpadev-net/niconicomments/commit/1ed1c9e3eb58c5e80a19fac63aed7e2f3c74f2a9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37794205)</sub>

<!-- /greptile_comment -->