### PR TITLE
[codex] fix package artifact docs consistency

### DIFF
--- a/.github/workflows/pr-test-build.yml
+++ b/.github/workflows/pr-test-build.yml
@@ -40,5 +40,11 @@ jobs:
       - name: Run unit tests
         run: pnpm test:unit
 
+      - name: Check package docs before build
+        run: pnpm check-package-artifacts --allow-missing-dist
+
       - name: Building niconicomments
         run: pnpm build
+
+      - name: Check package artifacts
+        run: pnpm check-package-artifacts

--- a/.github/workflows/release-create-release.yml
+++ b/.github/workflows/release-create-release.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Update package.json version
         run: |
           pnpm version ${{ steps.version.outputs.new_version }} --no-git-tag-version
-          git add package.json pnpm-lock.yaml README.md docs/index.html docs/sample/sample.js docs/sample/index.html
+          git add package.json pnpm-lock.yaml README.md README.en.md docs/index.html docs/sample/sample.js docs/sample/index.html
           git commit -m "chore: bump version to v${{ steps.version.outputs.new_version }}"
           git push origin develop
           

--- a/README.en.md
+++ b/README.en.md
@@ -14,7 +14,7 @@ npm： https://www.npmjs.com/package/@xpadev-net/niconicomments
 ## Installation
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@xpadev-net/niconicomments@latest/dist/bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@xpadev-net/niconicomments@0.3.0/dist/bundle.js"></script>
 ```
 
 or

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm： https://www.npmjs.com/package/@xpadev-net/niconicomments
 CDN から読み込む場合は、可変エイリアスではなく固定バージョンを指定してください。
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/@xpadev-net/niconicomments@0.3.0/dist/bundle.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@xpadev-net/niconicomments@0.3.0/dist/bundle.js"></script>
 ```
 
 or

--- a/docs/index.html
+++ b/docs/index.html
@@ -141,7 +141,7 @@
         <p>NodeJS:</p>
         <pre><code>npm i @xpadev-net/niconicomments</code></pre>
         <p>Web:</p>
-        <pre><code><span class="blue">&lt;script <span class="yellow">src=</span><span class="green">&quot;https://cdn.jsdelivr.net/npm/@xpadev-net/niconicomments@0.3.0/dist/bundle.min.js&quot;</span>&gt;&lt;/script&gt;</span></code></pre>
+        <pre><code><span class="blue">&lt;script <span class="yellow">src=</span><span class="green">&quot;https://cdn.jsdelivr.net/npm/@xpadev-net/niconicomments@0.3.0/dist/bundle.js&quot;</span>&gt;&lt;/script&gt;</span></code></pre>
       </section>
       <section id="example">
         <h2>Example</h2>

--- a/docs/sample/sample.js
+++ b/docs/sample/sample.js
@@ -120,7 +120,7 @@ const encodeVersionForUrl = (value) => encodeURIComponent(value);
 const getNCUrl = (v) =>
   USE_LOCAL_NC_DEV_BUILD
     ? NC_DEV_URL
-    : `https://cdn.jsdelivr.net/npm/@xpadev-net/niconicomments@${encodeVersionForUrl(v)}/dist/bundle.min.js`;
+    : `https://cdn.jsdelivr.net/npm/@xpadev-net/niconicomments@${encodeVersionForUrl(v)}/dist/bundle.js`;
 const getPluginUrl = (v) =>
   `https://cdn.jsdelivr.net/npm/@xpadev-net/niconicomments-plugin-niwango@${encodeVersionForUrl(v)}/dist/bundle.min.js`;
 const getNiwangoUrl = (v) =>

--- a/package.json
+++ b/package.json
@@ -11,10 +11,11 @@
     "build:dts": "rolldown -c rolldown.config.dts.mjs",
     "watch": "rolldown -c rolldown.config.mjs -w",
     "typedoc": "typedoc --entryPointStrategy Expand --out ./docs/type/ ./src/",
-    "prepublishOnly": "\"$npm_execpath\" run check-docs-version && \"$npm_execpath\" run check-types && \"$npm_execpath\" run build",
+    "prepublishOnly": "\"$npm_execpath\" run check-docs-version && \"$npm_execpath\" run check-package-artifacts -- --allow-missing-dist && \"$npm_execpath\" run check-types && \"$npm_execpath\" run build && \"$npm_execpath\" run check-package-artifacts",
     "check-types": "tsc --noEmit --jsx react --types node --project tsconfig.json",
     "sync-docs-version": "node scripts/sync-docs-version.mjs",
     "check-docs-version": "node scripts/sync-docs-version.mjs --check",
+    "check-package-artifacts": "node scripts/check-package-artifacts.mjs",
     "version": "\"$npm_execpath\" run sync-docs-version",
     "eslint": "biome lint src",
     "eslint:fix": "biome lint --write src",
@@ -47,7 +48,8 @@
   },
   "files": [
     "dist/bundle.js",
-    "dist/bundle.d.ts"
+    "dist/bundle.d.ts",
+    "dist/bundle.d.ts.map"
   ],
   "homepage": "https://xpadev-net.github.io/niconicomments/",
   "license": "MIT",

--- a/scripts/check-package-artifacts.mjs
+++ b/scripts/check-package-artifacts.mjs
@@ -1,0 +1,159 @@
+import { access, readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+const allowMissingDist = process.argv.includes("--allow-missing-dist");
+const packageJson = JSON.parse(
+  await readFile(join(rootDir, "package.json"), "utf8"),
+);
+const { version } = packageJson;
+const packageName = "@xpadev-net/niconicomments";
+const packageCdnUrl = `https://cdn.jsdelivr.net/npm/${packageName}@${version}/dist/bundle.js`;
+const files = new Set(packageJson.files ?? []);
+const errors = [];
+
+const readText = (path) => readFile(join(rootDir, path), "utf8");
+const addError = (message) => errors.push(message);
+const fileExists = (path) =>
+  access(join(rootDir, path)).then(
+    () => true,
+    () => false,
+  );
+
+if (typeof version !== "string" || version.length === 0) {
+  addError("package.json version must be a non-empty string.");
+}
+
+if (packageJson.main !== "dist/bundle.js") {
+  addError('package.json main must be "dist/bundle.js".');
+}
+
+if (packageJson.types !== "dist/bundle.d.ts") {
+  addError('package.json types must be "dist/bundle.d.ts".');
+}
+
+for (const requiredFile of ["dist/bundle.js", "dist/bundle.d.ts"]) {
+  if (!files.has(requiredFile)) {
+    addError(`package.json files must include ${requiredFile}.`);
+  }
+}
+
+const distPackageFiles = [...files].filter((file) => file.startsWith("dist/"));
+const distArtifactsPresent = (
+  await Promise.all(distPackageFiles.map((file) => fileExists(file)))
+).some(Boolean);
+const distRequired = !allowMissingDist || distArtifactsPresent;
+const readDistText = async (path) => {
+  try {
+    return await readText(path);
+  } catch (error) {
+    if (!distRequired && error.code === "ENOENT") {
+      return null;
+    }
+    addError(`${path} is missing or unreadable: ${error.message}`);
+    return "";
+  }
+};
+
+const cdnTargets = ["README.md", "README.en.md", "docs/index.html"];
+const cdnPattern =
+  /https:\/\/cdn\.jsdelivr\.net\/npm\/@xpadev-net\/niconicomments@([^/"'<>`]+)\/dist\/(bundle(?:\.min)?\.js)/g;
+
+for (const path of cdnTargets) {
+  const content = await readText(path);
+  const matches = [...content.matchAll(cdnPattern)];
+  if (matches.length !== 1) {
+    addError(`${path} must contain exactly one ${packageName} CDN URL.`);
+    continue;
+  }
+
+  const [, docsVersion, artifactName] = matches[0];
+  if (docsVersion !== version) {
+    addError(`${path} CDN version ${docsVersion} does not match ${version}.`);
+  }
+  if (artifactName !== "bundle.js") {
+    addError(`${path} CDN artifact must be dist/bundle.js.`);
+  }
+  if (
+    `https://cdn.jsdelivr.net/npm/${packageName}@${docsVersion}/dist/${artifactName}` !==
+    packageCdnUrl
+  ) {
+    addError(`${path} CDN URL does not match ${packageCdnUrl}.`);
+  }
+}
+
+const sampleJs = await readText("docs/sample/sample.js");
+const defaultVersionMatch = sampleJs.match(
+  /^const DEFAULT_NC_VERSION = "([^"]+)";$/m,
+);
+if (!defaultVersionMatch) {
+  addError("docs/sample/sample.js must declare DEFAULT_NC_VERSION.");
+} else if (defaultVersionMatch[1] !== version) {
+  addError(
+    `docs/sample/sample.js DEFAULT_NC_VERSION ${defaultVersionMatch[1]} does not match ${version}.`,
+  );
+}
+
+const sampleCdnPattern =
+  /https:\/\/cdn\.jsdelivr\.net\/npm\/@xpadev-net\/niconicomments@\$\{[^}]+}\/dist\/(bundle(?:\.min)?\.js)/g;
+const sampleCdnMatches = [...sampleJs.matchAll(sampleCdnPattern)];
+if (sampleCdnMatches.length !== 1) {
+  addError(
+    "docs/sample/sample.js must contain exactly one npm CDN URL template.",
+  );
+} else {
+  const [, sampleArtifactName] = sampleCdnMatches[0];
+  if (sampleArtifactName !== "bundle.js") {
+    addError("docs/sample/sample.js npm CDN artifact must be dist/bundle.js.");
+  }
+  if (!files.has(`dist/${sampleArtifactName}`)) {
+    addError(
+      `package.json files must include dist/${sampleArtifactName} used by docs/sample/sample.js.`,
+    );
+  }
+}
+
+const bundleJs = await readDistText("dist/bundle.js");
+if (bundleJs != null) {
+  const bannerVersion = bundleJs.match(/niconicomments\.js v([^\s]+)/)?.[1];
+  if (bannerVersion !== version) {
+    addError(
+      `dist/bundle.js banner version ${bannerVersion ?? "missing"} does not match ${version}.`,
+    );
+  }
+}
+
+const bundleDts = await readDistText("dist/bundle.d.ts");
+if (bundleDts != null) {
+  const dtsMapRef = bundleDts.match(/sourceMappingURL=(\S+)$/m)?.[1];
+  if (dtsMapRef != null) {
+    const dtsMapFile = `dist/${dtsMapRef}`;
+    if (!files.has(dtsMapFile)) {
+      addError(`package.json files must include ${dtsMapFile}.`);
+    }
+    await readDistText(dtsMapFile);
+  }
+}
+
+if (distRequired) {
+  for (const packageFile of distPackageFiles) {
+    await readDistText(packageFile);
+  }
+}
+
+if (errors.length > 0) {
+  console.error("Package artifact checks failed:");
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  `Package docs and dist artifacts match ${packageName}@${version} (${
+    distRequired
+      ? distPackageFiles.join(", ")
+      : `${distPackageFiles.join(", ")} declared; dist files absent before build`
+  }).`,
+);

--- a/scripts/check-package-artifacts.mjs
+++ b/scripts/check-package-artifacts.mjs
@@ -10,7 +10,10 @@ const packageJson = JSON.parse(
 const { version } = packageJson;
 const packageName = "@xpadev-net/niconicomments";
 const packageCdnUrl = `https://cdn.jsdelivr.net/npm/${packageName}@${version}/dist/bundle.js`;
-const files = new Set(packageJson.files ?? []);
+const packageFileEntries = Array.isArray(packageJson.files)
+  ? packageJson.files.filter((file) => typeof file === "string")
+  : [];
+const files = new Set(packageFileEntries);
 const errors = [];
 
 const readText = (path) => readFile(join(rootDir, path), "utf8");
@@ -20,6 +23,14 @@ const fileExists = (path) =>
     () => true,
     () => false,
   );
+const isFileIncluded = (path) => {
+  if (files.has(path)) return true;
+  for (const file of files) {
+    const prefix = file.endsWith("/") ? file : `${file}/`;
+    if (path.startsWith(prefix)) return true;
+  }
+  return false;
+};
 
 if (typeof version !== "string" || version.length === 0) {
   addError("package.json version must be a non-empty string.");
@@ -34,12 +45,18 @@ if (packageJson.types !== "dist/bundle.d.ts") {
 }
 
 for (const requiredFile of ["dist/bundle.js", "dist/bundle.d.ts"]) {
-  if (!files.has(requiredFile)) {
+  if (!isFileIncluded(requiredFile)) {
     addError(`package.json files must include ${requiredFile}.`);
   }
 }
 
-const distPackageFiles = [...files].filter((file) => file.startsWith("dist/"));
+const distPackageFiles = [
+  ...new Set([
+    ...packageFileEntries.filter((file) => file.startsWith("dist/")),
+    "dist/bundle.js",
+    "dist/bundle.d.ts",
+  ]),
+];
 const distArtifactsPresent = (
   await Promise.all(distPackageFiles.map((file) => fileExists(file)))
 ).some(Boolean);
@@ -107,7 +124,7 @@ if (sampleCdnMatches.length !== 1) {
   if (sampleArtifactName !== "bundle.js") {
     addError("docs/sample/sample.js npm CDN artifact must be dist/bundle.js.");
   }
-  if (!files.has(`dist/${sampleArtifactName}`)) {
+  if (!isFileIncluded(`dist/${sampleArtifactName}`)) {
     addError(
       `package.json files must include dist/${sampleArtifactName} used by docs/sample/sample.js.`,
     );
@@ -129,7 +146,7 @@ if (bundleDts != null) {
   const dtsMapRef = bundleDts.match(/sourceMappingURL=(\S+)$/m)?.[1];
   if (dtsMapRef != null) {
     const dtsMapFile = `dist/${dtsMapRef}`;
-    if (!files.has(dtsMapFile)) {
+    if (!isFileIncluded(dtsMapFile)) {
       addError(`package.json files must include ${dtsMapFile}.`);
     }
     await readDistText(dtsMapFile);

--- a/scripts/sync-docs-version.mjs
+++ b/scripts/sync-docs-version.mjs
@@ -23,10 +23,10 @@ const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 const packageCdnUrlPattern = new RegExp(
   `${escapeRegExp(
     "https://cdn.jsdelivr.net/npm/@xpadev-net/niconicomments@",
-  )}[^/"'<>]+${escapeRegExp("/dist/bundle.min.js")}`,
+  )}[^/"'<>]+${escapeRegExp("/dist/bundle.js")}`,
   "g",
 );
-const packageCdnUrl = `https://cdn.jsdelivr.net/npm/@xpadev-net/niconicomments@${version}/dist/bundle.min.js`;
+const packageCdnUrl = `https://cdn.jsdelivr.net/npm/@xpadev-net/niconicomments@${version}/dist/bundle.js`;
 
 const replaceExpected = (content, pattern, replacement, path) => {
   const matchPattern = pattern.global
@@ -50,6 +50,16 @@ const targets = [
         packageCdnUrlPattern,
         packageCdnUrl,
         "README.md",
+      ),
+  },
+  {
+    path: "README.en.md",
+    update: (content) =>
+      replaceExpected(
+        content,
+        packageCdnUrlPattern,
+        packageCdnUrl,
+        "README.en.md",
       ),
   },
   {


### PR DESCRIPTION
## Summary
- switch niconicomments CDN docs/sample references from the nonexistent `dist/bundle.min.js` to the built and published `dist/bundle.js`
- publish `dist/bundle.d.ts.map` alongside `dist/bundle.d.ts`
- add package artifact checks for docs CDN versions, sample URL templates, package files, dist banner version, and d.ts source map availability
- run artifact checks before and after CI/prepublish builds, and stage `README.en.md` in the release version workflow

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm check-package-artifacts --allow-missing-dist` after removing generated `dist`
- `pnpm build && pnpm check-package-artifacts`
- `pnpm check-types`
- `pnpm test:unit`
- `pnpm lint`
- `pnpm prepublishOnly`
- `npm pack --dry-run`
- `git diff --check`

## Review
- independent artifact/automation subagent review found stale-dist masking and release staging issues; both fixed
- second-pass review found no code findings; remaining staging note was resolved before commit

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a stale CDN artifact reference (`dist/bundle.min.js` → `dist/bundle.js`) across all user-facing docs and samples, adds `dist/bundle.d.ts.map` to the published package files, and introduces a new `check-package-artifacts` script that validates CDN URL consistency, bundle banner version, and d.ts source-map availability both before and after each build.

- **CDN URL fix**: `README.md`, `README.en.md`, `docs/index.html`, and `docs/sample/sample.js` are updated to reference the built `dist/bundle.js`; `sync-docs-version.mjs` now includes `README.en.md` in its update targets and the release workflow stages it in the version-bump commit.
- **New artifact check script**: `scripts/check-package-artifacts.mjs` validates `package.json` `main`/`types`/`files` fields, CDN URLs in docs, sample version constants, and dist file availability; it is wired into both CI and `prepublishOnly`.
- **Source map publishing**: `dist/bundle.d.ts.map` is declared in `package.json`'s `files` array so it is included in the npm tarball alongside the type declaration file.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; all changes are documentation, tooling, and packaging metadata with no impact on the runtime library itself.

The new check-package-artifacts script has two minor rough edges: the sourceMappingURL regex can capture a trailing 
 on CRLF line endings (producing a false file-not-included error), and the d.ts.map file is read twice when missing, doubling the error output. Neither affects the library at runtime or blocks CI on a Unix environment.

scripts/check-package-artifacts.mjs — the sourceMappingURL extraction and the duplicate readDistText call for the .d.ts.map file.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/check-package-artifacts.mjs | New validation script checking CDN URLs, version consistency, bundle banner, and d.ts source map; two minor issues: duplicate error reporting for the .d.ts.map file and a potential CRLF-carriage-return bug in the sourceMappingURL extraction. |
| scripts/sync-docs-version.mjs | Adds README.en.md to the sync targets list and updates the CDN URL pattern from bundle.min.js to bundle.js; logic is correct. |
| .github/workflows/release-create-release.yml | Adds README.en.md to the git add command so version-bumped content is included in the release commit; consistent with the sync-docs-version target addition. |
| .github/workflows/pr-test-build.yml | Adds pre-build docs check (--allow-missing-dist) and post-build artifact check steps; order is correct and mirrors the prepublishOnly pipeline. |
| package.json | Adds dist/bundle.d.ts.map to the published files list and wires check-package-artifacts into prepublishOnly before and after the build. |
| README.en.md | Switches from the nonexistent bundle.min.js to bundle.js and from @latest (floating) to a pinned version that sync-docs-version.mjs will keep current. |
| README.md | Fixes CDN artifact name from bundle.min.js to bundle.js; no other changes. |
| docs/index.html | Fixes CDN artifact name from bundle.min.js to bundle.js; no other changes. |
| docs/sample/sample.js | Fixes the getNCUrl template from bundle.min.js to bundle.js; no other changes. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Dev as Developer / CI
    participant prepublish as prepublishOnly
    participant syncDocs as sync-docs-version
    participant checkArt as check-package-artifacts
    participant build as pnpm build

    Dev->>prepublish: pnpm prepublishOnly
    prepublish->>syncDocs: check-docs-version (--check)
    syncDocs-->>prepublish: check README.md, README.en.md, docs in sync

    prepublish->>checkArt: check-package-artifacts --allow-missing-dist
    checkArt-->>prepublish: CDN URLs, sample version (dist skipped if absent)

    prepublish->>build: build
    build-->>prepublish: dist/bundle.js, dist/bundle.d.ts, dist/bundle.d.ts.map

    prepublish->>checkArt: check-package-artifacts
    checkArt-->>prepublish: dist banner version, d.ts sourceMappingURL, package files
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Dev as Developer / CI
    participant prepublish as prepublishOnly
    participant syncDocs as sync-docs-version
    participant checkArt as check-package-artifacts
    participant build as pnpm build

    Dev->>prepublish: pnpm prepublishOnly
    prepublish->>syncDocs: check-docs-version (--check)
    syncDocs-->>prepublish: check README.md, README.en.md, docs in sync

    prepublish->>checkArt: check-package-artifacts --allow-missing-dist
    checkArt-->>prepublish: CDN URLs, sample version (dist skipped if absent)

    prepublish->>build: build
    build-->>prepublish: dist/bundle.js, dist/bundle.d.ts, dist/bundle.d.ts.map

    prepublish->>checkArt: check-package-artifacts
    checkArt-->>prepublish: dist banner version, d.ts sourceMappingURL, package files
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Ascripts%2Fcheck-package-artifacts.mjs%3A146%0AThe%20%60%5CS%2B%60%20quantifier%20in%20the%20%60sourceMappingURL%60%20regex%20captures%20non-whitespace%20characters%2C%20which%20includes%20%60%0A%60.%20On%20a%20file%20with%20Windows-style%20CRLF%20line%20endings%2C%20%60dtsMapRef%60%20will%20be%20%60%22bundle.d.ts.map%0A%22%60%2C%20so%20%60dtsMapFile%60%20becomes%20%60%22dist%2Fbundle.d.ts.map%0A%22%60.%20That%20string%20will%20not%20match%20anything%20in%20%60files%60%2C%20causing%20a%20false%20%60isFileIncluded%60%20error%2C%20and%20the%20subsequent%20%60readDistText%60%20call%20will%20also%20fail%20with%20ENOENT.%20Trimming%20the%20captured%20value%20makes%20the%20check%20robust%20to%20line-ending%20style.%0A%0A%60%60%60suggestion%0A%20%20const%20dtsMapRef%20%3D%20bundleDts.match%28%2FsourceMappingURL%3D%28%5CS%2B%29%24%2Fm%29%3F.%5B1%5D%3F.trimEnd%28%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Ascripts%2Fcheck-package-artifacts.mjs%3A144-160%0A**Duplicate%20errors%20for%20%60dist%2Fbundle.d.ts.map%60%20when%20it%20is%20missing**%0A%0AWhen%20%60distRequired%60%20is%20true%20and%20%60dist%2Fbundle.d.ts.map%60%20is%20absent%2C%20the%20file%20is%20read%20twice%3A%20once%20inside%20the%20%60bundleDts%60%20block%20%28line%20152%20%E2%80%94%20%60await%20readDistText%28dtsMapFile%29%60%29%20and%20again%20in%20the%20%60distPackageFiles%60%20loop%20at%20line%20157.%20Each%20call%20independently%20calls%20%60addError%28...%29%60%2C%20so%20the%20same%20%22is%20missing%20or%20unreadable%22%20message%20appears%20twice%20in%20the%20output.%20Since%20the%20%60distPackageFiles%60%20loop%20already%20covers%20all%20declared%20dist%20files%2C%20the%20standalone%20%60readDistText%28dtsMapFile%29%60%20on%20line%20152%20could%20be%20dropped%20%28the%20%60isFileIncluded%60%20check%20above%20it%20is%20still%20valuable%29.%0A%0A&repo=xpadev-net%2Fniconicomments&pr=363&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
scripts/check-package-artifacts.mjs:146
The `\S+` quantifier in the `sourceMappingURL` regex captures non-whitespace characters, which includes `
`. On a file with Windows-style CRLF line endings, `dtsMapRef` will be `"bundle.d.ts.map
"`, so `dtsMapFile` becomes `"dist/bundle.d.ts.map
"`. That string will not match anything in `files`, causing a false `isFileIncluded` error, and the subsequent `readDistText` call will also fail with ENOENT. Trimming the captured value makes the check robust to line-ending style.

```suggestion
  const dtsMapRef = bundleDts.match(/sourceMappingURL=(\S+)$/m)?.[1]?.trimEnd();
```

### Issue 2 of 2
scripts/check-package-artifacts.mjs:144-160
**Duplicate errors for `dist/bundle.d.ts.map` when it is missing**

When `distRequired` is true and `dist/bundle.d.ts.map` is absent, the file is read twice: once inside the `bundleDts` block (line 152 — `await readDistText(dtsMapFile)`) and again in the `distPackageFiles` loop at line 157. Each call independently calls `addError(...)`, so the same "is missing or unreadable" message appears twice in the output. Since the `distPackageFiles` loop already covers all declared dist files, the standalone `readDistText(dtsMapFile)` on line 152 could be dropped (the `isFileIncluded` check above it is still valuable).

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix package artifact file matching"](https://github.com/xpadev-net/niconicomments/commit/d9cfd8d66791db3a45c15043cb7a458423c8d3dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37850268)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->