### PR TITLE
REV-08: align CI and local test coverage

### DIFF
--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -32,7 +32,13 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          pnpm install
+          pnpm install --frozen-lockfile
+
+      - name: Check types
+        run: pnpm check-types
+
+      - name: Run unit tests
+        run: pnpm test:unit
 
       - name: Building niconicomments
         run: pnpm build

--- a/.github/workflows/pr-test-playwright.yml
+++ b/.github/workflows/pr-test-playwright.yml
@@ -33,9 +33,13 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          pnpm install
+          pnpm install --frozen-lockfile
           pnpm playwright install-deps
           pnpm playwright install firefox
+
+      - name: Check types
+        run: pnpm check-types
+
       - name: Building niconicomments
         run: |
           pnpm build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,20 @@
-# Prebuilt MS image
-FROM mcr.microsoft.com/playwright:focal
+# Prebuilt MS image matching the lockfile's Playwright version.
+FROM mcr.microsoft.com/playwright:v1.60.0-noble
 
 ENV PWUSER pwuser
 
-# Install aws-lambda-ric build dependencies
-#RUN echo 'nameserver 1.1.1.1' | tee /etc/resolv.conf
 RUN apt-get update && apt-get install -y sudo\
  && usermod -aG sudo $PWUSER\
  && echo '%sudo ALL=(ALL) NOPASSWD:ALL' | tee -a /etc/sudoers
-RUN npm i -g pnpm
+RUN corepack enable && corepack prepare pnpm@11 --activate
 
 USER $PWUSER
 
 WORKDIR /home/$PWUSER/app
 RUN sudo chown -R $PWUSER:$PWUSER /home/$PWUSER/app
+COPY --chown=$PWUSER:$PWUSER package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY --chown=$PWUSER:$PWUSER scripts/prepare.mjs ./scripts/prepare.mjs
+RUN pnpm install --frozen-lockfile
 COPY --chown=$PWUSER:$PWUSER . .
-RUN sudo chown -R $PWUSER:$PWUSER /home/$PWUSER/app
-RUN pnpm add playwright
-RUN pnpm playwright install firefox
 
 # ENTRYPOINT ["node", "./sample.js"]

--- a/compose.yml
+++ b/compose.yml
@@ -11,8 +11,5 @@ services:
     dns:
       - 1.1.1.1
       - 8.8.8.8
-    volumes:
-      - ./:/home/pwuser/app/
-      - /home/pwuser/app/node_modules
     working_dir: /home/pwuser/app
     entrypoint: pnpm run test:playwright

--- a/compose.yml
+++ b/compose.yml
@@ -13,5 +13,6 @@ services:
       - 8.8.8.8
     volumes:
       - ./:/home/pwuser/app/
+      - /home/pwuser/app/node_modules
     working_dir: /home/pwuser/app
-    entrypoint: pnpm playwright test
+    entrypoint: pnpm run test:playwright

--- a/package.json
+++ b/package.json
@@ -23,8 +23,9 @@
     "lint": "\"$npm_execpath\" run check-docs-version && biome check src",
     "lint:fix": "\"$npm_execpath\" run sync-docs-version && biome check --write --unsafe src",
     "prepare": "node scripts/prepare.mjs",
-    "test": "docker-compose run --rm pw",
+    "test": "docker-compose run --rm --build pw",
     "test-server": "http-server",
+    "test:playwright": "\"$npm_execpath\" run build && playwright test",
     "test:unit": "vitest run",
     "bench": "vitest bench --run"
   },

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -12,7 +12,7 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["tests/unit/**/*.spec.ts"],
-    passWithNoTests: true,
+    passWithNoTests: false,
     benchmark: {
       include: ["tests/bench/**/*.bench.ts"],
     },


### PR DESCRIPTION
## Summary
- add frozen-lockfile installs plus typecheck/unit coverage to PR CI before builds
- make local test rebuild fresh dist before Playwright runs
- make Vitest fail if unit test discovery finds zero tests
- update Docker/compose to install from lockfile and preserve container node_modules under bind mounts

## Validation
- pnpm install --frozen-lockfile: pass
- pnpm check-types: pass
- pnpm test:unit: pass (one earlier rerun hit a 5s timeout flake in html5-resource-bounds; immediate retry passed 101/101)
- pnpm lint: pass
- pnpm build: pass
- git diff --check: pass
- ruby YAML parse for edited workflows/compose: pass
- docker-compose config: pass (existing obsolete version warning)
- docker-compose run --help: confirms --build and --rm are supported
- temp Docker install-layer simulation with package.json, lockfile, workspace file, scripts/prepare.mjs: pass
- docker build --progress=plain -t pw:rev-08-check .: blocked locally because Docker Desktop is unable to start
- PLAYWRIGHT_PORT=18080 pnpm test:playwright: blocked as a validation experiment by existing tests hardcoding localhost:8080; reverted config experiment and retained existing Playwright config

## Review
- deep-review local pass completed
- independent subagent found Docker prepare script copy issue; fixed and re-reviewed with no actionable findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR aligns CI gating with local test coverage by adding `--frozen-lockfile` installs, type-checking, and unit tests to both PR workflows, and rewires the Docker/Compose setup to produce reproducible builds without a host-directory bind mount.

- **Workflow hardening**: `pr-test-build.yml` now runs `check-types` and `test:unit` before the build step; `pr-test-playwright.yml` gains `--frozen-lockfile` and `check-types`; both drop the old bare `pnpm install`.
- **Docker reproducibility**: The Playwright base image is pinned to `v1.60.0-noble`, a two-stage `COPY` pattern enables install-layer caching, and the bind mount is removed so tests always run against image-baked files (with `--build` forcing a rebuild on each local `npm test`).
- **Vitest safety net**: `passWithNoTests` is flipped to `false` so a misconfigured glob silently passing is no longer possible.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; the CI and Docker changes are well-reasoned and the removed bind-mount/added --build flag combination preserves correctness. The only open item is the non-pinned pnpm version in the Dockerfile.

All functional behaviour is sound — frozen-lockfile install, image-pinning, two-stage COPY with .dockerignore, and the passWithNoTests flip are all correct. The single point worth addressing before merging is that `corepack prepare pnpm@11` resolves to whatever the latest 11.x release is at build time, meaning two Docker images built weeks apart could have different pnpm binaries, which works against the reproducibility the rest of this PR is trying to establish.

Dockerfile — the pnpm version in the corepack prepare line should be pinned to an exact version.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/pr-test-build.yml | Adds --frozen-lockfile, pnpm check-types, and pnpm test:unit steps before the build step — consistent with the stated goal of aligning CI and local coverage. |
| .github/workflows/pr-test-playwright.yml | Adds --frozen-lockfile and pnpm check-types to the Playwright workflow; unit tests are intentionally omitted here since pr-test-build.yml already covers them on the same triggers. |
| Dockerfile | Pins the Playwright base image to v1.60.0-noble and adopts a two-stage COPY for install-layer caching; pnpm is activated with a major-only version tag (pnpm@11) rather than an exact pinned version. |
| compose.yml | Removes the bind-mount so tests run against image-baked files; updates the entrypoint to pnpm run test:playwright which includes a fresh build step. |
| package.json | Adds --build to the test script to force image rebuilds and adds a new test:playwright script that runs build then playwright, aligning local and CI flows. |
| vitest.config.mts | Changes passWithNoTests from true to false so Vitest fails if the unit test glob discovers no files — correct safety measure. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Dev as Developer
    participant DC as docker-compose
    participant DK as Docker build
    participant CT as Container
    participant PW as Playwright

    Dev->>DC: npm test (--rm --build)
    DC->>DK: build image
    DK->>DK: COPY package.json + lockfile + prepare.mjs
    DK->>DK: pnpm install --frozen-lockfile
    DK->>DK: COPY . . (node_modules excluded via .dockerignore)
    DC->>CT: run entrypoint
    CT->>CT: pnpm run test:playwright
    CT->>CT: pnpm run build (fresh dist)
    CT->>PW: playwright test
    PW-->>Dev: results

    note over Dev,PW: CI (pr-test-playwright.yml) mirrors this:<br/>install --frozen-lockfile → check-types → build → playwright test
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Dev as Developer
    participant DC as docker-compose
    participant DK as Docker build
    participant CT as Container
    participant PW as Playwright

    Dev->>DC: npm test (--rm --build)
    DC->>DK: build image
    DK->>DK: COPY package.json + lockfile + prepare.mjs
    DK->>DK: pnpm install --frozen-lockfile
    DK->>DK: COPY . . (node_modules excluded via .dockerignore)
    DC->>CT: run entrypoint
    CT->>CT: pnpm run test:playwright
    CT->>CT: pnpm run build (fresh dist)
    CT->>PW: playwright test
    PW-->>Dev: results

    note over Dev,PW: CI (pr-test-playwright.yml) mirrors this:<br/>install --frozen-lockfile → check-types → build → playwright test
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0ADockerfile%3A9%0AUsing%20%60pnpm%4011%60%20%28major-version%20range%29%20makes%20the%20Docker%20build%20non-deterministic%3A%20the%20resolved%20pnpm%20version%20will%20differ%20between%20builds%20as%20new%2011.x%20releases%20land.%20Pinning%20to%20an%20exact%20version%20matches%20the%20reproducibility%20goal%20of%20the%20rest%20of%20this%20PR%20and%20the%20%60--frozen-lockfile%60%20install%20that%20follows%20it.%0A%0A%60%60%60suggestion%0ARUN%20corepack%20enable%20%26%26%20corepack%20prepare%20pnpm%4011.14.2%20--activate%0A%60%60%60%0A%0A&repo=xpadev-net%2Fniconicomments&pr=361&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
Dockerfile:9
Using `pnpm@11` (major-version range) makes the Docker build non-deterministic: the resolved pnpm version will differ between builds as new 11.x releases land. Pinning to an exact version matches the reproducibility goal of the rest of this PR and the `--frozen-lockfile` install that follows it.

```suggestion
RUN corepack enable && corepack prepare pnpm@11.14.2 --activate
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: avoid stale compose dependencies"](https://github.com/xpadev-net/niconicomments/commit/c93d1c4bba3c7a2ebcad735fb0e60cf4eea5f942) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37841755)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->