### PR TITLE
[codex] Validate structured config overrides

### DIFF
--- a/src/@types/config.ts
+++ b/src/@types/config.ts
@@ -104,4 +104,10 @@ export type BaseConfig = {
   };
 };
 
+/**
+ * Instance config overrides are shallow: each provided top-level key replaces
+ * the matching default config value. Nested objects are full replacements and
+ * must contain the complete structure described by BaseConfig, except where
+ * BaseConfig itself marks nested entries as partial.
+ */
 export type Config = Partial<BaseConfig>;

--- a/src/typeGuard.ts
+++ b/src/typeGuard.ts
@@ -81,6 +81,17 @@ const MAX_CONFIG_RATIO = 64;
 const MAX_CONFIG_SPACING = 1024;
 const COMMENT_SIZES = ["big", "medium", "small"] as const;
 const RESIZED_KEYS = ["default", "resized"] as const;
+const FLASH_CHAR_KEYS = [
+  "simsunStrong",
+  "simsunWeak",
+  "gulim",
+  "gothic",
+] as const;
+const FLASH_SCRIPT_CHAR_KEYS = ["super", "sub"] as const;
+const FLASH_FONT_KEYS = ["gulim", "simsun"] as const;
+const HTML5_FONT_KEYS = ["gothic", "mincho", "defont"] as const;
+const FLASH_SPACER_FONT_KEYS = ["gulim", "simsun", "defont"] as const;
+const COLOR_CODE_PATTERN = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
 
 /**
  * 入力がBooleanかどうかを返す
@@ -91,6 +102,12 @@ const isBoolean = (i: unknown): i is boolean => typeof i === "boolean";
 
 const isRecord = (i: unknown): i is Record<string, unknown> =>
   typeof i === "object" && i !== null;
+
+const isPlainRecord = (i: unknown): i is Record<string, unknown> =>
+  isRecord(i) &&
+  !Array.isArray(i) &&
+  (Object.getPrototypeOf(i) === Object.prototype ||
+    Object.getPrototypeOf(i) === null);
 
 const isFiniteNumberInRange = (
   i: unknown,
@@ -127,6 +144,24 @@ const hasConfigKeys = (
   item: Record<string, unknown>,
   keys: readonly string[],
 ): boolean => keys.every((key) => Object.hasOwn(item, key));
+
+const hasOnlyConfigKeys = (
+  item: Record<string, unknown>,
+  keys: readonly string[],
+): boolean => Object.keys(item).every((key) => keys.includes(key));
+
+const isColorCode = (item: unknown): item is string =>
+  typeof item === "string" && COLOR_CODE_PATTERN.test(item);
+
+const isRegexSource = (item: unknown): item is string => {
+  if (typeof item !== "string") return false;
+  try {
+    new RegExp(item);
+    return true;
+  } catch {
+    return false;
+  }
+};
 
 const isBoundedNumberConfigItem = (
   item: unknown,
@@ -264,6 +299,83 @@ const isValidCommentLimit = (item: unknown): boolean =>
     integer: true,
   });
 
+const isValidColors = (item: unknown): boolean =>
+  isPlainRecord(item) && Object.values(item).every(isColorCode);
+
+const isValidFlashChar = (item: unknown): boolean =>
+  isPlainRecord(item) &&
+  hasConfigKeys(item, FLASH_CHAR_KEYS) &&
+  FLASH_CHAR_KEYS.every((key) => isRegexSource(item[key]));
+
+const isValidFlashMode = (item: unknown): boolean =>
+  item === "xp" || item === "vista";
+
+const isValidFlashScriptChar = (item: unknown): boolean =>
+  isPlainRecord(item) &&
+  hasConfigKeys(item, FLASH_SCRIPT_CHAR_KEYS) &&
+  FLASH_SCRIPT_CHAR_KEYS.every((key) => isRegexSource(item[key]));
+
+const isValidFontFamily = (item: unknown): boolean =>
+  typeof item === "string" && item.length > 0;
+
+const isValidFontItem = (item: unknown): boolean =>
+  isPlainRecord(item) &&
+  isValidFontFamily(item.font) &&
+  isFiniteNumberInRange(item.offset, {
+    min: -MAX_CONFIG_SPACING,
+    max: MAX_CONFIG_SPACING,
+  }) &&
+  isFiniteNumberInRange(item.weight, {
+    min: Number.MIN_VALUE,
+    max: 1000,
+  });
+
+const isValidFonts = (item: unknown): boolean => {
+  if (!isPlainRecord(item) || !hasConfigKeys(item, ["flash", "html5"])) {
+    return false;
+  }
+  const flash = item.flash;
+  if (!isPlainRecord(flash) || !hasConfigKeys(flash, FLASH_FONT_KEYS)) {
+    return false;
+  }
+  if (!FLASH_FONT_KEYS.every((key) => isValidFontFamily(flash[key]))) {
+    return false;
+  }
+  const html5 = item.html5;
+  if (!isPlainRecord(html5) || !hasConfigKeys(html5, HTML5_FONT_KEYS)) {
+    return false;
+  }
+  return HTML5_FONT_KEYS.every((key) => isValidFontItem(html5[key]));
+};
+
+const isValidCompatSpacerFontMap = (
+  item: unknown,
+  keys: readonly string[],
+): boolean => {
+  if (!isPlainRecord(item) || !hasOnlyConfigKeys(item, keys)) return false;
+  return Object.values(item).every((value) =>
+    isFiniteNumberInRange(value, { max: MAX_CONFIG_RATIO }),
+  );
+};
+
+const isValidCompatSpacerKey = (key: string): boolean => key.length === 1;
+
+const isValidCompatSpacerGroup = (
+  item: unknown,
+  keys: readonly string[],
+): boolean =>
+  isPlainRecord(item) &&
+  Object.entries(item).every(
+    ([key, value]) =>
+      isValidCompatSpacerKey(key) && isValidCompatSpacerFontMap(value, keys),
+  );
+
+const isValidCompatSpacer = (item: unknown): boolean =>
+  isPlainRecord(item) &&
+  hasConfigKeys(item, ["flash", "html5"]) &&
+  isValidCompatSpacerGroup(item.flash, FLASH_SPACER_FONT_KEYS) &&
+  isValidCompatSpacerGroup(item.html5, HTML5_FONT_KEYS);
+
 const isValidConfig = (item: unknown): boolean => {
   if (!isRecord(item)) return false;
   const validators: Record<string, (i: unknown) => boolean> = {
@@ -282,6 +394,7 @@ const isValidConfig = (item: unknown): boolean => {
     atButtonRadius: isBoundedSpacing,
     collisionPadding: isBoundedSpacing,
     collisionRange: isBoundedCollisionRange,
+    colors: isValidColors,
     commentDrawPadding: (i) =>
       isFiniteNumberInRange(i, { max: MAX_CANVAS_DIMENSION }),
     commentDrawRange: (i) =>
@@ -300,10 +413,16 @@ const isValidConfig = (item: unknown): boolean => {
       isBoundedNumberConfigItem(i, (value) =>
         isFiniteNumberInRange(value, { max: MAX_CONFIG_SPACING }),
       ),
+    contextStrokeColor: isColorCode,
+    contextStrokeInversionColor: isColorCode,
     contextStrokeOpacity: (i) => isFiniteNumberInRange(i, { max: 1 }),
     contextFillLiveOpacity: (i) => isFiniteNumberInRange(i, { max: 1 }),
+    compatSpacer: isValidCompatSpacer,
+    fonts: isValidFonts,
+    flashChar: isValidFlashChar,
     flashLetterSpacing: (i) =>
       isFiniteNumberInRange(i, { max: MAX_CONFIG_SPACING }),
+    flashMode: isValidFlashMode,
     flashCommentYPaddingTop: (i) => isBoundedResizedItem(i, isBoundedSpacing),
     flashCommentYOffset: (i) =>
       isBoundedSizeItem(i, (sizeValue) =>
@@ -319,6 +438,7 @@ const isValidConfig = (item: unknown): boolean => {
       ),
     flashScriptCharOffset: (i) =>
       isFiniteNumberInRange(i, { max: MAX_CONFIG_RATIO }),
+    flashScriptChar: isValidFlashScriptChar,
     flashThreshold: (i) =>
       isFiniteNumberInRange(i, { max: MAX_UNIX_TIME_SECONDS }),
     fontSize: isBoundedFontSizeConfig,

--- a/tests/unit/init-option-config-bounds.spec.ts
+++ b/tests/unit/init-option-config-bounds.spec.ts
@@ -238,6 +238,138 @@ describe("init option and config bounds", () => {
     ).toThrow(InvalidOptionError);
   });
 
+  test.each([
+    [
+      "bad flashChar regex source",
+      () => ({
+        flashChar: {
+          ...defaultConfig.flashChar,
+          gulim: "[",
+        },
+      }),
+    ],
+    [
+      "bad flashScriptChar regex source",
+      () => ({
+        flashScriptChar: {
+          ...defaultConfig.flashScriptChar,
+          super: "(",
+        },
+      }),
+    ],
+    [
+      "invalid flashMode",
+      () => ({
+        flashMode: "legacy" as BaseConfig["flashMode"],
+      }),
+    ],
+    [
+      "missing compatSpacer.flash replacement",
+      () => ({
+        compatSpacer: {
+          html5: {},
+        } as unknown as BaseConfig["compatSpacer"],
+      }),
+    ],
+    [
+      "missing flash font family replacement",
+      () => ({
+        fonts: {
+          html5: defaultConfig.fonts.html5,
+          flash: {
+            gulim: defaultConfig.fonts.flash.gulim,
+          },
+        } as unknown as BaseConfig["fonts"],
+      }),
+    ],
+    [
+      "missing html5 font family replacement",
+      () => ({
+        fonts: {
+          flash: defaultConfig.fonts.flash,
+          html5: {
+            gothic: defaultConfig.fonts.html5.gothic,
+            mincho: defaultConfig.fonts.html5.mincho,
+          },
+        } as unknown as BaseConfig["fonts"],
+      }),
+    ],
+    [
+      "null color map",
+      () => ({
+        colors: null as unknown as BaseConfig["colors"],
+      }),
+    ],
+    [
+      "malformed color map value",
+      () => ({
+        colors: {
+          white: "white",
+        },
+      }),
+    ],
+    [
+      "malformed stroke color",
+      () => ({
+        contextStrokeColor: "black",
+      }),
+    ],
+    [
+      "malformed stroke inversion color",
+      () => ({
+        contextStrokeInversionColor: "white",
+      }),
+    ],
+    [
+      "empty compatSpacer key",
+      () => ({
+        compatSpacer: {
+          flash: {},
+          html5: {
+            "": {
+              defont: 1,
+            },
+          },
+        } as unknown as BaseConfig["compatSpacer"],
+      }),
+    ],
+    [
+      "multi-character compatSpacer key",
+      () => ({
+        compatSpacer: {
+          flash: {},
+          html5: {
+            ab: {
+              defont: 1,
+            },
+          },
+        } as unknown as BaseConfig["compatSpacer"],
+      }),
+    ],
+    [
+      "structurally invalid compatSpacer font map",
+      () => ({
+        compatSpacer: {
+          flash: {
+            " ": {
+              missing: 1,
+            },
+          },
+          html5: {},
+        } as unknown as BaseConfig["compatSpacer"],
+      }),
+    ],
+  ])("rejects invalid structured config: %s", (_, createConfig) => {
+    expect(
+      () =>
+        new NiconiComments(new FakeRenderer(), [], {
+          format: "formatted",
+          mode: "html5",
+          config: createConfig(),
+        }),
+    ).toThrow(InvalidOptionError);
+  });
+
   test("accepts the explicit default config", () => {
     expect(
       () =>


### PR DESCRIPTION
## Summary
- Add runtime validators for structured `BaseConfig` overrides including colors, fonts, regex sources, stroke colors, flash mode, and compat spacer maps.
- Document the existing shallow override contract: provided top-level config keys replace defaults, so nested replacements must be complete unless the type itself permits partial entries.
- Add focused unit coverage for malformed regex/color/font/spacer overrides and incomplete nested replacements throwing `InvalidOptionError` during construction.

## Validation
- `corepack pnpm exec vitest run tests/unit/init-option-config-bounds.spec.ts` - 23 passed
- `corepack pnpm run check-types` - passed
- `corepack pnpm run test:unit` - 10 files / 155 tests passed
- `corepack pnpm run lint` - passed
- `corepack pnpm run build` - passed
- `git diff --check` - passed

## Review
- Deep-review self pass completed against boundary validation and test coverage.
- Independent subagent review found two issues (compatSpacer key shape and `contextStrokeInversionColor` coverage); both were fixed.
- Replacement independent subagent review found no remaining actionable regressions.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds runtime validators for the structured `BaseConfig` override fields (`colors`, `fonts`, `flashChar`, `flashScriptChar`, `flashMode`, `contextStrokeColor`, `contextStrokeInversionColor`, `compatSpacer`) and wires them into `isValidConfig`, which already guarded all scalar fields. A JSDoc comment on `Config = Partial<BaseConfig>` documents the shallow-replacement contract.

- **`src/typeGuard.ts`**: Introduces `isPlainRecord`, `isColorCode`, `isRegexSource`, and seven composite validators; all hooked into the existing `validators` map in `isValidConfig`. The `compatSpacer` validator correctly uses `hasOnlyConfigKeys` (permitting partial font maps matching the `Partial<>` type) while character-key length is enforced to exactly 1.
- **`tests/unit/init-option-config-bounds.spec.ts`**: 12 new `test.each` cases cover regex compilation failures, null/malformed color maps, incomplete font-key replacements, and invalid compatSpacer key shapes, all asserting `InvalidOptionError`.
- **`src/@types/config.ts`**: Documentation-only change clarifying the override semantics.
</details>

<h3>Confidence Score: 4/5</h3>

Safe to merge; all new validators fire through the existing guard path and the default config passes the new checks without modification.

The implementation is correct and well-tested. The one finding is a narrow inconsistency between COLOR_CODE_PATTERN (3/6 hex digits only) and the existing typeGuard.comment.colorCode guard (3/4/6 hex digits), which would silently reject a 4-digit shorthand hex value in config color fields. No existing default uses that format, so it does not break anything today, but the intent should be explicit.

The COLOR_CODE_PATTERN constant in src/typeGuard.ts (line 94) deserves a second look to confirm whether 4-digit hex exclusion is deliberate.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/@types/config.ts | Added a JSDoc comment clarifying the shallow-override contract for the Config = Partial<BaseConfig> type; no logic changes. |
| src/typeGuard.ts | Adds isPlainRecord, isColorCode, isRegexSource, and a set of composite validators (colors, fonts, flashChar, flashMode, compatSpacer, etc.) wired into isValidConfig. One minor inconsistency: COLOR_CODE_PATTERN only matches 3/6-digit hex while the existing comment colorCode guard accepts 3/4/6-digit. |
| tests/unit/init-option-config-bounds.spec.ts | Adds 12 test.each cases covering malformed regex, bad color codes, incomplete font maps, and invalid compatSpacer keys/structures; all verify InvalidOptionError is thrown. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[isValidConfig] --> B{key present?}
    B -- yes --> C[run validator]
    C --> D{valid?}
    D -- no --> E[console.warn + return false]
    D -- yes --> F[next key]

    subgraph "New structured validators"
        G[isValidColors] --> G1[isPlainRecord + every value isColorCode]
        H[isValidFonts] --> H1[flash: hasConfigKeys + isValidFontFamily]
        H --> H2[html5: hasConfigKeys + isValidFontItem]
        I[isValidFlashChar] --> I1[hasConfigKeys FLASH_CHAR_KEYS + isRegexSource each]
        J[isValidFlashScriptChar] --> J1[hasConfigKeys FLASH_SCRIPT_CHAR_KEYS + isRegexSource each]
        K[isValidCompatSpacer] --> K1[isValidCompatSpacerGroup flash]
        K --> K2[isValidCompatSpacerGroup html5]
        K1 --> K3[isValidCompatSpacerKey key.length===1]
        K1 --> K4[isValidCompatSpacerFontMap hasOnlyConfigKeys + range check]
    end

    C --> G & H & I & J & K
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[isValidConfig] --> B{key present?}
    B -- yes --> C[run validator]
    C --> D{valid?}
    D -- no --> E[console.warn + return false]
    D -- yes --> F[next key]

    subgraph "New structured validators"
        G[isValidColors] --> G1[isPlainRecord + every value isColorCode]
        H[isValidFonts] --> H1[flash: hasConfigKeys + isValidFontFamily]
        H --> H2[html5: hasConfigKeys + isValidFontItem]
        I[isValidFlashChar] --> I1[hasConfigKeys FLASH_CHAR_KEYS + isRegexSource each]
        J[isValidFlashScriptChar] --> J1[hasConfigKeys FLASH_SCRIPT_CHAR_KEYS + isRegexSource each]
        K[isValidCompatSpacer] --> K1[isValidCompatSpacerGroup flash]
        K --> K2[isValidCompatSpacerGroup html5]
        K1 --> K3[isValidCompatSpacerKey key.length===1]
        K1 --> K4[isValidCompatSpacerFontMap hasOnlyConfigKeys + range check]
    end

    C --> G & H & I & J & K
```

</a>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2FtypeGuard.ts%3A94%0A**%60COLOR_CODE_PATTERN%60%20narrower%20than%20the%20existing%20comment%20color%20validator**%0A%0A%60COLOR_CODE_PATTERN%60%20only%20accepts%20%60%23RGB%60%20and%20%60%23RRGGBB%60%20formats.%20The%20existing%20%60typeGuard.comment.colorCode%60%20guard%20%28line%20598%29%20accepts%20%60%23RGB%60%2C%20%60%23RGBA%60%2C%20and%20%60%23RRGGBB%60.%20Any%20user%20who%20passes%20a%204-digit%20shorthand%20with%20alpha%20%28e.g.%20%60contextStrokeColor%3A%20%22%23000A%22%60%29%20will%20receive%20an%20%60InvalidOptionError%60%2C%20even%20though%20the%20same%20string%20is%20considered%20a%20valid%20comment%20color%20elsewhere%20in%20the%20codebase.%20If%204-digit%20hex%20is%20intentionally%20unsupported%20for%20config-level%20colors%20this%20should%20be%20noted%20in%20a%20comment%3B%20otherwise%20the%20pattern%20should%20be%20widened%20to%20%60%7B3%2C4%7D%60%20to%20stay%20consistent.%0A%0A&repo=xpadev-net%2Fniconicomments&pr=366&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/typeGuard.ts:94
**`COLOR_CODE_PATTERN` narrower than the existing comment color validator**

`COLOR_CODE_PATTERN` only accepts `#RGB` and `#RRGGBB` formats. The existing `typeGuard.comment.colorCode` guard (line 598) accepts `#RGB`, `#RGBA`, and `#RRGGBB`. Any user who passes a 4-digit shorthand with alpha (e.g. `contextStrokeColor: "#000A"`) will receive an `InvalidOptionError`, even though the same string is considered a valid comment color elsewhere in the codebase. If 4-digit hex is intentionally unsupported for config-level colors this should be noted in a comment; otherwise the pattern should be widened to `{3,4}` to stay consistent.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/dev..."](https://github.com/xpadev-net/niconicomments/commit/fc3e6d0703c5d06afdd11d73180f74c420a4262d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37882182)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->