### PR TITLE
Fix draw dirty state after flush failure and WebGL restore

### DIFF
--- a/src/@types/renderer.ts
+++ b/src/@types/renderer.ts
@@ -66,5 +66,13 @@ export interface IRenderer {
    * AFTER all drawImage calls within a single frame.
    */
   flush(): void;
+  /**
+   * Return true when the renderer's committed surface is no longer trustworthy
+   * and the owner should redraw even if its frame inputs are unchanged.
+   *
+   * Implementations that report true should keep doing so until a subsequent
+   * successful `flush()` commits a fresh frame.
+   */
+  needsRedraw?(): boolean;
   invalidateImage(image: IRenderer): void;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -151,8 +151,10 @@ class NiconiComments {
   public showFPS: boolean;
   public showCommentCount: boolean;
   private lastVpos: number;
+  private lastEventVpos: number;
   private lastCursor?: Position;
   private lastFrameBanActive: boolean;
+  private frameDirty: boolean;
   private get lastVposInt() {
     return Math.floor(this.lastVpos);
   }
@@ -264,7 +266,9 @@ class NiconiComments {
       right: {},
     };
     this.lastVpos = -1;
+    this.lastEventVpos = -1;
     this.lastFrameBanActive = false;
+    this.frameDirty = true;
     this.lazyCommentOrderSortedByVpos = true;
     this.nextUnprocessedCommentIndex = 0;
     this.commentArrayIndexMap = new WeakMap();
@@ -592,6 +596,7 @@ class NiconiComments {
     const vposInt = Math.floor(vpos);
     const drawCanvasStart = performance.now();
     const requiresVideoRedraw = rendererHasVideoSurface(this.renderer);
+    const rendererNeedsRedraw = this.renderer.needsRedraw?.() ?? false;
     const cursorChanged =
       (cursor === undefined) !== (this.lastCursor === undefined) ||
       (cursor !== undefined &&
@@ -601,6 +606,8 @@ class NiconiComments {
       cursor === undefined ? undefined : { x: cursor.x, y: cursor.y };
     const requiresDynamicFrameRedraw =
       requiresVideoRedraw ||
+      rendererNeedsRedraw ||
+      this.frameDirty ||
       this.plugins.length > 0 ||
       this.showCollision ||
       this.showFPS ||
@@ -614,7 +621,12 @@ class NiconiComments {
       return false;
     }
     const triggerHandlerStart = profile ? performance.now() : 0;
-    this.eventHandler.trigger(vposInt, this.lastVposInt, this.ctx.nicoScripts);
+    this.eventHandler.trigger(
+      vposInt,
+      Math.floor(this.lastEventVpos),
+      this.ctx.nicoScripts,
+    );
+    this.lastEventVpos = vpos;
     setProfile("triggerHandler", triggerHandlerStart);
     const frameBanActive = isBanActive(
       vpos,
@@ -642,14 +654,13 @@ class NiconiComments {
     ) {
       if (arrayEqual(timelineRange, lastTimelineRange)) return false;
     }
+    this.frameDirty = true;
     this.renderer.clearRect(
       0,
       0,
       this.ctx.config.canvasWidth,
       this.ctx.config.canvasHeight,
     );
-    this.lastVpos = vpos;
-    this.lastFrameBanActive = frameBanActive;
 
     const drawVideoStart = profile ? performance.now() : 0;
     this._drawVideo();
@@ -693,6 +704,9 @@ class NiconiComments {
     const flushStart = profile ? performance.now() : 0;
     this.renderer.flush();
     setProfile("flush", flushStart);
+    this.lastVpos = vpos;
+    this.lastFrameBanActive = frameBanActive;
+    this.frameDirty = false;
 
     if (profile) {
       profile.total = performance.now() - drawCanvasStart;

--- a/src/main.ts
+++ b/src/main.ts
@@ -623,10 +623,10 @@ class NiconiComments {
     const triggerHandlerStart = profile ? performance.now() : 0;
     this.eventHandler.trigger(
       vposInt,
-      Math.floor(this.lastEventVpos),
+      this.lastEventVpos,
       this.ctx.nicoScripts,
     );
-    this.lastEventVpos = vpos;
+    this.lastEventVpos = vposInt;
     setProfile("triggerHandler", triggerHandlerStart);
     const frameBanActive = isBanActive(
       vpos,

--- a/src/renderer/webgl2.ts
+++ b/src/renderer/webgl2.ts
@@ -156,6 +156,7 @@ class WebGL2Renderer implements IRenderer {
   // Canvas 2D helper for text & path operations
   private helper: CanvasRenderer;
   private helperDirty = false;
+  private redrawNeeded = false;
 
   // Color parsing
   private readonly colorCtx: CanvasRenderingContext2D;
@@ -559,6 +560,7 @@ class WebGL2Renderer implements IRenderer {
     this.rectLocColor = res.rectLocColor;
     this.quadVAO = res.quadVAO;
     this.quadBuf = res.quadBuf;
+    this.redrawNeeded = true;
   }
 
   /* ═══ IRenderer: State ═══ */
@@ -919,6 +921,7 @@ class WebGL2Renderer implements IRenderer {
   flush(): void {
     const gl = this.gl;
     gl.bindVertexArray(this.quadVAO);
+    let flushSucceeded = false;
 
     try {
       let currentProg: WebGLProgram | null = null;
@@ -989,11 +992,13 @@ class WebGL2Renderer implements IRenderer {
           gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
         }
       }
+      flushSucceeded = true;
     } finally {
       gl.bindVertexArray(null);
       this.cmds.length = 0;
       this.helperDirty = false;
       this.frameCount++;
+      this.redrawNeeded = !flushSucceeded;
     }
 
     // Periodic texture GC
@@ -1011,6 +1016,10 @@ class WebGL2Renderer implements IRenderer {
       this._deleteTiles(entry);
       this.texMap.delete(image.canvas);
     }
+  }
+
+  needsRedraw(): boolean {
+    return this.redrawNeeded;
   }
 
   /* ═══ Lifecycle ═══ */

--- a/tests/unit/renderer-draw-robustness.spec.ts
+++ b/tests/unit/renderer-draw-robustness.spec.ts
@@ -37,6 +37,9 @@ class RecordingRenderer implements IRenderer {
   public drawImageCalls = 0;
   public drawImageFailuresRemaining = 0;
   public drawVideoCalls = 0;
+  public flushCalls = 0;
+  public flushFailuresRemaining = 0;
+  public rendererNeedsRedraw = false;
   public saveDepth = 0;
   private font = "10px sans-serif";
   private size = { width: 1920, height: 1080 };
@@ -100,7 +103,17 @@ class RecordingRenderer implements IRenderer {
       throw new Error("invalid draw source");
     }
   }
-  flush() {}
+  flush() {
+    this.flushCalls++;
+    if (this.flushFailuresRemaining > 0) {
+      this.flushFailuresRemaining--;
+      throw new Error("flush failed");
+    }
+    this.rendererNeedsRedraw = false;
+  }
+  needsRedraw() {
+    return this.rendererNeedsRedraw;
+  }
   invalidateImage() {}
 }
 
@@ -132,6 +145,43 @@ type WebGLTextureSetupMock = {
 type WebGL2RendererTexturePrivate = {
   gl: WebGLTextureSetupMock;
   _createTexture(uploadSource: HTMLCanvasElement): WebGLTexture;
+};
+
+type WebGLRestoreSetupMock = {
+  readonly BLEND: number;
+  readonly ONE: number;
+  readonly ONE_MINUS_SRC_ALPHA: number;
+  readonly UNPACK_PREMULTIPLY_ALPHA_WEBGL: number;
+  enable: ReturnType<typeof vi.fn>;
+  blendFunc: ReturnType<typeof vi.fn>;
+  pixelStorei: ReturnType<typeof vi.fn>;
+  viewport: ReturnType<typeof vi.fn>;
+  bindVertexArray: ReturnType<typeof vi.fn>;
+};
+
+type WebGL2RendererRestorePrivate = {
+  gl: WebGLRestoreSetupMock;
+  canvas: { width: number; height: number };
+  texMap: Map<unknown, unknown>;
+  cmds: unknown[];
+  helperDirty: boolean;
+  frameCount: number;
+  quadVAO: WebGLVertexArrayObject;
+  _initGLResources(): {
+    spriteProg: WebGLProgram;
+    spriteLocRect: WebGLUniformLocation;
+    spriteLocProj: WebGLUniformLocation;
+    spriteLocAlpha: WebGLUniformLocation;
+    rectProg: WebGLProgram;
+    rectLocRect: WebGLUniformLocation;
+    rectLocProj: WebGLUniformLocation;
+    rectLocColor: WebGLUniformLocation;
+    quadVAO: WebGLVertexArrayObject;
+    quadBuf: WebGLBuffer;
+  };
+  _rebuildGLResources(): void;
+  flush(): void;
+  needsRedraw(): boolean;
 };
 
 class BaseStyleCommentWithoutButtons extends BaseComment {
@@ -425,6 +475,69 @@ describe("renderer draw robustness", () => {
     expect(renderer.clearRectCalls).toBe(1);
   });
 
+  test("retries an unchanged frame after renderer flush fails", () => {
+    const renderer = new RecordingRenderer();
+    renderer.flushFailuresRemaining = 1;
+    const instance = new NiconiComments(renderer, [], {
+      format: "formatted",
+      mode: "html5",
+    });
+
+    expect(() => instance.drawCanvas(1)).toThrow("flush failed");
+    expect(instance.drawCanvas(1)).toBe(true);
+
+    expect(renderer.clearRectCalls).toBe(2);
+    expect(renderer.flushCalls).toBe(2);
+  });
+
+  test("does not replay NicoScript transitions when retrying after flush fails", () => {
+    const renderer = new RecordingRenderer();
+    renderer.flushFailuresRemaining = 1;
+    const instance = new NiconiComments(
+      renderer,
+      [
+        createComment({
+          content: "@ジャンプ sm9 retry-safe",
+          owner: true,
+        }),
+      ],
+      {
+        format: "formatted",
+        mode: "html5",
+      },
+    );
+    const jumpHandler = vi.fn();
+    instance.addEventListener("jump", jumpHandler);
+
+    expect(() => instance.drawCanvas(1)).toThrow("flush failed");
+    expect(jumpHandler).toHaveBeenCalledTimes(1);
+
+    expect(instance.drawCanvas(1)).toBe(true);
+
+    expect(jumpHandler).toHaveBeenCalledTimes(1);
+    expect(jumpHandler).toHaveBeenCalledWith(
+      expect.objectContaining({ to: "sm9", message: "retry-safe" }),
+    );
+  });
+
+  test("redraws unchanged frames when renderer reports restored resources", () => {
+    const renderer = new RecordingRenderer();
+    const instance = new NiconiComments(renderer, [], {
+      format: "formatted",
+      mode: "html5",
+    });
+
+    expect(instance.drawCanvas(1)).toBe(true);
+    expect(instance.drawCanvas(1)).toBe(false);
+
+    renderer.rendererNeedsRedraw = true;
+
+    expect(instance.drawCanvas(1)).toBe(true);
+    expect(instance.drawCanvas(1)).toBe(false);
+    expect(renderer.clearRectCalls).toBe(2);
+    expect(renderer.flushCalls).toBe(2);
+  });
+
   test("redraws identical vpos frames when the cursor changes", () => {
     const renderer = new RecordingRenderer();
     const instance = new NiconiComments(
@@ -568,5 +681,48 @@ describe("renderer draw robustness", () => {
     expect(gl.bindTexture).toHaveBeenCalledTimes(2);
     expect(gl.deleteTexture).toHaveBeenCalledTimes(1);
     expect(gl.deleteTexture).toHaveBeenCalledWith(texture);
+  });
+
+  test("WebGL resource rebuild marks the renderer dirty until flush succeeds", () => {
+    const gl: WebGLRestoreSetupMock = {
+      BLEND: 1,
+      ONE: 2,
+      ONE_MINUS_SRC_ALPHA: 3,
+      UNPACK_PREMULTIPLY_ALPHA_WEBGL: 4,
+      enable: vi.fn(),
+      blendFunc: vi.fn(),
+      pixelStorei: vi.fn(),
+      viewport: vi.fn(),
+      bindVertexArray: vi.fn(),
+    };
+    const renderer = Object.create(
+      WebGL2Renderer.prototype,
+    ) as WebGL2RendererRestorePrivate;
+    renderer.gl = gl;
+    renderer.canvas = { width: 1920, height: 1080 };
+    renderer.texMap = new Map();
+    renderer.cmds = [];
+    renderer.helperDirty = false;
+    renderer.frameCount = 0;
+    renderer._initGLResources = vi.fn(() => ({
+      spriteProg: {} as WebGLProgram,
+      spriteLocRect: {} as WebGLUniformLocation,
+      spriteLocProj: {} as WebGLUniformLocation,
+      spriteLocAlpha: {} as WebGLUniformLocation,
+      rectProg: {} as WebGLProgram,
+      rectLocRect: {} as WebGLUniformLocation,
+      rectLocProj: {} as WebGLUniformLocation,
+      rectLocColor: {} as WebGLUniformLocation,
+      quadVAO: {} as WebGLVertexArrayObject,
+      quadBuf: {} as WebGLBuffer,
+    }));
+
+    renderer._rebuildGLResources();
+
+    expect(renderer.needsRedraw()).toBe(true);
+
+    renderer.flush();
+
+    expect(renderer.needsRedraw()).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- keep drawCanvas frame state dirty until renderer.flush() succeeds
- add optional renderer needsRedraw() contract and WebGL dirty signaling after context resource rebuilds/flush failures
- cover flush retry, WebGL restore dirty state, and NicoScript event de-duplication regressions

## Validation
- pnpm install --frozen-lockfile
- pnpm run test:unit -- tests/unit/renderer-draw-robustness.spec.ts
- pnpm run check-types
- pnpm run lint
- pnpm run build
- pnpm run test:unit
- git diff --check

## Review
- deep-review self-review performed
- independent subagent failure/lifecycle review found duplicate NicoScript event replay; fixed with separate event progress and regression test
- independent subagent tests/interface review found no actionable issues

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes two related bugs: (1) `drawCanvas` used to mark `lastVpos` before `flush()`, so a failed flush caused the next call with the same vpos to return early without retrying; (2) a WebGL2 context restore rebuilt GPU resources without signaling the owner to redraw. It also adds a de-duplication guard (`lastEventVpos`) to prevent NicoScript events from firing twice when the same vpos is retried.

- **`main.ts`**: `lastVpos`/`lastFrameBanActive` are now committed only after a successful `flush()`; a new `frameDirty` boolean ensures the frame is re-rendered on the next `drawCanvas` call if flush threw. `lastEventVpos` is advanced immediately after `eventHandler.trigger()` so that a retry sees a zero-length event range and skips event replay.
- **`src/renderer/webgl2.ts`**: Adds `redrawNeeded` flag set in `_rebuildGLResources()` and on flush failure, cleared after a successful flush; exposed via the new optional `needsRedraw()` method on `IRenderer`.
- **Tests**: Three new unit tests cover flush retry, NicoScript event de-duplication on retry, and the WebGL resource-rebuild dirty signal.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge. The flush-retry and WebGL-restore paths are logically correct and backed by targeted unit tests.

The two-flag approach (frameDirty in main.ts and redrawNeeded in WebGL2) is correct and complementary. lastVpos is now committed only after a successful flush, ensuring the early-exit guard in drawCanvas never suppresses a needed retry. lastEventVpos is advanced immediately after trigger() so a retried frame sees a zero-length event window and NicoScript side-effects do not fire twice. Neither observation affects correctness of the shipped code.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/@types/renderer.ts | Adds optional needsRedraw(): boolean method to IRenderer with clear JSDoc contract; backward-compatible optional extension. |
| src/main.ts | Introduces frameDirty and lastEventVpos to keep frames retryable after flush failure and prevent NicoScript event replay on retry; lastVpos/lastFrameBanActive now update only after successful flush. |
| src/renderer/webgl2.ts | Adds redrawNeeded flag set on context resource rebuild and on flush failure (via finally), cleared on successful flush; needsRedraw() exposes it to callers. |
| tests/unit/renderer-draw-robustness.spec.ts | Adds flush-retry, NicoScript deduplication, and WebGL resource-rebuild tests; RecordingRenderer.flush() mock doesn't set rendererNeedsRedraw=true on failure, leaving the needsRedraw() co-path for flush failures untested. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Caller
    participant NiconiComments
    participant Renderer

    Caller->>NiconiComments: drawCanvas(vpos)
    NiconiComments->>Renderer: needsRedraw()?
    Renderer-->>NiconiComments: false (or true if context restored)
    Note over NiconiComments: requiresDynamicFrameRedraw = rendererNeedsRedraw || frameDirty || ...
    NiconiComments->>NiconiComments: "trigger(vposInt, lastEventVpos) lastEventVpos=vposInt"
    NiconiComments->>NiconiComments: "frameDirty = true"
    NiconiComments->>Renderer: clearRect / draw commands
    NiconiComments->>Renderer: flush()
    alt flush succeeds
        Renderer-->>NiconiComments: "returns, redrawNeeded=false"
        NiconiComments->>NiconiComments: "lastVpos=vpos, frameDirty=false"
        NiconiComments-->>Caller: true
    else flush throws
        Renderer-->>NiconiComments: "throws (redrawNeeded=true in finally)"
        Note over NiconiComments: lastVpos NOT updated, frameDirty stays true
        NiconiComments-->>Caller: throws
        Caller->>NiconiComments: drawCanvas(vpos) retry
        NiconiComments->>Renderer: needsRedraw() true
        Note over NiconiComments: frameDirty=true skip early-return
        NiconiComments->>NiconiComments: "trigger(vposInt, lastEventVpos=vposInt) no-op range"
        NiconiComments->>Renderer: clearRect / draw commands
        NiconiComments->>Renderer: flush()
        Renderer-->>NiconiComments: "returns, redrawNeeded=false"
        NiconiComments->>NiconiComments: "lastVpos=vpos, frameDirty=false"
        NiconiComments-->>Caller: true
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Caller
    participant NiconiComments
    participant Renderer

    Caller->>NiconiComments: drawCanvas(vpos)
    NiconiComments->>Renderer: needsRedraw()?
    Renderer-->>NiconiComments: false (or true if context restored)
    Note over NiconiComments: requiresDynamicFrameRedraw = rendererNeedsRedraw || frameDirty || ...
    NiconiComments->>NiconiComments: "trigger(vposInt, lastEventVpos) lastEventVpos=vposInt"
    NiconiComments->>NiconiComments: "frameDirty = true"
    NiconiComments->>Renderer: clearRect / draw commands
    NiconiComments->>Renderer: flush()
    alt flush succeeds
        Renderer-->>NiconiComments: "returns, redrawNeeded=false"
        NiconiComments->>NiconiComments: "lastVpos=vpos, frameDirty=false"
        NiconiComments-->>Caller: true
    else flush throws
        Renderer-->>NiconiComments: "throws (redrawNeeded=true in finally)"
        Note over NiconiComments: lastVpos NOT updated, frameDirty stays true
        NiconiComments-->>Caller: throws
        Caller->>NiconiComments: drawCanvas(vpos) retry
        NiconiComments->>Renderer: needsRedraw() true
        Note over NiconiComments: frameDirty=true skip early-return
        NiconiComments->>NiconiComments: "trigger(vposInt, lastEventVpos=vposInt) no-op range"
        NiconiComments->>Renderer: clearRect / draw commands
        NiconiComments->>Renderer: flush()
        Renderer-->>NiconiComments: "returns, redrawNeeded=false"
        NiconiComments->>NiconiComments: "lastVpos=vpos, frameDirty=false"
        NiconiComments-->>Caller: true
    end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Avoid repeated event vpos flooring"](https://github.com/xpadev-net/niconicomments/commit/061491c6ffccbf58799620ec7b6916f62efc3aae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37872467)</sub>

<!-- /greptile_comment -->