### PR TITLE
REV-03 parser compatibility and malformed item handling

### DIFF
--- a/src/@types/format.legacy.ts
+++ b/src/@types/format.legacy.ts
@@ -1,14 +1,5 @@
 import type { InferOutput } from "valibot";
-import {
-  notValue,
-  object,
-  optional,
-  pipe,
-  record,
-  string,
-  union,
-  unknown,
-} from "valibot";
+import { object, optional, record, string, unknown } from "valibot";
 
 import {
   ZCommentDate,
@@ -33,10 +24,7 @@ export const ZApiChat = object({
 });
 export type ApiChat = InferOutput<typeof ZApiChat>;
 
-export const ZRawApiResponse = union([
-  object({ chat: unknown() }),
-  record(pipe(string(), notValue("chat")), unknown()),
-]);
+export const ZRawApiResponse = record(string(), unknown());
 export type RawApiResponse = InferOutput<typeof ZRawApiResponse>;
 
 /**

--- a/src/@types/format.legacy.ts
+++ b/src/@types/format.legacy.ts
@@ -34,7 +34,7 @@ export const ZApiChat = object({
 export type ApiChat = InferOutput<typeof ZApiChat>;
 
 export const ZRawApiResponse = union([
-  object({ chat: ZApiChat }),
+  object({ chat: unknown() }),
   record(pipe(string(), notValue("chat")), unknown()),
 ]);
 export type RawApiResponse = InferOutput<typeof ZRawApiResponse>;

--- a/src/@types/format.owner.ts
+++ b/src/@types/format.owner.ts
@@ -1,9 +1,9 @@
 import type { InferOutput } from "valibot";
-import { object, string } from "valibot";
+import { object, optional, string } from "valibot";
 
 export const ZOwnerComment = object({
   time: string(),
-  command: string(),
+  command: optional(string(), ""),
   comment: string(),
 });
 export type OwnerComment = InferOutput<typeof ZOwnerComment>;

--- a/src/@types/format.xml2js.ts
+++ b/src/@types/format.xml2js.ts
@@ -2,7 +2,7 @@ import type { InferOutput } from "valibot";
 import { array, object, optional, string } from "valibot";
 
 export const ZXml2jsChatItem = object({
-  _: string(),
+  _: optional(string(), ""),
   $: object({
     no: optional(string()),
     vpos: string(),

--- a/src/input/legacyOwner.ts
+++ b/src/input/legacyOwner.ts
@@ -21,10 +21,10 @@ export const LegacyOwnerParser: InputParser = {
  */
 const fromLegacyOwner = (data: string): FormattedComment[] => {
   const data_: FormattedComment[] = [];
-  const comments = data.split("\n");
+  const comments = data.split(/\r\n|\r|\n/);
   for (let i = 0, n = comments.length; i < n; i++) {
-    const value = comments[i];
-    if (!value) continue;
+    const value = comments[i] ?? "";
+    if (value.trim() === "") continue;
     const commentData = value.split(":");
     if (commentData.length < 3) {
       continue;

--- a/src/typeGuard.ts
+++ b/src/typeGuard.ts
@@ -536,6 +536,7 @@ const typeGuard = {
           check((i) => {
             const lists = i.split(/\r\n|\r|\n/);
             for (const list of lists) {
+              if (list.trim() === "") continue;
               if (list.split(":").length < 3) {
                 return false;
               }

--- a/tests/unit/inputParser.spec.ts
+++ b/tests/unit/inputParser.spec.ts
@@ -271,6 +271,23 @@ describe("convert2formattedComment", () => {
     expect(output).toMatchObject([{ id: 1, vpos: 10, content: "ok" }]);
   });
 
+  it("skips deleted and partial legacy API chat items without rejecting the response", () => {
+    const output = convert2formattedComment(
+      [
+        {
+          chat: { no: 1, vpos: 10, date: 1, user_id: "alice", content: "ok" },
+        },
+        { chat: { deleted: 1 } },
+        { chat: { no: 2, vpos: 20, date: 2 } },
+        { ping: { content: "rs:0" } },
+        null,
+      ],
+      "legacy",
+    );
+
+    expect(output).toMatchObject([{ id: 1, vpos: 10, content: "ok" }]);
+  });
+
   it("rejects non-finite v1 numeric fields and drops invalid postedAt comments", () => {
     const validComment = {
       id: "1",
@@ -381,6 +398,26 @@ describe("convert2formattedComment", () => {
     ).toMatchObject([{ id: 1, vpos: 10, date: 0, content: "missing date" }]);
   });
 
+  it("defaults missing xml2js chat bodies to empty text like XMLDocument", () => {
+    expect(
+      convert2formattedComment(
+        {
+          packet: {
+            chat: [{ $: { no: "1", vpos: "10", date: "1" } }],
+          },
+        },
+        "xml2js",
+      ),
+    ).toMatchObject([{ id: 1, vpos: 10, content: "" }]);
+
+    expect(
+      convert2formattedComment(
+        createXmlDocument([createXmlElement({ no: "1", vpos: "10" }, "")]),
+        "XMLDocument",
+      ),
+    ).toMatchObject([{ id: 1, vpos: 10, content: "" }]);
+  });
+
   it("drops malformed xml2js chat items while keeping valid comments", () => {
     const output = convert2formattedComment(
       {
@@ -404,11 +441,38 @@ describe("convert2formattedComment", () => {
 
   it("drops legacy owner text lines with malformed time fields", () => {
     const output = convert2formattedComment(
-      "10:ue:ok\nNaN:ue:bad\nInfinity:ue:bad\nabc:ue:bad",
+      "10:ue:ok\nNaN:ue:bad\nInfinity:ue:bad\nabc:ue:bad\n-1:ue:bad",
       "legacyOwner",
     );
 
     expect(output).toMatchObject([{ id: 0, vpos: 1000, content: "ok" }]);
+  });
+
+  it("accepts trailing blank lines in legacy owner text", () => {
+    const output = convert2formattedComment(
+      "10:ue:ok\n20::no command\r\n\r\n  \n",
+      "legacyOwner",
+    );
+
+    expect(output).toMatchObject([
+      { id: 0, vpos: 1000, content: "ok", mail: ["ue"] },
+      { id: 1, vpos: 2000, content: "no command", mail: [] },
+    ]);
+  });
+
+  it("defaults missing owner commands to an empty mail list", () => {
+    const output = convert2formattedComment(
+      [
+        { time: "0", comment: "no command" },
+        { time: "1", command: "ue", comment: "has command" },
+      ],
+      "owner",
+    );
+
+    expect(output).toMatchObject([
+      { id: 0, vpos: 0, content: "no command", mail: [] },
+      { id: 1, vpos: 100, content: "has command", mail: ["ue"] },
+    ]);
   });
 
   it("drops owner comments with malformed time fields", () => {


### PR DESCRIPTION
## Summary
- validate legacy API raw chat payloads at item conversion time so partial/deleted chat entries are skipped without rejecting the full response
- default missing owner commands and xml2js chat bodies to empty strings
- accept blank legacyOwner lines and keep malformed/nonnegative time handling per item

## Validation
- pnpm test:unit tests/unit/inputParser.spec.ts
- pnpm test:unit
- pnpm check-types
- pnpm lint
- pnpm build
- git diff --check

## Review
- deep-review self-review: no actionable findings
- independent type/boundary subagent: no actionable findings
- independent tests/failure-semantics subagent: no actionable findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves parser resilience for several legacy comment formats: partial/deleted legacy API chat entries are now skipped per-item (instead of rejecting the whole response), missing `command` fields in owner comments and missing `_` body in xml2js chat items default to empty strings, and the `legacyOwner` parser correctly handles CRLF line endings and whitespace-only lines.

- **`format.legacy.ts`** – `ZRawApiResponse` relaxed to `record(string(), unknown())`, so arrays containing deleted/partial chat entries pass the type guard and reach per-item `safeParse` filtering in `legacy.ts`.
- **`format.owner.ts` / `format.xml2js.ts`** – `command` and `_` fields made optional with `\"\"` defaults, matching how the XMLDocument parser already handles absent text content.
- **`legacyOwner.ts` / `typeGuard.ts`** – `split` now uses a CRLF-aware regex and both the guard and parser consistently skip blank/whitespace-only lines.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are targeted compatibility fixes with no regressions identified.

Every changed code path is exercised by a new unit test. The ZRawApiResponse relaxation looks broad, but the old union's second branch already accepted owner/formatted arrays via record(notValue("chat"), unknown()); the new record(string(), unknown()) produces identical format-detection behaviour in niconicomments-convert while additionally allowing partial-chat objects through to per-item safeParse filtering. All other changes are symmetric between the type guard and parser.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/@types/format.legacy.ts | ZRawApiResponse relaxed to record(string(), unknown()); no new false-positive regressions vs. the previous union which already accepted non-chat objects via its second branch |
| src/@types/format.owner.ts | command field made optional with "" default; aligns with new test and matches how the parser handles empty mail |
| src/@types/format.xml2js.ts | _ field made optional(string(), "") to match XMLDocument behaviour for chat elements with no text node |
| src/input/legacyOwner.ts | CRLF-aware split, whitespace-line skip, and ?? "" guard are all correct |
| src/typeGuard.ts | Blank-line skip added to legacyOwner type guard, keeping it consistent with the updated parser |
| tests/unit/inputParser.spec.ts | New tests cover all six changed behaviours: partial/deleted legacy items, missing xml2js body, blank legacyOwner lines, missing owner command, CRLF lines, and negative time rejection |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Input array - legacy format] --> B[parse as array of unknown]
    B --> C{For each item}
    C --> D{Has chat key and not null?}
    D -- No --> E[skip]
    D -- Yes --> F[safeParse ZApiChat]
    F -- fail --> G[skip partial or deleted]
    F -- success --> H{deleted === 1?}
    H -- Yes --> I[skip]
    H -- No --> J[build FormattedComment and push]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Input array - legacy format] --> B[parse as array of unknown]
    B --> C{For each item}
    C --> D{Has chat key and not null?}
    D -- No --> E[skip]
    D -- Yes --> F[safeParse ZApiChat]
    F -- fail --> G[skip partial or deleted]
    F -- success --> H{deleted === 1?}
    H -- Yes --> I[skip]
    H -- No --> J[build FormattedComment and push]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: simplify raw legacy response schema"](https://github.com/xpadev-net/niconicomments/commit/bc62bc67d1d4a23ce8bb1cc0d35415d3b9c9b0e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37888640)</sub>

<!-- /greptile_comment -->