### PR TITLE
REV-01 harden finite vpos boundaries

### DIFF
--- a/src/@types/format.formatted.ts
+++ b/src/@types/format.formatted.ts
@@ -1,25 +1,26 @@
 import type { InferOutput } from "valibot";
+import { array, boolean, object, omit, optional, string } from "valibot";
+
 import {
-  array,
-  boolean,
-  number,
-  object,
-  omit,
-  optional,
-  string,
-} from "valibot";
+  ZCommentDate,
+  ZCommentDateUsec,
+  ZCommentId,
+  ZCommentLayer,
+  ZCommentUserId,
+  ZCommentVpos,
+} from "./format.numeric";
 
 export const ZFormattedComment = object({
-  id: optional(number(), 0),
-  vpos: optional(number(), 0),
+  id: optional(ZCommentId, 0),
+  vpos: optional(ZCommentVpos, 0),
   content: optional(string(), ""),
-  date: optional(number(), 0),
-  date_usec: optional(number(), 0),
+  date: optional(ZCommentDate, 0),
+  date_usec: optional(ZCommentDateUsec, 0),
   owner: optional(boolean(), false),
   premium: optional(boolean(), false),
   mail: optional(array(string()), []),
-  user_id: optional(number(), 0),
-  layer: optional(number(), -1),
+  user_id: optional(ZCommentUserId, 0),
+  layer: optional(ZCommentLayer, -1),
   is_my_post: optional(boolean(), false),
 });
 export type FormattedComment = InferOutput<typeof ZFormattedComment>;

--- a/src/@types/format.legacy.ts
+++ b/src/@types/format.legacy.ts
@@ -1,7 +1,6 @@
 import type { InferOutput } from "valibot";
 import {
   notValue,
-  number,
   object,
   optional,
   pipe,
@@ -11,19 +10,26 @@ import {
   unknown,
 } from "valibot";
 
+import {
+  ZCommentDate,
+  ZCommentDateUsec,
+  ZCommentId,
+  ZCommentVpos,
+} from "./format.numeric";
+
 export const ZApiChat = object({
   thread: optional(string(), ""),
-  no: optional(number(), 0),
-  vpos: number(),
-  date: optional(number(), 0),
-  date_usec: optional(number(), 0),
-  nicoru: optional(number(), 0),
-  premium: optional(number(), 0),
-  anonymity: optional(number(), 0),
+  no: optional(ZCommentId, 0),
+  vpos: ZCommentVpos,
+  date: optional(ZCommentDate, 0),
+  date_usec: optional(ZCommentDateUsec, 0),
+  nicoru: optional(ZCommentId, 0),
+  premium: optional(ZCommentId, 0),
+  anonymity: optional(ZCommentId, 0),
   user_id: optional(string(), ""),
   mail: optional(string(), ""),
   content: string(),
-  deleted: optional(number(), 0),
+  deleted: optional(ZCommentId, 0),
 });
 export type ApiChat = InferOutput<typeof ZApiChat>;
 
@@ -48,11 +54,11 @@ export type ApiPing = InferOutput<typeof ZApiPing>;
  * @deprecated
  */
 export const ZApiThread = object({
-  resultcode: number(),
+  resultcode: ZCommentId,
   thread: string(),
-  server_time: number(),
+  server_time: ZCommentDate,
   ticket: string(),
-  revision: number(),
+  revision: ZCommentId,
 });
 /**
  * @deprecated
@@ -64,7 +70,7 @@ export type ApiThread = InferOutput<typeof ZApiThread>;
  */
 export const ZApiLeaf = object({
   thread: string(),
-  count: number(),
+  count: ZCommentId,
 });
 /**
  * @deprecated
@@ -76,7 +82,7 @@ export type ApiLeaf = InferOutput<typeof ZApiLeaf>;
  */
 export const ZApiGlobalNumRes = object({
   thread: string(),
-  num_res: number(),
+  num_res: ZCommentId,
 });
 /**
  * @deprecated

--- a/src/@types/format.numeric.ts
+++ b/src/@types/format.numeric.ts
@@ -7,6 +7,7 @@ type NumberRangeOptions = {
 };
 
 const MAX_SAFE_TIMELINE_VALUE = Number.MAX_SAFE_INTEGER;
+const MIN_SAFE_TIMELINE_VALUE = Number.MIN_SAFE_INTEGER;
 
 export const isFiniteNumberInRange = (
   value: unknown,
@@ -29,7 +30,7 @@ const rangedNumber = (options?: NumberRangeOptions) =>
   );
 
 export const ZCommentId = rangedNumber();
-export const ZCommentVpos = rangedNumber();
+export const ZCommentVpos = rangedNumber({ min: MIN_SAFE_TIMELINE_VALUE });
 export const ZCommentDate = rangedNumber();
 export const ZCommentDateUsec = rangedNumber({ max: 999_999 });
 export const ZCommentUserId = rangedNumber({ min: -1 });

--- a/src/@types/format.numeric.ts
+++ b/src/@types/format.numeric.ts
@@ -1,0 +1,53 @@
+import { check, number, pipe } from "valibot";
+
+type NumberRangeOptions = {
+  min?: number;
+  max?: number;
+  integer?: boolean;
+};
+
+const MAX_SAFE_TIMELINE_VALUE = Number.MAX_SAFE_INTEGER;
+
+export const isFiniteNumberInRange = (
+  value: unknown,
+  {
+    min = 0,
+    max = MAX_SAFE_TIMELINE_VALUE,
+    integer = true,
+  }: NumberRangeOptions = {},
+): value is number =>
+  typeof value === "number" &&
+  Number.isFinite(value) &&
+  value >= min &&
+  value <= max &&
+  (!integer || Number.isInteger(value));
+
+const rangedNumber = (options?: NumberRangeOptions) =>
+  pipe(
+    number(),
+    check((value) => isFiniteNumberInRange(value, options)),
+  );
+
+export const ZCommentId = rangedNumber();
+export const ZCommentVpos = rangedNumber();
+export const ZCommentDate = rangedNumber();
+export const ZCommentDateUsec = rangedNumber({ max: 999_999 });
+export const ZCommentUserId = rangedNumber({ min: -1 });
+export const ZCommentLayer = rangedNumber({ min: -1 });
+
+export const toFiniteNumberInRange = (
+  value: unknown,
+  options?: NumberRangeOptions,
+): number | undefined => {
+  if (
+    value === null ||
+    value === undefined ||
+    (typeof value === "string" && value.trim() === "")
+  ) {
+    return undefined;
+  }
+  const numericValue = typeof value === "number" ? value : Number(value);
+  return isFiniteNumberInRange(numericValue, options)
+    ? numericValue
+    : undefined;
+};

--- a/src/@types/format.numeric.ts
+++ b/src/@types/format.numeric.ts
@@ -35,6 +35,7 @@ export const ZCommentDate = rangedNumber();
 export const ZCommentDateUsec = rangedNumber({ max: 999_999 });
 export const ZCommentUserId = rangedNumber({ min: -1 });
 export const ZCommentLayer = rangedNumber({ min: -1 });
+export const ZCommentScore = rangedNumber({ min: MIN_SAFE_TIMELINE_VALUE });
 
 export const toFiniteNumberInRange = (
   value: unknown,

--- a/src/@types/format.v1.ts
+++ b/src/@types/format.v1.ts
@@ -3,24 +3,25 @@ import {
   array,
   boolean,
   nullable,
-  number,
   object,
   optional,
   string,
   unknown,
 } from "valibot";
 
+import { ZCommentId, ZCommentVpos } from "./format.numeric";
+
 export const ZV1Comment = object({
   id: string(),
-  no: number(),
-  vposMs: number(),
+  no: ZCommentId,
+  vposMs: ZCommentVpos,
   body: string(),
   commands: array(string()),
   userId: string(),
   isPremium: boolean(),
-  score: number(),
+  score: ZCommentId,
   postedAt: string(),
-  nicoruCount: number(),
+  nicoruCount: ZCommentId,
   nicoruId: nullable(string()),
   source: string(),
   isMyPost: boolean(),
@@ -30,7 +31,7 @@ export type V1Comment = InferOutput<typeof ZV1Comment>;
 export const ZV1Thread = object({
   id: unknown(),
   fork: string(),
-  commentCount: optional(number(), 0),
+  commentCount: optional(ZCommentId, 0),
   comments: array(ZV1Comment),
 });
 export type V1Thread = InferOutput<typeof ZV1Thread>;

--- a/src/@types/format.v1.ts
+++ b/src/@types/format.v1.ts
@@ -9,7 +9,7 @@ import {
   unknown,
 } from "valibot";
 
-import { ZCommentId, ZCommentVpos } from "./format.numeric";
+import { ZCommentId, ZCommentScore, ZCommentVpos } from "./format.numeric";
 
 export const ZV1Comment = object({
   id: string(),
@@ -19,7 +19,7 @@ export const ZV1Comment = object({
   commands: array(string()),
   userId: string(),
   isPremium: boolean(),
-  score: ZCommentId,
+  score: ZCommentScore,
   postedAt: string(),
   nicoruCount: ZCommentId,
   nicoruId: nullable(string()),

--- a/src/@types/index.ts
+++ b/src/@types/index.ts
@@ -7,6 +7,7 @@ export * from "./event";
 export * from "./fonts";
 export * from "./format.formatted";
 export * from "./format.legacy";
+export * from "./format.numeric";
 export * from "./format.owner";
 export * from "./format.v1";
 export * from "./format.xml2js";

--- a/src/input/legacy.ts
+++ b/src/input/legacy.ts
@@ -1,19 +1,13 @@
-import { array, parse, safeParse } from "valibot";
+import { array, parse, safeParse, unknown as unknownSchema } from "valibot";
 
-import type { InputParser } from "@/@types";
-import {
-  type FormattedComment,
-  type RawApiResponse,
-  ZApiChat,
-  ZRawApiResponse,
-} from "@/@types";
+import { type FormattedComment, type InputParser, ZApiChat } from "@/@types";
 
 import { assignUserId } from "./xmlDocument";
 
 export const LegacyParser: InputParser = {
   key: ["legacy"],
   parse: (input) => {
-    return fromLegacy(parse(array(ZRawApiResponse), input));
+    return fromLegacy(parse(array(unknownSchema()), input));
   },
 };
 
@@ -22,11 +16,15 @@ export const LegacyParser: InputParser = {
  * @param data legacy apiから帰ってきたデータ
  * @returns 変換後のデータ
  */
-const fromLegacy = (data: RawApiResponse[]): FormattedComment[] => {
+const fromLegacy = (data: unknown[]): FormattedComment[] => {
   const data_: FormattedComment[] = [];
   const userIdMap = new Map<string, number>();
   for (const _val of data) {
-    const val = safeParse(ZApiChat, _val.chat);
+    const chat =
+      typeof _val === "object" && _val !== null && "chat" in _val
+        ? _val.chat
+        : undefined;
+    const val = safeParse(ZApiChat, chat);
     if (!val.success) continue;
     const value = val.output;
     if (value.deleted !== 1) {

--- a/src/input/legacyOwner.ts
+++ b/src/input/legacyOwner.ts
@@ -1,4 +1,8 @@
-import type { FormattedComment, InputParser } from "@/@types";
+import {
+  type FormattedComment,
+  type InputParser,
+  toFiniteNumberInRange,
+} from "@/@types";
 import { InvalidFormatError } from "@/errors";
 import typeGuard from "@/typeGuard";
 
@@ -30,9 +34,13 @@ const fromLegacyOwner = (data: string): FormattedComment[] => {
         commentData[2] += `:${commentData[j]}`;
       }
     }
+    const seconds = toFiniteNumberInRange(commentData[0], {
+      max: Math.floor(Number.MAX_SAFE_INTEGER / 100),
+    });
+    if (seconds === undefined) continue;
     const tmpParam: FormattedComment = {
       id: i,
-      vpos: Number(commentData[0]) * 100,
+      vpos: seconds * 100,
       content: commentData[2] ?? "",
       date: i,
       date_usec: 0,

--- a/src/input/owner.ts
+++ b/src/input/owner.ts
@@ -1,9 +1,10 @@
 import { array, parse } from "valibot";
 
-import type { InputParser } from "@/@types";
 import {
   type FormattedComment,
+  type InputParser,
   type OwnerComment,
+  toFiniteNumberInRange,
   ZOwnerComment,
 } from "@/@types";
 
@@ -24,9 +25,11 @@ const fromOwner = (data: OwnerComment[]): FormattedComment[] => {
   for (let i = 0, n = data.length; i < n; i++) {
     const value = data[i];
     if (!value) continue;
+    const vpos = time2vpos(value.time);
+    if (vpos === undefined) continue;
     const tmpParam: FormattedComment = {
       id: i,
-      vpos: time2vpos(value.time),
+      vpos,
       content: value.comment,
       date: i,
       date_usec: 0,
@@ -53,32 +56,33 @@ const fromOwner = (data: OwnerComment[]): FormattedComment[] => {
  * @param input 分:秒.秒・分:秒・秒.秒・秒
  * @returns vpos
  */
-const time2vpos = (input: string): number => {
+const time2vpos = (input: string): number | undefined => {
   const time = RegExp(
     /^(?:(\d+):(\d+)\.(\d+)|(\d+):(\d+)|(\d+)\.(\d+)|(\d+))$/,
   ).exec(input);
+  let vpos: number | undefined;
   if (time) {
     if (
       time[1] !== undefined &&
       time[2] !== undefined &&
       time[3] !== undefined
     ) {
-      return (
+      vpos =
         (Number(time[1]) * 60 + Number(time[2])) * 100 +
-        Number(time[3]) / 10 ** (time[3].length - 2)
-      );
+        Number(time[3]) / 10 ** (time[3].length - 2);
     }
     if (time[4] !== undefined && time[5] !== undefined) {
-      return (Number(time[4]) * 60 + Number(time[5])) * 100;
+      vpos = (Number(time[4]) * 60 + Number(time[5])) * 100;
     }
     if (time[6] !== undefined && time[7] !== undefined) {
-      return (
-        Number(time[6]) * 100 + Number(time[7]) / 10 ** (time[7].length - 2)
-      );
+      vpos =
+        Number(time[6]) * 100 + Number(time[7]) / 10 ** (time[7].length - 2);
     }
     if (time[8] !== undefined) {
-      return Number(time[8]) * 100;
+      vpos = Number(time[8]) * 100;
     }
   }
-  return 0;
+  return toFiniteNumberInRange(
+    vpos === undefined ? undefined : Math.floor(vpos),
+  );
 };

--- a/src/input/v1.ts
+++ b/src/input/v1.ts
@@ -25,11 +25,13 @@ const fromV1 = (data: V1Thread[]): FormattedComment[] => {
     const val = item.comments;
     const forkName = item.fork;
     for (const value of val) {
+      const date = date2time(value.postedAt);
+      if (date === undefined) continue;
       const tmpParam: FormattedComment = {
         id: value.no,
         vpos: Math.floor(value.vposMs / 10),
         content: value.body,
-        date: date2time(value.postedAt),
+        date,
         date_usec: 0,
         owner: forkName === "owner",
         premium: value.isPremium,
@@ -53,4 +55,7 @@ const fromV1 = (data: V1Thread[]): FormattedComment[] => {
  * @param date ISO 8601 timestamp
  * @returns unix timestamp
  */
-const date2time = (date: string): number => Math.floor(Date.parse(date) / 1000);
+const date2time = (date: string): number | undefined => {
+  const time = Math.floor(Date.parse(date) / 1000);
+  return Number.isFinite(time) && time >= 0 ? time : undefined;
+};

--- a/src/input/xml2js.ts
+++ b/src/input/xml2js.ts
@@ -27,7 +27,9 @@ const fromXml2js = (data: Xml2jsPacket): FormattedComment[] => {
       rawNo === undefined
         ? index++
         : (toFiniteNumberInRange(rawNo) ?? undefined);
-    const vpos = toFiniteNumberInRange(item.$.vpos);
+    const vpos = toFiniteNumberInRange(item.$.vpos, {
+      min: Number.MIN_SAFE_INTEGER,
+    });
     const date = toFiniteNumberInRange(item.$.date);
     const dateUsec = toFiniteNumberInRange(item.$.date_usec, {
       max: 999_999,

--- a/src/input/xml2js.ts
+++ b/src/input/xml2js.ts
@@ -1,6 +1,11 @@
 import { parse } from "valibot";
 
-import type { FormattedComment, InputParser, Xml2jsPacket } from "@/@types";
+import {
+  type FormattedComment,
+  type InputParser,
+  toFiniteNumberInRange,
+  type Xml2jsPacket,
+} from "@/@types";
 import { ZXml2jsPacket } from "@/@types/";
 
 import { assignUserId } from "./xmlDocument";
@@ -17,12 +22,30 @@ const fromXml2js = (data: Xml2jsPacket): FormattedComment[] => {
   const userIdMap = new Map<string, number>();
   let index = data.packet.chat.length;
   for (const item of data.packet.chat) {
+    const rawNo = item.$.no;
+    const id =
+      rawNo === undefined
+        ? index++
+        : (toFiniteNumberInRange(rawNo) ?? undefined);
+    const vpos = toFiniteNumberInRange(item.$.vpos);
+    const date = toFiniteNumberInRange(item.$.date);
+    const dateUsec = toFiniteNumberInRange(item.$.date_usec, {
+      max: 999_999,
+    });
+    if (
+      id === undefined ||
+      vpos === undefined ||
+      date === undefined ||
+      dateUsec === undefined
+    ) {
+      continue;
+    }
     const tmpParam: FormattedComment = {
-      id: Number(item.$.no) || index++,
-      vpos: Number(item.$.vpos) || 0,
+      id,
+      vpos,
       content: item._,
-      date: Number(item.$.date) || 0,
-      date_usec: Number(item.$.date_usec) || 0,
+      date,
+      date_usec: dateUsec,
       owner: !(item.$.owner === "0" || item.$.user_id),
       premium: item.$.premium === "1",
       mail: item.$.mail.split(/\s+/g),

--- a/src/input/xmlDocument.ts
+++ b/src/input/xmlDocument.ts
@@ -50,7 +50,9 @@ const parseXMLDocument = (data: XMLDocument): FormattedComment[] => {
     const rawNo = item.getAttribute("no");
     const id =
       rawNo === null ? index++ : (toFiniteNumberInRange(rawNo) ?? undefined);
-    const vpos = toFiniteNumberInRange(item.getAttribute("vpos"));
+    const vpos = toFiniteNumberInRange(item.getAttribute("vpos"), {
+      min: Number.MIN_SAFE_INTEGER,
+    });
     const date = toFiniteNumberInRange(item.getAttribute("date"));
     const rawDateUsec = item.getAttribute("date_usec");
     const dateUsec =

--- a/src/input/xmlDocument.ts
+++ b/src/input/xmlDocument.ts
@@ -1,4 +1,8 @@
-import type { FormattedComment, InputParser } from "@/@types";
+import {
+  type FormattedComment,
+  type InputParser,
+  toFiniteNumberInRange,
+} from "@/@types";
 import { InvalidFormatError } from "@/errors";
 import typeGuard from "@/typeGuard";
 
@@ -43,12 +47,30 @@ const parseXMLDocument = (data: XMLDocument): FormattedComment[] => {
   let index = Array.from(data.documentElement.children).length;
   for (const item of Array.from(data.documentElement.children)) {
     if (item.nodeName !== "chat") continue;
+    const rawNo = item.getAttribute("no");
+    const id =
+      rawNo === null ? index++ : (toFiniteNumberInRange(rawNo) ?? undefined);
+    const vpos = toFiniteNumberInRange(item.getAttribute("vpos"));
+    const date = toFiniteNumberInRange(item.getAttribute("date"));
+    const rawDateUsec = item.getAttribute("date_usec");
+    const dateUsec =
+      rawDateUsec === null
+        ? 0
+        : toFiniteNumberInRange(rawDateUsec, { max: 999_999 });
+    if (
+      id === undefined ||
+      vpos === undefined ||
+      date === undefined ||
+      dateUsec === undefined
+    ) {
+      continue;
+    }
     const tmpParam: FormattedComment = {
-      id: Number(item.getAttribute("no")) || index++,
-      vpos: Number(item.getAttribute("vpos")),
+      id,
+      vpos,
       content: item.textContent ?? "",
-      date: Number(item.getAttribute("date")) || 0,
-      date_usec: Number(item.getAttribute("date_usec")) || 0,
+      date,
+      date_usec: dateUsec,
       owner: !item.getAttribute("user_id"),
       premium: item.getAttribute("premium") === "1",
       mail: [],

--- a/src/input/xmlDocument.ts
+++ b/src/input/xmlDocument.ts
@@ -53,7 +53,8 @@ const parseXMLDocument = (data: XMLDocument): FormattedComment[] => {
     const vpos = toFiniteNumberInRange(item.getAttribute("vpos"), {
       min: Number.MIN_SAFE_INTEGER,
     });
-    const date = toFiniteNumberInRange(item.getAttribute("date"));
+    const rawDate = item.getAttribute("date");
+    const date = rawDate === null ? 0 : toFiniteNumberInRange(rawDate);
     const rawDateUsec = item.getAttribute("date_usec");
     const dateUsec =
       rawDateUsec === null

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,5 @@
+import { safeParse } from "valibot";
+
 import type {
   Collision,
   CommentEventHandlerMap,
@@ -11,6 +13,7 @@ import type {
   Position,
   Timeline,
 } from "@/@types/";
+import { ZFormattedComment } from "@/@types/";
 import { FlashComment } from "@/comments/";
 import type { CommentInstanceContext } from "@/contexts/";
 import { createNicoScripts, ImageCacheContext } from "@/contexts/";
@@ -44,6 +47,18 @@ const EMPTY_TIMELINE = Object.freeze([]) as readonly IComment[];
 const BAN_FRAME_POSITION_RESOLUTION_BUDGET = 256;
 const TIMELINE_COMMENT_SORT = (a: IComment, b: IComment) =>
   Number(a.owner) - Number(b.owner) || a.index - b.index;
+const isFiniteVpos = (vpos: number) => Number.isFinite(vpos);
+const isFinitePosition = (pos: Position) =>
+  Number.isFinite(pos.x) && Number.isFinite(pos.y);
+const rejectInvalidCommentPosition = (comment: IComment) => {
+  comment.comment.invisible = true;
+  try {
+    comment.invisible = true;
+  } catch (_e) {
+    // Built-in comments expose invisible as a getter over comment.invisible.
+  }
+  comment.posY = 0;
+};
 
 const toIntegerOrInfinity = (value: number) => {
   if (Number.isNaN(value) || value === 0) return 0;
@@ -293,6 +308,11 @@ class NiconiComments {
           );
     while (this.nextUnprocessedCommentIndex < scanEndIndex) {
       const comment = comments[this.nextUnprocessedCommentIndex];
+      if (comment && !isFiniteVpos(comment.vpos)) {
+        rejectInvalidCommentPosition(comment);
+        this.nextUnprocessedCommentIndex++;
+        continue;
+      }
       if (comment && !comment.invisible && comment.posY < 0) {
         break;
       }
@@ -413,6 +433,10 @@ class NiconiComments {
     let endIndex = startIndex - 1;
     for (let i = startIndex; i < scanEndIndex; i++) {
       const comment = this.comments[i];
+      if (comment && !isFiniteVpos(comment.vpos)) {
+        rejectInvalidCommentPosition(comment);
+        continue;
+      }
       if (!comment || comment.invisible || comment.posY > -1) {
         continue;
       }
@@ -456,9 +480,15 @@ class NiconiComments {
    * @param rawComments コメントデータ
    */
   public addComments(...rawComments: FormattedComment[]) {
+    const validComments = rawComments.reduce<FormattedComment[]>((pv, val) => {
+      const parsedComment = safeParse(ZFormattedComment, val);
+      if (parsedComment.success) pv.push(parsedComment.output);
+      return pv;
+    }, []);
+    if (validComments.length === 0) return;
     this.ctx.rangeCache.reset();
     const touchedTimeline = new Set<number>();
-    const comments = rawComments.reduce<IComment[]>((pv, val, index) => {
+    const comments = validComments.reduce<IComment[]>((pv, val, index) => {
       pv.push(
         createCommentInstance(
           val,
@@ -536,6 +566,7 @@ class NiconiComments {
     forceRendering = false,
     cursor?: Position,
   ): boolean {
+    if (!isFiniteVpos(vpos)) return false;
     const profile: DrawCanvasProfile | undefined = this.ctx.options.debug
       ? {
           triggerHandler: 0,
@@ -912,7 +943,8 @@ class NiconiComments {
    * @param pos カーソルの位置
    */
   public click(vpos: number, pos: Position) {
-    const _comments = this.timeline[vpos];
+    if (!isFiniteVpos(vpos) || !isFinitePosition(pos)) return;
+    const _comments = this.timeline[Math.floor(vpos)];
     if (!_comments) return;
     for (let i = _comments.length - 1; i >= 0; i--) {
       const comment = _comments[i];

--- a/src/typeGuard.ts
+++ b/src/typeGuard.ts
@@ -399,7 +399,7 @@ const typeGuard = {
     if (!document.documentElement.children) return false;
     for (const element of Array.from(document.documentElement.children)) {
       if (element?.nodeName !== "chat") continue;
-      if (!typeAttributeVerify(element, ["vpos", "date"])) return false;
+      if (!typeAttributeVerify(element, ["vpos"])) return false;
     }
     return true;
   },

--- a/src/utils/comment.ts
+++ b/src/utils/comment.ts
@@ -19,7 +19,12 @@ import type {
   ParsedCommand,
   Timeline,
 } from "@/@types/";
-import { ZCommentFont, ZCommentLoc, ZCommentSize } from "@/@types/";
+import {
+  isFiniteNumberInRange,
+  ZCommentFont,
+  ZCommentLoc,
+  ZCommentSize,
+} from "@/@types/";
 import type { CommentInstanceContext } from "@/contexts/";
 import { colors } from "@/definition/colors";
 import typeGuard from "@/typeGuard";
@@ -314,6 +319,25 @@ const markTimelineProcessed = (timeline: Timeline, comment: IComment) => {
     return;
   }
   processedTimelineComments.set(comment, new WeakSet([timeline]));
+};
+
+const isValidTimelineCommentRange = (comment: IComment) =>
+  isFiniteNumberInRange(comment.vpos) &&
+  isFiniteNumberInRange(comment.long, { min: 1, max: MAX_COMMENT_LONG }) &&
+  isFiniteNumberInRange(comment.height, { integer: false });
+
+const isValidMovableCommentRange = (comment: IComment) =>
+  isValidTimelineCommentRange(comment) &&
+  isFiniteNumberInRange(comment.width, { integer: false });
+
+const rejectInvalidTimelineComment = (comment: IComment) => {
+  comment.comment.invisible = true;
+  try {
+    comment.invisible = true;
+  } catch (_e) {
+    // Built-in comments expose invisible as a getter over comment.invisible.
+  }
+  comment.posY = 0;
 };
 
 /**
@@ -1008,6 +1032,10 @@ const processFixedComment = (
   config: BaseConfig,
   touchedTimeline?: Set<number>,
 ) => {
+  if (!isValidTimelineCommentRange(comment)) {
+    rejectInvalidTimelineComment(comment);
+    return;
+  }
   const commentVpos = comment.vpos;
   const commentLong = comment.long;
   const collisionEnd = Math.max(commentLong - 20, 0);
@@ -1042,6 +1070,10 @@ const processMovableComment = (
   config: BaseConfig,
   touchedTimeline?: Set<number>,
 ) => {
+  if (!isValidMovableCommentRange(comment)) {
+    rejectInvalidTimelineComment(comment);
+    return;
+  }
   const commentWidth = comment.width;
   const commentLong = comment.long;
   const commentVpos = comment.vpos;

--- a/src/utils/comment.ts
+++ b/src/utils/comment.ts
@@ -322,7 +322,7 @@ const markTimelineProcessed = (timeline: Timeline, comment: IComment) => {
 };
 
 const isValidTimelineCommentRange = (comment: IComment) =>
-  isFiniteNumberInRange(comment.vpos) &&
+  isFiniteNumberInRange(comment.vpos, { min: Number.MIN_SAFE_INTEGER }) &&
   isFiniteNumberInRange(comment.long, { min: 1, max: MAX_COMMENT_LONG }) &&
   isFiniteNumberInRange(comment.height, { integer: false });
 

--- a/tests/unit/inputParser.spec.ts
+++ b/tests/unit/inputParser.spec.ts
@@ -209,6 +209,29 @@ describe("convert2formattedComment", () => {
     ).toThrow();
   });
 
+  it("accepts negative finite formatted vpos values", () => {
+    const output = convert2formattedComment(
+      [
+        {
+          id: 1,
+          vpos: -9200,
+          content: "early",
+          date: 1,
+          date_usec: 0,
+          owner: false,
+          premium: false,
+          mail: [],
+          user_id: 1,
+          layer: -1,
+          is_my_post: false,
+        },
+      ],
+      "formatted",
+    );
+
+    expect(output).toMatchObject([{ id: 1, vpos: -9200, content: "early" }]);
+  });
+
   it("drops malformed legacy API chat items while keeping valid comments", () => {
     const output = convert2formattedComment(
       [
@@ -310,6 +333,28 @@ describe("convert2formattedComment", () => {
     );
 
     expect(output).toMatchObject([{ id: 1, vpos: 10, content: "ok" }]);
+  });
+
+  it("keeps negative finite XML vpos values", () => {
+    expect(
+      convert2formattedComment(
+        createXmlDocument([
+          createXmlElement({ no: "1", vpos: "-9200", date: "1" }, "early"),
+        ]),
+        "XMLDocument",
+      ),
+    ).toMatchObject([{ id: 1, vpos: -9200, content: "early" }]);
+
+    expect(
+      convert2formattedComment(
+        {
+          packet: {
+            chat: [{ _: "early", $: { no: "1", vpos: "-9200", date: "1" } }],
+          },
+        },
+        "xml2js",
+      ),
+    ).toMatchObject([{ id: 1, vpos: -9200, content: "early" }]);
   });
 
   it("drops malformed xml2js chat items while keeping valid comments", () => {

--- a/tests/unit/inputParser.spec.ts
+++ b/tests/unit/inputParser.spec.ts
@@ -182,6 +182,180 @@ describe("convert2formattedComment", () => {
     ).toMatchObject([{ id: 1, content: "array", user_id: 99 }]);
   });
 
+  it.each([
+    Number.NaN,
+    Infinity,
+    -Infinity,
+  ])("rejects non-finite formatted vpos %s", (vpos) => {
+    expect(() =>
+      convert2formattedComment(
+        [
+          {
+            id: 1,
+            vpos,
+            content: "bad",
+            date: 1,
+            date_usec: 0,
+            owner: false,
+            premium: false,
+            mail: [],
+            user_id: 1,
+            layer: -1,
+            is_my_post: false,
+          },
+        ],
+        "formatted",
+      ),
+    ).toThrow();
+  });
+
+  it("drops malformed legacy API chat items while keeping valid comments", () => {
+    const output = convert2formattedComment(
+      [
+        { chat: { no: 1, vpos: 10, date: 1, user_id: "alice", content: "ok" } },
+        {
+          chat: {
+            no: 2,
+            vpos: Infinity,
+            date: 1,
+            user_id: "bob",
+            content: "bad vpos",
+          },
+        },
+        {
+          chat: {
+            no: Number.NaN,
+            vpos: 20,
+            date: 1,
+            user_id: "carol",
+            content: "bad id",
+          },
+        },
+        {
+          chat: {
+            no: 3,
+            vpos: 30,
+            date_usec: Infinity,
+            date: 1,
+            user_id: "dave",
+            content: "bad date_usec",
+          },
+        },
+      ],
+      "legacy",
+    );
+
+    expect(output).toMatchObject([{ id: 1, vpos: 10, content: "ok" }]);
+  });
+
+  it("rejects non-finite v1 numeric fields and drops invalid postedAt comments", () => {
+    const validComment = {
+      id: "1",
+      no: 1,
+      vposMs: 100,
+      body: "ok",
+      commands: [],
+      userId: "alice",
+      isPremium: false,
+      score: 0,
+      postedAt: "2024-01-01T00:00:01.000Z",
+      nicoruCount: 0,
+      nicoruId: null,
+      source: "nicovideo",
+      isMyPost: false,
+    };
+
+    expect(() =>
+      convert2formattedComment(
+        [
+          {
+            id: "thread",
+            fork: "main",
+            comments: [{ ...validComment, vposMs: Infinity }],
+          },
+        ],
+        "v1",
+      ),
+    ).toThrow();
+
+    expect(
+      convert2formattedComment(
+        [
+          {
+            id: "thread",
+            fork: "main",
+            comments: [
+              validComment,
+              { ...validComment, id: "2", no: 2, postedAt: "not-a-date" },
+            ],
+          },
+        ],
+        "v1",
+      ),
+    ).toMatchObject([{ id: 1, vpos: 10, content: "ok" }]);
+  });
+
+  it("drops malformed XMLDocument chat items while keeping valid comments", () => {
+    const output = convert2formattedComment(
+      createXmlDocument([
+        createXmlElement({ no: "1", vpos: "10", date: "1" }, "ok"),
+        createXmlElement({ no: "2", vpos: "Infinity", date: "1" }, "bad"),
+        createXmlElement({ no: "3", vpos: "20", date: "NaN" }, "bad"),
+        createXmlElement(
+          { no: "4", vpos: "30", date: "1", date_usec: "1000000" },
+          "bad",
+        ),
+      ]),
+      "XMLDocument",
+    );
+
+    expect(output).toMatchObject([{ id: 1, vpos: 10, content: "ok" }]);
+  });
+
+  it("drops malformed xml2js chat items while keeping valid comments", () => {
+    const output = convert2formattedComment(
+      {
+        packet: {
+          chat: [
+            { _: "ok", $: { no: "1", vpos: "10", date: "1" } },
+            { _: "bad", $: { no: "2", vpos: "NaN", date: "1" } },
+            { _: "bad", $: { no: "3", vpos: "20", date: "Infinity" } },
+            {
+              _: "bad",
+              $: { no: "4", vpos: "30", date: "1", date_usec: "nonsense" },
+            },
+          ],
+        },
+      },
+      "xml2js",
+    );
+
+    expect(output).toMatchObject([{ id: 1, vpos: 10, content: "ok" }]);
+  });
+
+  it("drops legacy owner text lines with malformed time fields", () => {
+    const output = convert2formattedComment(
+      "10:ue:ok\nNaN:ue:bad\nInfinity:ue:bad\nabc:ue:bad",
+      "legacyOwner",
+    );
+
+    expect(output).toMatchObject([{ id: 0, vpos: 1000, content: "ok" }]);
+  });
+
+  it("drops owner comments with malformed time fields", () => {
+    const output = convert2formattedComment(
+      [
+        { time: "1:23.45", command: "ue", comment: "ok" },
+        { time: "abc", command: "ue", comment: "bad" },
+        { time: "Infinity", command: "ue", comment: "bad" },
+        { time: "9".repeat(400), command: "ue", comment: "bad" },
+      ],
+      "owner",
+    );
+
+    expect(output).toMatchObject([{ id: 0, vpos: 8345, content: "ok" }]);
+  });
+
   it("keeps first-seen user_id assignment stable after the final sort", () => {
     const output = convert2formattedComment(
       [

--- a/tests/unit/inputParser.spec.ts
+++ b/tests/unit/inputParser.spec.ts
@@ -316,6 +316,19 @@ describe("convert2formattedComment", () => {
         "v1",
       ),
     ).toMatchObject([{ id: 1, vpos: 10, content: "ok" }]);
+
+    expect(
+      convert2formattedComment(
+        [
+          {
+            id: "thread",
+            fork: "main",
+            comments: [{ ...validComment, score: -100 }],
+          },
+        ],
+        "v1",
+      ),
+    ).toMatchObject([{ id: 1, vpos: 10, content: "ok" }]);
   });
 
   it("drops malformed XMLDocument chat items while keeping valid comments", () => {
@@ -355,6 +368,17 @@ describe("convert2formattedComment", () => {
         "xml2js",
       ),
     ).toMatchObject([{ id: 1, vpos: -9200, content: "early" }]);
+  });
+
+  it("defaults missing XMLDocument date to zero", () => {
+    expect(
+      convert2formattedComment(
+        createXmlDocument([
+          createXmlElement({ no: "1", vpos: "10" }, "missing date"),
+        ]),
+        "XMLDocument",
+      ),
+    ).toMatchObject([{ id: 1, vpos: 10, date: 0, content: "missing date" }]);
   });
 
   it("drops malformed xml2js chat items while keeping valid comments", () => {

--- a/tests/unit/renderer-draw-robustness.spec.ts
+++ b/tests/unit/renderer-draw-robustness.spec.ts
@@ -3,6 +3,7 @@ import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import type {
   FormattedComment,
   FormattedCommentWithSize,
+  IComment,
   IRenderer,
 } from "@/@types";
 import { BaseComment } from "@/comments";
@@ -170,6 +171,26 @@ class BaseStyleCommentWithoutButtons extends BaseComment {
   protected override _drawCollision() {}
 }
 
+class NaNVposFirstCommentPlugin {
+  static readonly id = "nan-vpos-first-comment-plugin";
+
+  constructor(canvas: IRenderer, comments: IComment[]) {
+    void canvas;
+    void comments;
+  }
+
+  draw() {
+    return false;
+  }
+
+  transformComments(comments: IComment[]) {
+    if (comments[0]) {
+      comments[0].comment.vpos = Number.NaN;
+    }
+    return comments;
+  }
+}
+
 const createComment = (
   overrides: Partial<FormattedComment> = {},
 ): FormattedComment => ({
@@ -217,6 +238,59 @@ describe("renderer draw robustness", () => {
 
     expect(renderer.children).toHaveLength(0);
     expect(renderer.drawImageCalls).toBe(0);
+  });
+
+  test.each([
+    Number.NaN,
+    Infinity,
+    -Infinity,
+  ])("ignores non-finite drawCanvas vpos %s before lazy work", (vpos) => {
+    const renderer = new RecordingRenderer();
+    const instance = new NiconiComments(
+      renderer,
+      [createComment({ vpos: 1000, content: "lazy" })],
+      { format: "formatted", mode: "html5", lazy: true },
+    );
+    const state = instance as unknown as {
+      processedCommentIndex: number;
+      nextUnprocessedCommentIndex: number;
+    };
+
+    expect(instance.drawCanvas(vpos)).toBe(false);
+
+    expect(renderer.clearRectCalls).toBe(0);
+    expect(state.processedCommentIndex).toBe(-1);
+    expect(state.nextUnprocessedCommentIndex).toBe(0);
+  });
+
+  test("skips malformed plugin comment vpos without starving later lazy comments", () => {
+    const renderer = new RecordingRenderer();
+    const instance = new NiconiComments(
+      renderer,
+      [
+        createComment({ id: 1, vpos: 1000, content: "plugin-malformed" }),
+        createComment({ id: 2, vpos: 1000, content: "valid", mail: ["ue"] }),
+      ],
+      {
+        format: "formatted",
+        mode: "html5",
+        lazy: true,
+        config: { plugins: [NaNVposFirstCommentPlugin] },
+      },
+    );
+    const state = instance as unknown as {
+      comments: IComment[];
+      timeline: Record<number, IComment[]>;
+    };
+
+    expect(instance.drawCanvas(1000, true)).toBe(true);
+
+    expect(state.comments[0]?.invisible).toBe(true);
+    expect(state.comments[0]?.posY).toBe(0);
+    expect(state.timeline[1000]?.map((comment) => comment.comment.id)).toEqual([
+      2,
+    ]);
+    expect(Object.hasOwn(state.timeline, "NaN")).toBe(false);
   });
 
   test.each([
@@ -392,5 +466,47 @@ describe("renderer draw robustness", () => {
     expect(() => instance.click(0, { x: 50, y: 10 })).not.toThrow();
     expect(state.comments).toHaveLength(1);
     expect(state.comments[0]?.comment.button?.limit).toBe(1);
+  });
+
+  test("ignores non-finite click vpos before reading timeline buckets", () => {
+    const instance = new NiconiComments(new RecordingRenderer(), [], {
+      format: "formatted",
+      mode: "html5",
+    });
+    const state = instance as unknown as {
+      timeline: Record<string, IComment[]>;
+    };
+    state.timeline.NaN = [
+      {
+        isHovered: () => {
+          throw new Error("NaN bucket should not be read");
+        },
+      } as IComment,
+    ];
+
+    expect(() => instance.click(Number.NaN, { x: 0, y: 0 })).not.toThrow();
+  });
+
+  test.each([
+    { x: Number.NaN, y: 0 },
+    { x: 0, y: Infinity },
+    { x: -Infinity, y: 0 },
+  ])("ignores non-finite click position %# before reading timeline", (pos) => {
+    const instance = new NiconiComments(new RecordingRenderer(), [], {
+      format: "formatted",
+      mode: "html5",
+    });
+    const state = instance as unknown as {
+      timeline: Record<string, IComment[]>;
+    };
+    state.timeline[0] = [
+      {
+        isHovered: () => {
+          throw new Error("invalid cursor should not read timeline");
+        },
+      } as IComment,
+    ];
+
+    expect(() => instance.click(0, pos)).not.toThrow();
   });
 });

--- a/tests/unit/timeline.spec.ts
+++ b/tests/unit/timeline.spec.ts
@@ -1,10 +1,16 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-import type { FormattedComment, IComment, IRenderer, Timeline } from "@/@types";
+import type {
+  Collision,
+  FormattedComment,
+  IComment,
+  IRenderer,
+  Timeline,
+} from "@/@types";
 import { defaultConfig } from "@/definition/config";
 import { initConfig } from "@/definition/initConfig";
 import NiconiComments from "@/main";
-import { processFixedComment } from "@/utils/comment";
+import { processFixedComment, processMovableComment } from "@/utils/comment";
 
 const emptyTextMetrics = (width: number): TextMetrics =>
   ({
@@ -127,6 +133,13 @@ const createFixedComment = (index: number, vpos: number, long: number) =>
     isHovered: () => false,
   }) as IComment;
 
+const createMovableComment = (index: number, vpos: number, long: number) =>
+  ({
+    ...createFixedComment(index, vpos, long),
+    loc: "naka",
+    mail: [],
+  }) as IComment;
+
 describe("timeline construction", () => {
   beforeEach(() => {
     initConfig();
@@ -192,6 +205,58 @@ describe("timeline construction", () => {
     expect(includesCalls).toBe(0);
     expect(timeline[200]).toHaveLength(500);
   });
+
+  test.each([
+    ["fixed", createFixedComment(1, Infinity, 30)],
+    ["fixed", createFixedComment(1, Number.NaN, 30)],
+    ["fixed", createFixedComment(1, 100, Infinity)],
+  ])("does not populate buckets for malformed %s comments", (_, comment) => {
+    const timeline: Timeline = {};
+    const collision: Timeline = {};
+    const touchedTimeline = new Set<number>();
+
+    processFixedComment(
+      comment,
+      collision,
+      timeline,
+      false,
+      defaultConfig,
+      touchedTimeline,
+    );
+
+    expect(Object.keys(timeline)).toHaveLength(0);
+    expect(Object.keys(collision)).toHaveLength(0);
+    expect(touchedTimeline.size).toBe(0);
+    expect(comment.invisible).toBe(true);
+    expect(comment.posY).toBe(0);
+  });
+
+  test.each([
+    ["movable", createMovableComment(1, Infinity, 30)],
+    ["movable", createMovableComment(1, Number.NaN, 30)],
+    ["movable", createMovableComment(1, 100, Infinity)],
+    ["movable", { ...createMovableComment(1, 100, 30), width: Infinity }],
+  ])("does not populate buckets for malformed %s comments", (_, comment) => {
+    const timeline: Timeline = {};
+    const collision: Collision = { ue: {}, shita: {}, left: {}, right: {} };
+    const touchedTimeline = new Set<number>();
+
+    processMovableComment(
+      comment as IComment,
+      collision,
+      timeline,
+      false,
+      defaultConfig,
+      touchedTimeline,
+    );
+
+    expect(Object.keys(timeline)).toHaveLength(0);
+    expect(Object.keys(collision.left)).toHaveLength(0);
+    expect(Object.keys(collision.right)).toHaveLength(0);
+    expect(touchedTimeline.size).toBe(0);
+    expect((comment as IComment).invisible).toBe(true);
+    expect((comment as IComment).posY).toBe(0);
+  });
 });
 
 describe("destroy", () => {
@@ -209,6 +274,46 @@ describe("destroy", () => {
 });
 
 describe("addComments", () => {
+  test("ignores malformed runtime input before creating comment instances", () => {
+    ensureCanvasElement();
+    const niconiComments = new NiconiComments(new FakeRenderer(), [], {
+      format: "formatted",
+    });
+    const state = niconiComments as unknown as {
+      comments: IComment[];
+      timeline: Timeline;
+    };
+
+    niconiComments.addComments(
+      formattedComment(1, Infinity) as unknown as FormattedComment,
+    );
+
+    expect(state.comments).toHaveLength(0);
+    expect(Object.keys(state.timeline)).toHaveLength(0);
+  });
+
+  test("adds valid runtime comments from a batch that also contains malformed input", () => {
+    ensureCanvasElement();
+    const niconiComments = new NiconiComments(new FakeRenderer(), [], {
+      format: "formatted",
+    });
+    const state = niconiComments as unknown as {
+      comments: IComment[];
+      timeline: Timeline;
+    };
+
+    niconiComments.addComments(
+      formattedComment(1, 100),
+      formattedComment(2, Infinity) as unknown as FormattedComment,
+    );
+
+    expect(state.comments).toHaveLength(1);
+    expect(state.timeline[100]?.map((comment) => comment.comment.id)).toEqual([
+      1,
+    ]);
+    expect(Object.hasOwn(state.timeline, "Infinity")).toBe(false);
+  });
+
   test("sorts overlapping touched buckets without resorting unrelated timeline buckets", () => {
     ensureCanvasElement();
     const renderer = new FakeRenderer();


### PR DESCRIPTION
## Summary
- add shared finite/ranged numeric schemas for comment ids, vpos, dates, user ids, and layers
- validate formatted/legacy/v1 schemas and XMLDocument/xml2js/owner/legacyOwner conversion paths so malformed item data is rejected or dropped per parser family
- guard addComments, drawCanvas, click, lazy resolution, and timeline/collision population against non-finite positions

## Validation
- pnpm install --frozen-lockfile
- pnpm run lint
- pnpm vitest run tests/unit/inputParser.spec.ts tests/unit/timeline.spec.ts tests/unit/renderer-draw-robustness.spec.ts
- pnpm run test:unit
- pnpm run check-types
- pnpm run build
- git diff --check origin/develop...HEAD

## Review
- deep-review self-review with boundary/failure checklist
- independent subagent boundary/type review: found owner parser and addComments batch semantics; fixed with tests
- independent subagent failure/lazy review: found plugin NaN lazy starvation and click position validation; fixed with tests

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens numeric boundaries across the entire comment pipeline by introducing shared finite/ranged valibot schemas (`ZCommentVpos`, `ZCommentId`, `ZCommentScore`, etc.) and wiring them into every input parser and the main rendering loop.

- **New `format.numeric.ts`** centralises all finite/range predicates; parsers for `formatted`, `legacy`, `v1`, `xml2js`, `xmlDocument`, `owner`, and `legacyOwner` formats now drop or reject comments whose key fields (`vpos`, `id`, `date`, `date_usec`) are non-finite or out of range.
- **`main.ts` guards** reject non-finite `vpos` in `drawCanvas`, the lazy-scan loop, and `click`; `addComments` pre-filters the input batch through `ZFormattedComment`; `click` now correctly floors `vpos` before indexing into the integer-keyed timeline.
- **`utils/comment.ts`** guards `processFixedComment` and `processMovableComment` against non-finite `vpos`, `long`, `height`, and `width`, preventing NaN positions from silently polluting the timeline or collision tables.
</details>


<h3>Confidence Score: 5/5</h3>

All validation paths are covered by new unit tests; no regressions were introduced in the common parsing paths.

Every parser family now rejects or drops malformed numeric fields before they reach the timeline, and the rendering loop has independent guards at drawCanvas, the lazy scan, and click. The test suite exercises all boundary conditions explicitly. The only observations are schema-naming style concerns with no runtime impact.

src/@types/format.legacy.ts — ZCommentId is reused for premium, anonymity, deleted, and resultcode; semantically misleading though functionally safe today.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| src/@types/format.numeric.ts | New file: shared finite/ranged numeric schemas and toFiniteNumberInRange helper used by all parsers. Logic and defaults are correct. |
| src/@types/format.legacy.ts | Replaces number() with shared range schemas; ZCommentId is reused for binary flags (premium, anonymity, deleted, resultcode) — semantically misleading though functionally safe today. |
| src/@types/format.formatted.ts | All numeric fields replaced with appropriate range schemas; ZCommentVpos allows negatives correctly for pre-roll comments. |
| src/@types/format.v1.ts | score now uses ZCommentScore (min: MIN_SAFE_INTEGER) allowing negative NG scores; vposMs uses ZCommentVpos; all changes are correct. |
| src/input/xml2js.ts | Manual validation added for id/vpos/date/date_usec before constructing FormattedComment; id=0 now correctly assigned when no="0" instead of falling through to index++. |
| src/input/xmlDocument.ts | Null guard on date attribute correctly falls back to 0; typeGuard.ts no longer requires date attribute; invalid numeric attributes cause the chat element to be dropped. |
| src/main.ts | Guards added for non-finite vpos in drawCanvas, lazy scan, click; addComments validates via ZFormattedComment; click now correctly floors vpos before timeline lookup. |
| src/utils/comment.ts | isValidTimelineCommentRange/isValidMovableCommentRange guards processFixed/MovableComment against non-finite vpos, long, height, width; long >= 1 is safe since normalizeCommentLong always returns DEFAULT_COMMENT_LONG or higher. |
| src/input/owner.ts | time2vpos returns number|undefined; Math.floor applied before toFiniteNumberInRange prevents overflow and non-integer vpos values. |
| src/input/legacyOwner.ts | Added max guard on seconds (MAX_SAFE_INTEGER/100) before multiplication to prevent overflow; malformed time fields skip the line. |
| src/input/legacy.ts | Switched from parse(array(ZRawApiResponse)) to parse(array(unknown())) with explicit chat property guard; cleaner and more resilient to mixed-type arrays. |
| src/input/v1.ts | date2time now returns undefined for invalid ISO timestamps; comments with malformed postedAt are correctly dropped rather than getting a NaN date. |

</details>


</details>


<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Raw Input] --> B{Parser type?}
    B -->|legacy| C[parse array unknown\ncheck chat property\nsafeParse ZApiChat]
    B -->|v1| D[parse array ZV1Thread\nZCommentVpos / ZCommentScore\ndrop invalid postedAt]
    B -->|formatted| E[parse array ZFormattedComment\nZCommentVpos / ZCommentId\nZCommentDate / ZCommentLayer]
    B -->|xml2js / XMLDocument| F[toFiniteNumberInRange per field\ndrop if id/vpos/date/dateUsec invalid]
    B -->|owner| G[time2vpos → floor → toFiniteNumberInRange\ndrop if undefined]
    B -->|legacyOwner| H[toFiniteNumberInRange seconds\nmax = MAX_SAFE_INT/100\ndrop if undefined]
    C & D & E & F & G & H --> I[FormattedComment list]
    I --> J[addComments\nsafeParse ZFormattedComment per item\ndrop invalids, early-return if none]
    J --> K[createCommentInstance]
    K --> L{loc?}
    L -->|naka| M[processMovableComment\nisValidMovableCommentRange\nrejectInvalidTimelineComment if bad]
    L -->|ue / shita| N[processFixedComment\nisValidTimelineCommentRange\nrejectInvalidTimelineComment if bad]
    M & N --> O[timeline / collision populated]
    O --> P[drawCanvas isFiniteVpos guard]
    O --> Q[lazy scan isFiniteVpos guard\nrejectInvalidCommentPosition]
    O --> R[click isFiniteVpos + isFinitePosition guard\nMath.floor vpos for lookup]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Raw Input] --> B{Parser type?}
    B -->|legacy| C[parse array unknown\ncheck chat property\nsafeParse ZApiChat]
    B -->|v1| D[parse array ZV1Thread\nZCommentVpos / ZCommentScore\ndrop invalid postedAt]
    B -->|formatted| E[parse array ZFormattedComment\nZCommentVpos / ZCommentId\nZCommentDate / ZCommentLayer]
    B -->|xml2js / XMLDocument| F[toFiniteNumberInRange per field\ndrop if id/vpos/date/dateUsec invalid]
    B -->|owner| G[time2vpos → floor → toFiniteNumberInRange\ndrop if undefined]
    B -->|legacyOwner| H[toFiniteNumberInRange seconds\nmax = MAX_SAFE_INT/100\ndrop if undefined]
    C & D & E & F & G & H --> I[FormattedComment list]
    I --> J[addComments\nsafeParse ZFormattedComment per item\ndrop invalids, early-return if none]
    J --> K[createCommentInstance]
    K --> L{loc?}
    L -->|naka| M[processMovableComment\nisValidMovableCommentRange\nrejectInvalidTimelineComment if bad]
    L -->|ue / shita| N[processFixedComment\nisValidTimelineCommentRange\nrejectInvalidTimelineComment if bad]
    M & N --> O[timeline / collision populated]
    O --> P[drawCanvas isFiniteVpos guard]
    O --> Q[lazy scan isFiniteVpos guard\nrejectInvalidCommentPosition]
    O --> R[click isFiniteVpos + isFinitePosition guard\nMath.floor vpos for lookup]
```

</a>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/main.ts`, line 542-550 ([link](https://github.com/xpadev-net/niconicomments/blob/960b5b6852c4e906c9ed5023804145914545f04c/src/main.ts#L542-L550)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Duplicated rejection helper**

   `rejectInvalidCommentPosition` here is byte-for-byte identical to `rejectInvalidTimelineComment` in `src/utils/comment.ts` (including the `try/catch` comment). Exporting the utility from `utils/comment.ts` and importing it in `main.ts` would keep the invariant in one place and avoid the two implementations drifting if the logic ever changes.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/main.ts
   Line: 542-550

   Comment:
   **Duplicated rejection helper**

   `rejectInvalidCommentPosition` here is byte-for-byte identical to `rejectInvalidTimelineComment` in `src/utils/comment.ts` (including the `try/catch` comment). Exporting the utility from `utils/comment.ts` and importing it in `main.ts` would keep the invariant in one place and avoid the two implementations drifting if the logic ever changes.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fmain.ts%0ALine%3A%20542-550%0A%0AComment%3A%0A**Duplicated%20rejection%20helper**%0A%0A%60rejectInvalidCommentPosition%60%20here%20is%20byte-for-byte%20identical%20to%20%60rejectInvalidTimelineComment%60%20in%20%60src%2Futils%2Fcomment.ts%60%20%28including%20the%20%60try%2Fcatch%60%20comment%29.%20Exporting%20the%20utility%20from%20%60utils%2Fcomment.ts%60%20and%20importing%20it%20in%20%60main.ts%60%20would%20keep%20the%20invariant%20in%20one%20place%20and%20avoid%20the%20two%20implementations%20drifting%20if%20the%20logic%20ever%20changes.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=xpadev-net%2Fniconicomments&pr=362&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/dev..."](https://github.com/xpadev-net/niconicomments/commit/139363188088025680b0ed8970195f049c89f499) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37844257)</sub>

<!-- /greptile_comment -->