### PR TITLE
Fix destroy lifecycle cleanup

### DIFF
--- a/src/@types/IComment.ts
+++ b/src/@types/IComment.ts
@@ -33,5 +33,12 @@ export interface IComment {
     cursor?: Position,
     frameActiveState?: FrameActiveState,
   ) => void;
+  /**
+   * Release comment-owned renderer surfaces and pending timeout handles.
+   *
+   * Implementations must be idempotent. NiconiComments calls this during
+   * instance teardown before clearing shared image caches.
+   */
+  destroy?: () => void;
   isHovered: (cursor?: Position, posX?: number, posY?: number) => boolean;
 }

--- a/src/@types/IPlugins.ts
+++ b/src/@types/IPlugins.ts
@@ -15,6 +15,13 @@ export interface IPlugin {
   draw?: (vpos: number) => boolean | undefined;
   addComments?: (comments: IComment[]) => void;
   transformComments?: (comments: IComment[]) => IComment[];
+  /**
+   * Release plugin-owned resources before the plugin canvas is destroyed.
+   *
+   * Implementations must be idempotent because NiconiComments.destroy() may be
+   * called repeatedly by SPA lifecycles.
+   */
+  destroy?: () => void;
 }
 
 export type IPluginList = {

--- a/src/__tests__/html5css-renderer.spec.ts
+++ b/src/__tests__/html5css-renderer.spec.ts
@@ -123,6 +123,52 @@ test("HTML5CSSRenderer commits direct canvas drawing into its DOM layer", async 
   expect(renderedChildren).toBeGreaterThan(0);
 });
 
+test("HTML5CSSRenderer destroy is idempotent and releases helper surfaces", async ({
+  page,
+}) => {
+  await loadBundle(page);
+
+  const result = await page.evaluate(() => {
+    const root = document.createElement("div");
+    root.dataset.width = "100";
+    root.dataset.height = "100";
+    document.body.appendChild(root);
+    const global = window as typeof window & {
+      NiconiComments: typeof import("@/main").default;
+    };
+    const renderer =
+      new global.NiconiComments.internal.renderer.HTML5CSSRenderer(root);
+    renderer.fillText("text", 0, 10);
+    renderer.flush();
+    renderer.destroy();
+    renderer.destroy();
+    const state = renderer as unknown as {
+      helper?: unknown;
+      helperSurfaces: unknown[];
+      videoSurface?: unknown;
+    };
+    const output = {
+      hasRendererClass: root.classList.contains(
+        "niconicomments-html5css-renderer",
+      ),
+      helperCleared: state.helper === undefined,
+      helperSurfaceCount: state.helperSurfaces.length,
+      rootChildCount: root.childElementCount,
+      videoSurfaceCleared: state.videoSurface === undefined,
+    };
+    root.remove();
+    return output;
+  });
+
+  expect(result).toEqual({
+    hasRendererClass: false,
+    helperCleared: true,
+    helperSurfaceCount: 0,
+    rootChildCount: 0,
+    videoSurfaceCleared: true,
+  });
+});
+
 test("HTML5CSSRenderer preserves display scale across clearRect", async ({
   page,
 }) => {

--- a/src/comments/BaseComment.ts
+++ b/src/comments/BaseComment.ts
@@ -31,6 +31,7 @@ const destroyTextImage = (image: IRenderer) => {
   // Legacy runtime renderers without destroy() are covered by
   // html5-resource-bounds tests; only destroyed modern images need tracking.
   if (typeof image.destroy !== "function") return false;
+  if (destroyedTextImages.has(image)) return false;
   destroyedTextImages.add(image);
   image.destroy();
   return true;
@@ -86,6 +87,8 @@ class BaseComment implements IComment {
   public image?: IRenderer | null;
   public buttonImage?: IRenderer | null;
   public index: number;
+  private readonly _timeoutIds = new Set<number>();
+  private _destroyed = false;
 
   /**
    * コンストラクタ
@@ -377,6 +380,7 @@ class BaseComment implements IComment {
    * @returns 生成した画像
    */
   protected getTextImage(): IRenderer | null {
+    if (this._destroyed) return null;
     if (
       this.comment.invisible ||
       (this.comment.lineCount === 1 && this.comment.width === 0) ||
@@ -395,22 +399,14 @@ class BaseComment implements IComment {
         entries.add(key);
       }
       this.image = cache.image;
-      window.setTimeout(
-        () => {
-          this.image = undefined;
-        },
+      this._setCommentImageClearTimeout(
         this.comment.long * 10 + config.cacheAge,
       );
       clearTimeout(cache.timeout);
       const cachedImage = cache.image;
-      cache.timeout = window.setTimeout(
-        () => {
-          if (imageCache.get(key)?.image === cachedImage) {
-            destroyTextImage(cachedImage);
-            imageCache.delete(key);
-            imageCacheEntries.get(imageCache)?.delete(key);
-          }
-        },
+      cache.timeout = this._setCacheImageExpiryTimeout(
+        key,
+        cachedImage,
         this.comment.long * 10 + config.cacheAge,
       );
       return cache.image;
@@ -460,17 +456,10 @@ class BaseComment implements IComment {
         entries.delete(oldestKey);
       }
     }
-    window.setTimeout(() => {
-      this.image = undefined;
-    }, lifetime);
+    this._setCommentImageClearTimeout(lifetime);
+    const timeout = this._setCacheImageExpiryTimeout(key, image, lifetime);
     imageCache.set(key, {
-      timeout: window.setTimeout(() => {
-        if (imageCache.get(key)?.image === image) {
-          destroyTextImage(image);
-          imageCache.delete(key);
-          imageCacheEntries.get(imageCache)?.delete(key);
-        }
-      }, lifetime),
+      timeout,
       image,
     });
     entries.delete(key);
@@ -500,6 +489,54 @@ class BaseComment implements IComment {
   protected getCacheKey() {
     const mail = boundedCachePart(JSON.stringify(this.comment.mail ?? []));
     return `${this.pluginName}\0${mail}\0${boundedCachePart(this.comment.rawContent)}`;
+  }
+
+  private _setCommentImageClearTimeout(lifetime: number): void {
+    const timeout = window.setTimeout(() => {
+      this._timeoutIds.delete(timeout);
+      this.image = undefined;
+    }, lifetime);
+    this._timeoutIds.add(timeout);
+  }
+
+  private _setCacheImageExpiryTimeout(
+    key: string,
+    image: IRenderer,
+    lifetime: number,
+  ): number {
+    const timeout = window.setTimeout(() => {
+      this._timeoutIds.delete(timeout);
+      if (this.ctx.imageCache.get(key)?.image === image) {
+        destroyTextImage(image);
+        this.ctx.imageCache.delete(key);
+        imageCacheEntries.get(this.ctx.imageCache)?.delete(key);
+      }
+    }, lifetime);
+    this._timeoutIds.add(timeout);
+    return timeout;
+  }
+
+  public destroy(): void {
+    if (this._destroyed) return;
+    this._destroyed = true;
+    for (const timeout of this._timeoutIds) {
+      clearTimeout(timeout);
+    }
+    this._timeoutIds.clear();
+    const textImage = this.image;
+    if (textImage) {
+      const cachedImage = this.ctx.imageCache.get(this.cacheKey)?.image;
+      if (cachedImage !== textImage) {
+        destroyTextImage(textImage);
+      }
+    } else {
+      this.image = null;
+    }
+    this.image = null;
+    if (this.buttonImage && this.buttonImage !== textImage) {
+      destroyTextImage(this.buttonImage);
+    }
+    this.buttonImage = null;
   }
 }
 

--- a/src/comments/BaseComment.ts
+++ b/src/comments/BaseComment.ts
@@ -529,8 +529,6 @@ class BaseComment implements IComment {
       if (cachedImage !== textImage) {
         destroyTextImage(textImage);
       }
-    } else {
-      this.image = null;
     }
     this.image = null;
     if (this.buttonImage && this.buttonImage !== textImage) {

--- a/src/comments/FlashComment.ts
+++ b/src/comments/FlashComment.ts
@@ -114,6 +114,11 @@ class FlashComment extends BaseComment {
     this.image = undefined;
   }
 
+  override destroy(): void {
+    super.destroy();
+    this._buttonImageState = undefined;
+  }
+
   override convertComment(comment: FormattedComment): FormattedCommentWithSize {
     this._globalScale = getConfig(this.config.commentScale, true);
     return getButtonParts(

--- a/src/main.ts
+++ b/src/main.ts
@@ -308,14 +308,14 @@ class NiconiComments {
         console.error("Failed to destroy plugin", e);
       }
       try {
-        plugin.canvas.destroy();
+        plugin.canvas.destroy?.();
       } catch (e) {
         console.error("Failed to destroy plugin canvas", e);
       }
     }
     this.plugins = [];
     this.ctx.imageCache.reset();
-    this.renderer.destroy();
+    this.renderer.destroy?.();
   }
 
   private _clearTimeline() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -167,6 +167,7 @@ class NiconiComments {
   private commentArrayIndexMap: WeakMap<IComment, number>;
   private processedCommentIndex: number;
   private comments: IComment[];
+  private destroyed = false;
   private readonly renderer: IRenderer;
   private readonly collision: Collision;
   private readonly timeline: Timeline;
@@ -286,8 +287,54 @@ class NiconiComments {
   }
 
   public destroy() {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    for (const comment of this.comments) {
+      try {
+        comment.destroy?.();
+      } catch (e) {
+        console.error("Failed to destroy comment", e);
+      }
+    }
+    this.comments = [];
+    this.commentArrayIndexMap = new WeakMap();
+    this._clearTimeline();
+    this._clearCollision();
+    this.ctx.rangeCache.reset();
+    for (const plugin of this.plugins) {
+      try {
+        plugin.instance.destroy?.();
+      } catch (e) {
+        console.error("Failed to destroy plugin", e);
+      }
+      try {
+        plugin.canvas.destroy();
+      } catch (e) {
+        console.error("Failed to destroy plugin canvas", e);
+      }
+    }
+    this.plugins = [];
     this.ctx.imageCache.reset();
     this.renderer.destroy();
+  }
+
+  private _clearTimeline() {
+    for (const key of Object.keys(this.timeline)) {
+      delete this.timeline[Number(key)];
+    }
+  }
+
+  private _clearCollision() {
+    for (const collision of [
+      this.collision.ue,
+      this.collision.shita,
+      this.collision.left,
+      this.collision.right,
+    ]) {
+      for (const key of Object.keys(collision)) {
+        delete collision[Number(key)];
+      }
+    }
   }
 
   private _rebuildCommentArrayIndex(comments: IComment[]) {

--- a/src/renderer/canvas.ts
+++ b/src/renderer/canvas.ts
@@ -71,6 +71,7 @@ class CanvasRenderer implements IRenderer {
   /** プールから取得した canvas かどうか (destroy 時にプールに返却するため) */
   private readonly pooled: boolean;
   private readonly _onDestroy?: () => void;
+  private _destroyed = false;
 
   constructor(
     canvas?: HTMLCanvasElement,
@@ -339,6 +340,8 @@ class CanvasRenderer implements IRenderer {
   }
 
   destroy() {
+    if (this._destroyed) return;
+    this._destroyed = true;
     this._onDestroy?.();
     if (this.pooled) {
       canvasPool.release(this.canvas);

--- a/src/renderer/canvasPool.ts
+++ b/src/renderer/canvasPool.ts
@@ -6,24 +6,33 @@
 class CanvasPool {
   private readonly maxSize: number;
   private pool: HTMLCanvasElement[] = [];
+  private pooledCanvases = new WeakSet<HTMLCanvasElement>();
 
   constructor(maxSize = 16) {
     this.maxSize = maxSize;
   }
 
   acquire(): HTMLCanvasElement {
-    return this.pool.pop() ?? document.createElement("canvas");
+    const canvas = this.pool.pop();
+    if (canvas) {
+      this.pooledCanvases.delete(canvas);
+      return canvas;
+    }
+    return document.createElement("canvas");
   }
 
   release(canvas: HTMLCanvasElement): void {
+    if (this.pooledCanvases.has(canvas)) return;
     if (this.pool.length >= this.maxSize) return;
     canvas.width = 0;
     canvas.height = 0;
+    this.pooledCanvases.add(canvas);
     this.pool.push(canvas);
   }
 
   clear(): void {
     this.pool.length = 0;
+    this.pooledCanvases = new WeakSet<HTMLCanvasElement>();
   }
 }
 

--- a/src/renderer/html5css.ts
+++ b/src/renderer/html5css.ts
@@ -198,7 +198,7 @@ class HTML5CSSRenderer implements IRenderer {
       helper.destroy();
     }
     this.helperSurfaces.length = 0;
-    this.helper = undefined as unknown as CanvasRenderer;
+    (this.helper as CanvasRenderer | undefined) = undefined;
     if (this.videoSurface) {
       this.teardownSurfaceCanvas(this.videoSurface);
       this.videoSurface.destroy();

--- a/src/renderer/html5css.ts
+++ b/src/renderer/html5css.ts
@@ -53,7 +53,7 @@ class HTML5CSSRenderer implements IRenderer {
   private pathActive = false;
   private textDrawnBeforeDom = false;
   private readonly helperSurfaces: CanvasRenderer[] = [];
-  private readonly videoSurface?: CanvasRenderer;
+  private videoSurface?: CanvasRenderer;
   private width = 0;
   private height = 0;
   private state: CssRenderState = { ...DEFAULT_CSS_RENDER_STATE };
@@ -63,6 +63,7 @@ class HTML5CSSRenderer implements IRenderer {
   private activeCanvasSet = new Set<HTMLCanvasElement>();
   private prevCanvasSet = new Set<HTMLCanvasElement>();
   private readonly setupCanvases = new WeakSet<HTMLCanvasElement>();
+  private destroyed = false;
   // Maps source canvas → set of clone canvases created for it this frame.
   // Clones are created when the same IRenderer is drawn more than once per frame.
   private readonly cloneMap = new Map<
@@ -184,6 +185,8 @@ class HTML5CSSRenderer implements IRenderer {
   }
 
   destroy(): void {
+    if (this.destroyed) return;
+    this.destroyed = true;
     // If the caller still holds live sub-renderers obtained via getCanvas(),
     // layer.remove() below detaches their canvases from the DOM implicitly.
     // prevCanvasSet/activeCanvasSet are cleared, so any subsequent
@@ -194,11 +197,15 @@ class HTML5CSSRenderer implements IRenderer {
       this.teardownSurfaceCanvas(helper);
       helper.destroy();
     }
+    this.helperSurfaces.length = 0;
+    this.helper = undefined as unknown as CanvasRenderer;
     if (this.videoSurface) {
       this.teardownSurfaceCanvas(this.videoSurface);
       this.videoSurface.destroy();
+      this.videoSurface = undefined;
     }
     this.nodes.length = 0;
+    this.stateStack.length = 0;
     this.prevCanvasSet.clear();
     this.activeCanvasSet.clear();
     this.cloneMap.clear();

--- a/tests/unit/destroy-lifecycle.spec.ts
+++ b/tests/unit/destroy-lifecycle.spec.ts
@@ -1,0 +1,316 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import type {
+  Collision,
+  FormattedComment,
+  IComment,
+  IPlugin,
+  IPluginConstructor,
+  IRenderer,
+  Timeline,
+} from "@/@types";
+import { FlashComment, HTML5Comment } from "@/comments";
+import { createNicoScripts, ImageCacheContext } from "@/contexts";
+import { defaultConfig, defaultOptions } from "@/definition/config";
+import { initConfig } from "@/definition/initConfig";
+import NiconiComments from "@/main";
+import { CanvasRenderer } from "@/renderer/canvas";
+import { canvasPool } from "@/renderer/canvasPool";
+import { RangeCacheContext } from "@/utils";
+
+const textMetrics = (width: number): TextMetrics =>
+  ({
+    width,
+    actualBoundingBoxLeft: 0,
+    actualBoundingBoxRight: width,
+    actualBoundingBoxAscent: 0,
+    actualBoundingBoxDescent: 0,
+    alphabeticBaseline: 0,
+    hangingBaseline: 0,
+    emHeightAscent: 0,
+    emHeightDescent: 0,
+    fontBoundingBoxAscent: 0,
+    fontBoundingBoxDescent: 0,
+    ideographicBaseline: 0,
+  }) as TextMetrics;
+
+class RecordingRenderer implements IRenderer {
+  public readonly rendererName = "RecordingRenderer";
+  public readonly canvas = {} as HTMLCanvasElement;
+  public readonly children: RecordingRenderer[] = [];
+  public destroyCalls = 0;
+  public setSizeCalls = 0;
+  public fillTextCalls = 0;
+  public strokeTextCalls = 0;
+  private font = "10px sans-serif";
+  private size = { width: 1920, height: 1080 };
+
+  destroy() {
+    this.destroyCalls++;
+  }
+  drawVideo() {}
+  getFont() {
+    return this.font;
+  }
+  getFillStyle() {
+    return "#000000";
+  }
+  setScale() {}
+  fillRect() {}
+  strokeRect() {}
+  fillText() {
+    this.fillTextCalls++;
+  }
+  strokeText() {
+    this.strokeTextCalls++;
+  }
+  quadraticCurveTo() {}
+  clearRect() {}
+  setFont(font: string) {
+    this.font = font;
+  }
+  setFillStyle() {}
+  setStrokeStyle() {}
+  setLineWidth() {}
+  setGlobalAlpha() {}
+  setSize(width: number, height: number) {
+    this.setSizeCalls++;
+    this.size = { width, height };
+  }
+  getSize() {
+    return this.size;
+  }
+  measureText(text: string) {
+    const fontSize = Number(/([0-9.]+)px/.exec(this.font)?.[1] ?? 10);
+    return textMetrics(text.length * fontSize * 0.5);
+  }
+  beginPath() {}
+  closePath() {}
+  moveTo() {}
+  lineTo() {}
+  stroke() {}
+  save() {}
+  restore() {}
+  getCanvas() {
+    const child = new RecordingRenderer();
+    this.children.push(child);
+    return child;
+  }
+  drawImage() {}
+  flush() {}
+  invalidateImage() {}
+}
+
+class TestHTML5Comment extends HTML5Comment {
+  exposeTextImage() {
+    return this.getTextImage();
+  }
+}
+
+class TestFlashComment extends FlashComment {}
+
+const formattedComment = (
+  content: string,
+  mail: string[] = [],
+): FormattedComment => ({
+  id: 1,
+  vpos: 0,
+  content,
+  date: 1_700_000_000,
+  date_usec: 0,
+  owner: false,
+  premium: false,
+  mail,
+  user_id: 1,
+  layer: -1,
+  is_my_post: false,
+});
+
+const createContext = () => ({
+  config: defaultConfig,
+  options: { ...defaultOptions, format: "formatted" as const },
+  nicoScripts: createNicoScripts(),
+  imageCache: new ImageCacheContext(),
+  rangeCache: new RangeCacheContext(),
+});
+
+const ensureCanvasElement = () => {
+  if (!("HTMLCanvasElement" in globalThis)) {
+    vi.stubGlobal("HTMLCanvasElement", class HTMLCanvasElement {});
+  }
+};
+
+const createCanvasLike = (): HTMLCanvasElement => {
+  const context = {
+    textAlign: "start",
+    textBaseline: "alphabetic",
+    lineJoin: "round",
+    scale: vi.fn(),
+    drawImage: vi.fn(),
+    fillRect: vi.fn(),
+    strokeRect: vi.fn(),
+    fillText: vi.fn(),
+    strokeText: vi.fn(),
+    quadraticCurveTo: vi.fn(),
+    clearRect: vi.fn(),
+    getTransform: vi.fn(() => ({ a: 1, d: 1, e: 0, f: 0 })),
+    save: vi.fn(),
+    restore: vi.fn(),
+    setTransform: vi.fn(),
+    measureText: vi.fn(() => textMetrics(1)),
+    beginPath: vi.fn(),
+    closePath: vi.fn(),
+    moveTo: vi.fn(),
+    lineTo: vi.fn(),
+    stroke: vi.fn(),
+  };
+  return {
+    width: 0,
+    height: 0,
+    getContext: vi.fn(() => context),
+  } as unknown as HTMLCanvasElement;
+};
+
+describe("destroy lifecycle cleanup", () => {
+  beforeEach(() => {
+    initConfig();
+    canvasPool.clear();
+    let timeoutId = 0;
+    vi.stubGlobal("window", {
+      setTimeout: vi.fn(() => ++timeoutId),
+    });
+    vi.stubGlobal("clearTimeout", vi.fn());
+    ensureCanvasElement();
+  });
+
+  test("destroys comments and clears instance lifecycle references idempotently", () => {
+    const renderer = new RecordingRenderer();
+    const niconiComments = new NiconiComments(renderer, [], {
+      format: "formatted",
+    });
+    const comment = {
+      comment: formattedComment("manual") as IComment["comment"],
+      invisible: false,
+      index: 0,
+      loc: "ue",
+      width: 1,
+      long: 1,
+      height: 1,
+      vpos: 1,
+      flash: false,
+      posY: 0,
+      owner: false,
+      layer: -1,
+      mail: [],
+      content: "manual",
+      destroy: vi.fn(),
+      draw: vi.fn(),
+      isHovered: vi.fn(() => false),
+    } as IComment;
+    const state = niconiComments as unknown as {
+      collision: Collision;
+      comments: IComment[];
+      timeline: Timeline;
+    };
+    state.comments = [comment];
+    state.timeline[1] = [comment];
+    state.collision.ue[1] = [comment];
+
+    niconiComments.destroy();
+    niconiComments.destroy();
+
+    expect(comment.destroy).toHaveBeenCalledTimes(1);
+    expect(renderer.destroyCalls).toBe(1);
+    expect(state.comments).toHaveLength(0);
+    expect(Object.keys(state.timeline)).toHaveLength(0);
+    expect(Object.keys(state.collision.ue)).toHaveLength(0);
+  });
+
+  test("destroys plugin hooks and plugin canvases idempotently", () => {
+    const renderer = new RecordingRenderer();
+    class LifecyclePlugin implements IPlugin {
+      static instance: LifecyclePlugin | undefined;
+      public destroyCalls = 0;
+      constructor() {
+        LifecyclePlugin.instance = this;
+      }
+      destroy() {
+        this.destroyCalls++;
+      }
+    }
+
+    const niconiComments = new NiconiComments(renderer, [], {
+      config: {
+        plugins: [LifecyclePlugin as IPluginConstructor],
+      },
+      format: "formatted",
+    });
+
+    niconiComments.destroy();
+    niconiComments.destroy();
+
+    expect(LifecyclePlugin.instance?.destroyCalls).toBe(1);
+    expect(renderer.children[0]?.destroyCalls).toBe(1);
+    expect(renderer.destroyCalls).toBe(1);
+    expect(
+      (niconiComments as unknown as { plugins: unknown[] }).plugins,
+    ).toHaveLength(0);
+  });
+
+  test("clears BaseComment-owned timeout handles during destroy", () => {
+    const renderer = new RecordingRenderer();
+    const ctx = createContext();
+    const comment = new TestHTML5Comment(
+      formattedComment("cached text"),
+      renderer,
+      0,
+      ctx,
+    );
+
+    const image = comment.exposeTextImage();
+    comment.destroy();
+    ctx.imageCache.reset();
+
+    expect(image).not.toBeNull();
+    expect(clearTimeout).toHaveBeenCalledWith(1);
+    expect(clearTimeout).toHaveBeenCalledWith(2);
+    expect(renderer.children[0]?.destroyCalls).toBe(1);
+  });
+
+  test("destroys Flash at-button images during comment destroy", () => {
+    const renderer = new RecordingRenderer();
+    const comment = new TestFlashComment(
+      formattedComment('@ボタン "[Push]" "posted" "表示" "" "3"'),
+      renderer,
+      0,
+      createContext(),
+    );
+
+    comment.draw(0, false);
+    comment.destroy();
+
+    const textImage = renderer.children[0];
+    const buttonImage = renderer.children[1];
+    expect(textImage?.destroyCalls).toBe(0);
+    expect(buttonImage?.destroyCalls).toBe(1);
+  });
+
+  test("does not return the same pooled canvas twice after repeated renderer destroy", () => {
+    vi.stubGlobal("document", {
+      createElement: vi.fn(() => createCanvasLike()),
+    });
+    const renderer = new CanvasRenderer();
+    const releasedCanvas = renderer.canvas;
+
+    renderer.destroy();
+    renderer.destroy();
+    const firstReuse = new CanvasRenderer();
+    const secondReuse = new CanvasRenderer();
+
+    expect(firstReuse.canvas).toBe(releasedCanvas);
+    expect(secondReuse.canvas).not.toBe(releasedCanvas);
+
+    firstReuse.destroy();
+    secondReuse.destroy();
+  });
+});


### PR DESCRIPTION
## Summary
- add idempotent destroy contracts for comments/plugins and have NiconiComments tear down comments, plugins, plugin canvases, timelines, collision buckets, image cache, and renderer once
- track BaseComment timeout handles, release text/button images, and guard renderer/canvas pool releases against duplicate destroy
- add lifecycle regression coverage for repeated destroy, plugin canvas cleanup, button/text image cleanup, CanvasPool duplicate release, and HTML5CSS helper surface release

## Validation
- pnpm run test:unit -- tests/unit/destroy-lifecycle.spec.ts (Vitest ran configured unit suite: 10 files, 142 tests)
- pnpm run check-types
- pnpm exec biome check tests/unit/destroy-lifecycle.spec.ts
- pnpm run lint
- pnpm run build
- git diff --check
- pnpm run test:playwright -- src/__tests__/html5css-renderer.spec.ts -g "HTML5CSSRenderer destroy is idempotent" built successfully but timed out waiting for Playwright webServer because port 8080 was already occupied and http-server fell forward to 8081

## Review
- deep-review lifecycle/resource checklist pass: no actionable findings
- independent subagent review: no actionable findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces a comprehensive lifecycle cleanup for `NiconiComments`, ensuring that `destroy()` is idempotent across the entire object graph — main instance, comments, plugins, plugin canvases, renderers, and the canvas pool.

- **`NiconiComments.destroy()`** now iterates all comments and plugins, invoking their optional `destroy()` hooks with per-item error isolation, then clears the timeline, collision buckets, range cache, image cache, and renderer in the correct dependency order.
- **`BaseComment`** gains `_destroyed`/`_timeoutIds` bookkeeping to cancel pending image-clear and cache-expiry timeouts on teardown, and correctly guards against double-freeing images that are still held in the shared cache.
- **`CanvasPool`** and **`CanvasRenderer`** add duplicate-release guards via a `WeakSet` and a `_destroyed` flag respectively, preventing a canvas from re-entering the pool after being reclaimed.
</details>

<h3>Confidence Score: 5/5</h3>

The change is safe to merge; all teardown paths are guarded against double invocation and the cleanup order preserves invariants relied on by each step.

Every modified path has an idempotency guard, the image-destruction logic correctly distinguishes cached from uncached images so nothing is freed twice, the destroyedTextImages WeakSet provides a fallback double-free guard, and the new unit + Playwright tests exercise the exact failure modes the PR claims to fix. The IComment.destroy and IPlugin.destroy additions are optional, keeping the interface change backward-compatible with the related niconicomments-plugin-niwango repo which does not implement them.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/@types/IComment.ts | Adds optional destroy() contract to IComment interface with idempotency requirement; backward-compatible. |
| src/@types/IPlugins.ts | Adds optional destroy() contract to IPlugin interface; backward-compatible, related plugin repo does not implement it. |
| src/comments/BaseComment.ts | Adds idempotent destroy() with timeout cancellation, image release guarded by cached-image check, and _destroyed early-return in getTextImage(); logic is correct. |
| src/comments/FlashComment.ts | Overrides destroy() to delegate to super and clear _buttonImageState; straightforward and correct. |
| src/main.ts | Expands destroy() to iterate comments/plugins, clear timeline/collision, reset imageCache, and guard against repeat calls; cleanup order is correct. |
| src/renderer/canvas.ts | Adds _destroyed guard to CanvasRenderer.destroy() preventing duplicate pool release; clean fix. |
| src/renderer/canvasPool.ts | Adds WeakSet tracking to prevent the same canvas being released into the pool twice; acquire removes it from the set correctly. |
| src/renderer/html5css.ts | Adds destroyed guard, nulls helper and videoSurface after teardown, clears stateStack/helperSurfaces; the cast works around the non-optional field type to achieve null-safety post-destroy. |
| src/__tests__/html5css-renderer.spec.ts | Adds Playwright integration test verifying HTML5CSSRenderer.destroy() is idempotent and clears helper/videoSurface references. |
| tests/unit/destroy-lifecycle.spec.ts | New unit test suite with 5 targeted scenarios covering idempotent NiconiComments destroy, plugin canvas cleanup, timeout cancellation, button-image release, and CanvasPool duplicate release. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant App
    participant NC as NiconiComments
    participant C as BaseComment
    participant P as IPlugin
    participant IC as ImageCacheContext
    participant R as IRenderer

    App->>NC: destroy()
    NC->>NC: if destroyed return
    NC->>NC: "destroyed = true"
    loop each comment
        NC->>C: destroy()
        C->>C: if _destroyed return
        C->>C: "_destroyed = true"
        C->>C: clearTimeout(_timeoutIds)
        C->>C: release uncached image via destroyTextImage()
        C->>C: "image = null, buttonImage = null"
    end
    NC->>NC: "comments = [], commentArrayIndexMap = WeakMap"
    NC->>NC: _clearTimeline(), _clearCollision()
    NC->>IC: rangeCache.reset()
    loop each plugin
        NC->>P: plugin.instance.destroy?()
        NC->>R: plugin.canvas.destroy?()
    end
    NC->>NC: "plugins = []"
    NC->>IC: imageCache.reset()
    IC->>IC: clearTimeout + image.destroy() for all entries
    NC->>R: renderer.destroy?()
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant App
    participant NC as NiconiComments
    participant C as BaseComment
    participant P as IPlugin
    participant IC as ImageCacheContext
    participant R as IRenderer

    App->>NC: destroy()
    NC->>NC: if destroyed return
    NC->>NC: "destroyed = true"
    loop each comment
        NC->>C: destroy()
        C->>C: if _destroyed return
        C->>C: "_destroyed = true"
        C->>C: clearTimeout(_timeoutIds)
        C->>C: release uncached image via destroyTextImage()
        C->>C: "image = null, buttonImage = null"
    end
    NC->>NC: "comments = [], commentArrayIndexMap = WeakMap"
    NC->>NC: _clearTimeline(), _clearCollision()
    NC->>IC: rangeCache.reset()
    loop each plugin
        NC->>P: plugin.instance.destroy?()
        NC->>R: plugin.canvas.destroy?()
    end
    NC->>NC: "plugins = []"
    NC->>IC: imageCache.reset()
    IC->>IC: clearTimeout + image.destroy() for all entries
    NC->>R: renderer.destroy?()
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Address destroy lifecycle review feedbac..."](https://github.com/xpadev-net/niconicomments/commit/2a4319f4ce3f7951c0dbdb7154c5845413ceea86) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37878153)</sub>

<!-- /greptile_comment -->