### PR TITLE
Fix NicoScript range boundary semantics

### DIFF
--- a/src/eventHandler.ts
+++ b/src/eventHandler.ts
@@ -47,13 +47,13 @@ const getRangeScanState = <T extends EventRange>(
 const rangeEndsAfter = (range: EventRange, vpos: number) =>
   range.end === undefined || vpos < range.end;
 
-const lowerBoundStart = <T extends EventRange>(ranges: T[], vpos: number) => {
+const upperBoundStart = <T extends EventRange>(ranges: T[], vpos: number) => {
   let low = 0;
   let high = ranges.length;
   while (low < high) {
     const mid = Math.floor((low + high) / 2);
     const range = ranges[mid];
-    if (range && range.start < vpos) {
+    if (range && range.start <= vpos) {
       low = mid + 1;
     } else {
       high = mid;
@@ -77,6 +77,19 @@ const upperBoundEnd = <T extends EventRange>(ranges: T[], vpos: number) => {
   return low;
 };
 
+const hasActiveRange = <T extends EventRange>(
+  ranges: T[],
+  vpos: number,
+  scanCache: WeakMap<T[], EventRangeScanState<T>>,
+) => {
+  if (!Number.isFinite(vpos)) return false;
+  const state = getRangeScanState(ranges, scanCache);
+  return (
+    upperBoundStart(state.sortedByStart, vpos) >
+    upperBoundEnd(state.sortedByEnd, vpos)
+  );
+};
+
 const getTransitionRanges = <T extends EventRange>(
   ranges: T[],
   vpos: number,
@@ -92,8 +105,8 @@ const getTransitionRanges = <T extends EventRange>(
 
   if (lastVpos <= vpos) {
     for (
-      let i = lowerBoundStart(state.sortedByStart, lastVpos),
-        end = lowerBoundStart(state.sortedByStart, vpos);
+      let i = upperBoundStart(state.sortedByStart, lastVpos),
+        end = upperBoundStart(state.sortedByStart, vpos);
       i < end;
       i++
     ) {
@@ -109,7 +122,7 @@ const getTransitionRanges = <T extends EventRange>(
       i++
     ) {
       const range = state.sortedByEnd[i];
-      if (range && range.start < lastVpos) {
+      if (range && range.start <= lastVpos) {
         exited.push(range);
       }
     }
@@ -121,13 +134,13 @@ const getTransitionRanges = <T extends EventRange>(
       i++
     ) {
       const range = state.sortedByEnd[i];
-      if (range && range.start < vpos) {
+      if (range && range.start <= vpos) {
         entered.push(range);
       }
     }
     for (
-      let i = lowerBoundStart(state.sortedByStart, vpos),
-        end = lowerBoundStart(state.sortedByStart, lastVpos);
+      let i = upperBoundStart(state.sortedByStart, vpos),
+        end = upperBoundStart(state.sortedByStart, lastVpos);
       i < end;
       i++
     ) {
@@ -211,20 +224,24 @@ class EventHandler {
       this.handlerCounts.commentEnable < 1
     )
       return;
-    const { entered, exited } = getTransitionRanges(
+    const wasActive = hasActiveRange(
       nicoScripts.ban,
-      vpos,
       lastVpos,
       this.banActiveRangeScans,
     );
-    for (const _range of entered) {
+    const active = hasActiveRange(
+      nicoScripts.ban,
+      vpos,
+      this.banActiveRangeScans,
+    );
+    if (!wasActive && active) {
       this._execute("commentDisable", {
         type: "commentDisable",
         timeStamp: Date.now(),
         vpos,
       });
     }
-    for (const _range of exited) {
+    if (wasActive && !active) {
       this._execute("commentEnable", {
         type: "commentEnable",
         timeStamp: Date.now(),
@@ -240,20 +257,24 @@ class EventHandler {
   ) {
     if (this.handlerCounts.seekDisable < 1 && this.handlerCounts.seekEnable < 1)
       return;
-    const { entered, exited } = getTransitionRanges(
+    const wasActive = hasActiveRange(
       nicoScripts.seekDisable,
-      vpos,
       lastVpos,
       this.seekDisableActiveRangeScans,
     );
-    for (const _range of entered) {
+    const active = hasActiveRange(
+      nicoScripts.seekDisable,
+      vpos,
+      this.seekDisableActiveRangeScans,
+    );
+    if (!wasActive && active) {
       this._execute("seekDisable", {
         type: "seekDisable",
         timeStamp: Date.now(),
         vpos,
       });
     }
-    for (const _range of exited) {
+    if (wasActive && !active) {
       this._execute("seekEnable", {
         type: "seekEnable",
         timeStamp: Date.now(),

--- a/src/eventHandler.ts
+++ b/src/eventHandler.ts
@@ -224,6 +224,7 @@ class EventHandler {
       this.handlerCounts.commentEnable < 1
     )
       return;
+    if (nicoScripts.ban.length === 0) return;
     const wasActive = hasActiveRange(
       nicoScripts.ban,
       lastVpos,
@@ -257,6 +258,7 @@ class EventHandler {
   ) {
     if (this.handlerCounts.seekDisable < 1 && this.handlerCounts.seekEnable < 1)
       return;
+    if (nicoScripts.seekDisable.length === 0) return;
     const wasActive = hasActiveRange(
       nicoScripts.seekDisable,
       lastVpos,

--- a/src/utils/comment.ts
+++ b/src/utils/comment.ts
@@ -425,13 +425,14 @@ const nicoscriptReplaceIgnoreable = (
     item.target === "全" ||
     item.target === "含む" ||
     item.target === "含まない";
+  if (!targetMatches) return true;
   const conditionMatches =
     item.condition === "完全一致"
       ? comment.content === item.keyword
       : comment.content.includes(item.keyword);
   const contentMatches =
     item.target === "含まない" ? !conditionMatches : conditionMatches;
-  return !targetMatches || !contentMatches;
+  return !contentMatches;
 };
 
 /**

--- a/src/utils/comment.ts
+++ b/src/utils/comment.ts
@@ -185,6 +185,11 @@ type TimedRange = {
   end: number;
 };
 
+type TimedDuration = {
+  start: number;
+  long: number | undefined;
+};
+
 type ActiveRangeScanState<T extends TimedRange> = {
   sourceLength: number;
   sortedByStart: T[];
@@ -261,6 +266,12 @@ const changeReverseTargetCount = (
   counts[range.target] += delta;
 };
 
+const durationEndsAfter = (range: TimedDuration, vpos: number) =>
+  range.long === undefined || vpos < range.start + range.long;
+
+const isDurationRangeActive = (range: TimedDuration, vpos: number) =>
+  range.start <= vpos && durationEndsAfter(range, vpos);
+
 const getActiveRangeState = <T extends TimedRange>(
   ranges: T[],
   vpos: number,
@@ -286,7 +297,7 @@ const getActiveRangeState = <T extends TimedRange>(
 
   while (state.startIndex < state.sortedByStart.length) {
     const range = state.sortedByStart[state.startIndex];
-    if (!range || vpos <= range.start) break;
+    if (!range || vpos < range.start) break;
     state.startIndex++;
     state.activeCount++;
     if (state.targetCounts) {
@@ -298,7 +309,7 @@ const getActiveRangeState = <T extends TimedRange>(
     const range = state.sortedByEnd[state.endIndex];
     if (!range || vpos < range.end) break;
     state.endIndex++;
-    if (range.start < vpos) {
+    if (range.start <= vpos) {
       state.activeCount--;
       if (state.targetCounts) {
         changeTargetCount?.(state.targetCounts, range, -1);
@@ -369,7 +380,7 @@ const getDefaultCommand = (
     for (let i = 0; i < nicoScripts.default.length; i++) {
       const item = nicoScripts.default[i];
       if (!item) continue;
-      if (item.long === undefined || item.start + item.long >= vpos) {
+      if (durationEndsAfter(item, vpos)) {
         nicoScripts.default[writeIdx++] = item;
       }
     }
@@ -380,6 +391,7 @@ const getDefaultCommand = (
   let font: CommentFont | undefined;
   let loc: CommentLoc | undefined;
   for (const item of nicoScripts.default) {
+    if (!isDurationRangeActive(item, vpos)) continue;
     if (item.loc) {
       loc = item.loc;
     }
@@ -406,13 +418,21 @@ const getDefaultCommand = (
 const nicoscriptReplaceIgnoreable = (
   comment: FormattedComment,
   item: NicoScriptReplace,
-) =>
-  ((item.target === "コメ" || item.target === "含まない") && comment.owner) ||
-  (item.target === "投コメ" && !comment.owner) ||
-  (item.target === "含まない" && comment.owner) ||
-  (item.condition === "完全一致" && comment.content !== item.keyword) ||
-  (item.condition === "部分一致" &&
-    comment.content.indexOf(item.keyword) === -1);
+) => {
+  const targetMatches =
+    (item.target === "コメ" && !comment.owner) ||
+    (item.target === "投コメ" && comment.owner) ||
+    item.target === "全" ||
+    item.target === "含む" ||
+    item.target === "含まない";
+  const conditionMatches =
+    item.condition === "完全一致"
+      ? comment.content === item.keyword
+      : comment.content.includes(item.keyword);
+  const contentMatches =
+    item.target === "含まない" ? !conditionMatches : conditionMatches;
+  return !targetMatches || !contentMatches;
+};
 
 /**
  * 置換コマンドを適用する
@@ -430,13 +450,14 @@ const applyNicoScriptReplace = (
     for (let i = 0; i < nicoScripts.replace.length; i++) {
       const item = nicoScripts.replace[i];
       if (!item) continue;
-      if (item.long === undefined || item.start + item.long >= comment.vpos) {
+      if (durationEndsAfter(item, comment.vpos)) {
         nicoScripts.replace[writeIdx++] = item;
       }
     }
     nicoScripts.replace.length = writeIdx;
   }
   for (const item of nicoScripts.replace) {
+    if (!isDurationRangeActive(item, comment.vpos)) continue;
     if (nicoscriptReplaceIgnoreable(comment, item)) continue;
     if (item.range === "単") {
       comment.content = comment.content.replaceAll(item.keyword, item.replace);

--- a/tests/unit/nicoscript-range.spec.ts
+++ b/tests/unit/nicoscript-range.spec.ts
@@ -1,0 +1,413 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { FormattedComment } from "@/@types";
+import type { CommentInstanceContext } from "@/contexts";
+import { createNicoScripts, ImageCacheContext } from "@/contexts";
+import { defaultConfig, defaultOptions } from "@/definition/config";
+import { initConfig } from "@/definition/initConfig";
+import { EventHandler } from "@/eventHandler";
+import {
+  isBanActive,
+  isReverseActive,
+  parseCommandAndNicoScript,
+} from "@/utils/comment";
+import { RangeCacheContext } from "@/utils/rangeCache";
+
+const START_VPOS = 100;
+const LONG_COMMAND = "@2";
+const LAST_ACTIVE_VPOS = 299;
+const END_VPOS = 300;
+
+const createComment = (
+  overrides: Partial<FormattedComment> = {},
+): FormattedComment => ({
+  id: overrides.id ?? 1,
+  vpos: overrides.vpos ?? 0,
+  content: overrides.content ?? "test comment",
+  date: overrides.date ?? 1,
+  date_usec: overrides.date_usec ?? 0,
+  owner: overrides.owner ?? false,
+  premium: overrides.premium ?? false,
+  mail: overrides.mail ?? [],
+  user_id: overrides.user_id ?? 1,
+  layer: overrides.layer ?? -1,
+  is_my_post: overrides.is_my_post ?? false,
+});
+
+const createContext = (): CommentInstanceContext => {
+  initConfig();
+  return {
+    config: { ...defaultConfig },
+    options: { ...defaultOptions, mode: "html5" },
+    nicoScripts: createNicoScripts(),
+    imageCache: new ImageCacheContext(),
+    rangeCache: new RangeCacheContext(),
+  };
+};
+
+const parseScript = (
+  ctx: CommentInstanceContext,
+  content: string,
+  mail = [LONG_COMMAND],
+  vpos = START_VPOS,
+) => {
+  parseCommandAndNicoScript(
+    createComment({
+      id: 1,
+      vpos,
+      content,
+      owner: true,
+      mail,
+    }),
+    ctx,
+  );
+};
+
+const parseViewerContent = (
+  ctx: CommentInstanceContext,
+  vpos: number,
+  content: string,
+) => {
+  const comment = createComment({
+    id: vpos,
+    vpos,
+    content,
+    owner: false,
+  });
+  parseCommandAndNicoScript(comment, ctx);
+  return comment.content;
+};
+
+describe("NicoScript range boundaries", () => {
+  beforeEach(() => {
+    initConfig();
+  });
+
+  test("@デフォルト is active on [start, end)", () => {
+    const ctx = createContext();
+    parseScript(ctx, "@デフォルト", ["red", LONG_COMMAND]);
+
+    expect(
+      parseCommandAndNicoScript(
+        createComment({ vpos: START_VPOS - 1, content: "before" }),
+        ctx,
+      ).color,
+    ).toBe("#FFFFFF");
+    expect(
+      parseCommandAndNicoScript(
+        createComment({ vpos: START_VPOS, content: "start" }),
+        ctx,
+      ).color,
+    ).toBe("#FF0000");
+    expect(
+      parseCommandAndNicoScript(
+        createComment({ vpos: LAST_ACTIVE_VPOS, content: "last" }),
+        ctx,
+      ).color,
+    ).toBe("#FF0000");
+    expect(
+      parseCommandAndNicoScript(
+        createComment({ vpos: END_VPOS, content: "end" }),
+        ctx,
+      ).color,
+    ).toBe("#FFFFFF");
+  });
+
+  test("@置換 is active on [start, end)", () => {
+    const ctx = createContext();
+    parseScript(ctx, '@置換 "needle" "hit" 全 全');
+
+    expect(parseViewerContent(ctx, START_VPOS - 1, "needle before")).toBe(
+      "needle before",
+    );
+    expect(parseViewerContent(ctx, START_VPOS, "needle start")).toBe("hit");
+    expect(parseViewerContent(ctx, LAST_ACTIVE_VPOS, "needle last")).toBe(
+      "hit",
+    );
+    expect(parseViewerContent(ctx, END_VPOS, "needle end")).toBe("needle end");
+  });
+
+  test("@逆 is active on [start, end)", () => {
+    const ctx = createContext();
+    parseScript(ctx, "@逆 全");
+
+    expect(
+      isReverseActive(START_VPOS - 1, false, ctx.nicoScripts, ctx.rangeCache),
+    ).toBe(false);
+    expect(
+      isReverseActive(START_VPOS, false, ctx.nicoScripts, ctx.rangeCache),
+    ).toBe(true);
+    expect(
+      isReverseActive(LAST_ACTIVE_VPOS, false, ctx.nicoScripts, ctx.rangeCache),
+    ).toBe(true);
+    expect(
+      isReverseActive(END_VPOS, false, ctx.nicoScripts, ctx.rangeCache),
+    ).toBe(false);
+  });
+
+  test("@コメント禁止 is active on [start, end)", () => {
+    const ctx = createContext();
+    parseScript(ctx, "@コメント禁止");
+
+    expect(isBanActive(START_VPOS - 1, ctx.nicoScripts, ctx.rangeCache)).toBe(
+      false,
+    );
+    expect(isBanActive(START_VPOS, ctx.nicoScripts, ctx.rangeCache)).toBe(true);
+    expect(isBanActive(LAST_ACTIVE_VPOS, ctx.nicoScripts, ctx.rangeCache)).toBe(
+      true,
+    );
+    expect(isBanActive(END_VPOS, ctx.nicoScripts, ctx.rangeCache)).toBe(false);
+  });
+
+  test("@コメント禁止 and @シーク禁止 events enter at start and exit at end", () => {
+    const ctx = createContext();
+    parseScript(ctx, "@コメント禁止");
+    parseScript(ctx, "@シーク禁止");
+    const eventHandler = new EventHandler();
+    const commentDisable = vi.fn();
+    const commentEnable = vi.fn();
+    const seekDisable = vi.fn();
+    const seekEnable = vi.fn();
+    eventHandler.register("commentDisable", commentDisable);
+    eventHandler.register("commentEnable", commentEnable);
+    eventHandler.register("seekDisable", seekDisable);
+    eventHandler.register("seekEnable", seekEnable);
+
+    eventHandler.trigger(START_VPOS - 1, START_VPOS - 2, ctx.nicoScripts);
+
+    expect(commentDisable).not.toHaveBeenCalled();
+    expect(seekDisable).not.toHaveBeenCalled();
+
+    eventHandler.trigger(START_VPOS, START_VPOS - 1, ctx.nicoScripts);
+
+    expect(commentDisable).toHaveBeenCalledTimes(1);
+    expect(seekDisable).toHaveBeenCalledTimes(1);
+    expect(commentEnable).not.toHaveBeenCalled();
+    expect(seekEnable).not.toHaveBeenCalled();
+
+    eventHandler.trigger(LAST_ACTIVE_VPOS, START_VPOS, ctx.nicoScripts);
+
+    expect(commentDisable).toHaveBeenCalledTimes(1);
+    expect(seekDisable).toHaveBeenCalledTimes(1);
+    expect(commentEnable).not.toHaveBeenCalled();
+    expect(seekEnable).not.toHaveBeenCalled();
+
+    eventHandler.trigger(END_VPOS, LAST_ACTIVE_VPOS, ctx.nicoScripts);
+
+    expect(commentEnable).toHaveBeenCalledTimes(1);
+    expect(seekEnable).toHaveBeenCalledTimes(1);
+  });
+
+  test("@ジャンプ fires when entering [start, end) but not at exact end", () => {
+    const ctx = createContext();
+    parseScript(ctx, "@ジャンプ sm9 jump message");
+
+    for (const [vpos, expectedCalls] of [
+      [START_VPOS, 1],
+      [LAST_ACTIVE_VPOS, 1],
+      [END_VPOS, 0],
+    ] as const) {
+      const eventHandler = new EventHandler();
+      const jump = vi.fn();
+      eventHandler.register("jump", jump);
+
+      eventHandler.trigger(vpos, START_VPOS - 1, ctx.nicoScripts);
+
+      expect(jump).toHaveBeenCalledTimes(expectedCalls);
+      if (expectedCalls > 0) {
+        expect(jump).toHaveBeenCalledWith(
+          expect.objectContaining({ to: "sm9", message: "jump message" }),
+        );
+      }
+    }
+  });
+
+  test("zero-length optional ranges are inactive at their start vpos", () => {
+    const defaultCtx = createContext();
+    parseScript(defaultCtx, "@デフォルト", ["red", "@0"]);
+
+    expect(
+      parseCommandAndNicoScript(
+        createComment({ vpos: START_VPOS, content: "default zero" }),
+        defaultCtx,
+      ).color,
+    ).toBe("#FFFFFF");
+
+    const replaceCtx = createContext();
+    parseScript(replaceCtx, '@置換 "needle" "hit" 全 全', ["@0"]);
+
+    expect(parseViewerContent(replaceCtx, START_VPOS, "needle zero")).toBe(
+      "needle zero",
+    );
+
+    const jumpCtx = createContext();
+    parseScript(jumpCtx, "@ジャンプ sm9 zero", ["@0"]);
+    const eventHandler = new EventHandler();
+    const jump = vi.fn();
+    eventHandler.register("jump", jump);
+
+    eventHandler.trigger(START_VPOS, START_VPOS - 1, jumpCtx.nicoScripts);
+
+    expect(jump).not.toHaveBeenCalled();
+  });
+
+  test("@逆 respects viewer and owner targets inside [start, end)", () => {
+    const viewerCtx = createContext();
+    parseScript(viewerCtx, "@逆 コメ");
+
+    expect(
+      isReverseActive(
+        START_VPOS,
+        false,
+        viewerCtx.nicoScripts,
+        viewerCtx.rangeCache,
+      ),
+    ).toBe(true);
+    expect(
+      isReverseActive(
+        START_VPOS,
+        true,
+        viewerCtx.nicoScripts,
+        viewerCtx.rangeCache,
+      ),
+    ).toBe(false);
+    expect(
+      isReverseActive(
+        END_VPOS,
+        false,
+        viewerCtx.nicoScripts,
+        viewerCtx.rangeCache,
+      ),
+    ).toBe(false);
+
+    const ownerCtx = createContext();
+    parseScript(ownerCtx, "@逆 投コメ");
+
+    expect(
+      isReverseActive(
+        START_VPOS,
+        false,
+        ownerCtx.nicoScripts,
+        ownerCtx.rangeCache,
+      ),
+    ).toBe(false);
+    expect(
+      isReverseActive(
+        START_VPOS,
+        true,
+        ownerCtx.nicoScripts,
+        ownerCtx.rangeCache,
+      ),
+    ).toBe(true);
+    expect(
+      isReverseActive(
+        END_VPOS,
+        true,
+        ownerCtx.nicoScripts,
+        ownerCtx.rangeCache,
+      ),
+    ).toBe(false);
+  });
+
+  test("@コメント禁止 and @シーク禁止 events stay active across overlap and adjacency", () => {
+    const cases = [
+      ["overlap", 200, 400],
+      ["adjacent", END_VPOS, 500],
+    ] as const;
+
+    for (const [_label, secondStart, finalEnd] of cases) {
+      const ctx = createContext();
+      parseScript(ctx, "@コメント禁止");
+      parseScript(ctx, "@シーク禁止");
+      parseScript(ctx, "@コメント禁止", [LONG_COMMAND], secondStart);
+      parseScript(ctx, "@シーク禁止", [LONG_COMMAND], secondStart);
+      const eventHandler = new EventHandler();
+      const commentDisable = vi.fn();
+      const commentEnable = vi.fn();
+      const seekDisable = vi.fn();
+      const seekEnable = vi.fn();
+      eventHandler.register("commentDisable", commentDisable);
+      eventHandler.register("commentEnable", commentEnable);
+      eventHandler.register("seekDisable", seekDisable);
+      eventHandler.register("seekEnable", seekEnable);
+
+      eventHandler.trigger(START_VPOS, START_VPOS - 1, ctx.nicoScripts);
+      eventHandler.trigger(secondStart, secondStart - 1, ctx.nicoScripts);
+      eventHandler.trigger(END_VPOS, END_VPOS - 1, ctx.nicoScripts);
+
+      expect(commentDisable).toHaveBeenCalledTimes(1);
+      expect(seekDisable).toHaveBeenCalledTimes(1);
+      expect(commentEnable).not.toHaveBeenCalled();
+      expect(seekEnable).not.toHaveBeenCalled();
+
+      eventHandler.trigger(finalEnd, finalEnd - 1, ctx.nicoScripts);
+
+      expect(commentEnable).toHaveBeenCalledTimes(1);
+      expect(seekEnable).toHaveBeenCalledTimes(1);
+    }
+  });
+});
+
+describe("@置換 target semantics", () => {
+  beforeEach(() => {
+    initConfig();
+  });
+
+  const applyReplace = (
+    target: "コメ" | "投コメ" | "全" | "含む" | "含まない",
+    owner: boolean,
+    content: string,
+  ) => {
+    const ctx = createContext();
+    parseScript(ctx, `@置換 "needle" "hit" 全 ${target}`);
+    const comment = createComment({
+      id: owner ? 3 : 2,
+      vpos: START_VPOS,
+      content,
+      owner,
+    });
+
+    parseCommandAndNicoScript(comment, ctx);
+
+    return comment.content;
+  };
+
+  test.each([
+    ["コメ", false, "needle viewer", "hit"],
+    ["コメ", true, "needle owner", "needle owner"],
+    ["投コメ", false, "needle viewer", "needle viewer"],
+    ["投コメ", true, "needle owner", "hit"],
+    ["全", false, "needle viewer", "hit"],
+    ["全", true, "needle owner", "hit"],
+    ["含む", false, "needle viewer", "hit"],
+    ["含む", true, "needle owner", "hit"],
+    ["含む", false, "plain viewer", "plain viewer"],
+    ["含む", true, "plain owner", "plain owner"],
+    ["含まない", false, "needle viewer", "needle viewer"],
+    ["含まない", true, "needle owner", "needle owner"],
+    ["含まない", false, "plain viewer", "hit"],
+    ["含まない", true, "plain owner", "hit"],
+  ] as const)("%s target maps owner=%s content %j to %j", (target, owner, content, expected) => {
+    expect(applyReplace(target, owner, content)).toBe(expected);
+  });
+
+  test.each([
+    ["含む", "needle", "hit"],
+    ["含む", "needle plus", "needle plus"],
+    ["含まない", "needle", "needle"],
+    ["含まない", "needle plus", "hit"],
+  ] as const)("%s target honors 完全一致 for %j", (target, content, expected) => {
+    const ctx = createContext();
+    parseScript(ctx, `@置換 "needle" "hit" 全 ${target} 完全一致`);
+    const comment = createComment({
+      id: 4,
+      vpos: START_VPOS,
+      content,
+      owner: false,
+    });
+
+    parseCommandAndNicoScript(comment, ctx);
+
+    expect(comment.content).toBe(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- standardize NicoScript active intervals to [start, end) for default, replace, reverse, ban, seek-disable, and jump behavior
- fix @置換 target matching so 含まない applies to comments that do not match the keyword while コメ/投コメ/全/含む remain explicit
- add focused boundary and target-semantic unit coverage for NicoScript families

## Validation
- corepack pnpm exec vitest run tests/unit/nicoscript-range.spec.ts
- corepack pnpm exec vitest run tests/unit/nicoscript-range.spec.ts tests/unit/timeline.spec.ts tests/unit/duration-lazy.spec.ts tests/unit/renderer-draw-robustness.spec.ts
- corepack pnpm run check-types
- corepack pnpm run test:unit
- corepack pnpm run lint
- corepack pnpm run build
- corepack pnpm exec biome check src tests/unit/nicoscript-range.spec.ts
- git diff --check

## Review
- deep-review self-review pass completed with no actionable findings
- independent subagent final-diff review completed with no actionable findings

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR standardizes NicoScript range boundaries to exclusive-end `[start, end)` semantics across `@デフォルト`, `@置換`, `@逆`, `@コメント禁止`, `@シーク禁止`, and `@ジャンプ`, and fixes a longstanding bug in `@置換` target matching for `含まない`.

- **Range boundary fix**: Switches binary-search helpers from `lowerBoundStart` (exclusive start) to `upperBoundStart` (inclusive start), updates `getActiveRangeState` to activate ranges at `vpos == start` and deactivate at `vpos == end`, and adds `durationEndsAfter`/`isDurationRangeActive` helpers for duration-based ranges — bringing all scripts to consistent `[start, end)` behaviour.
- **Ban/SeekDisable event refactor**: `_processCommentDisable` and `_processSeekDisable` now use `hasActiveRange` edge-detection instead of iterating over individual transition ranges, so `commentDisable`/`commentEnable`/`seekDisable`/`seekEnable` fire at most once per state transition even when multiple overlapping ranges exist.
- **`含まない` fix**: Rewrites `nicoscriptReplaceIgnoreable` so `含まない` correctly applies to comments that do *not* match the keyword (previously it was incorrectly aliased to `コメ`-only behaviour), and owner comments are now treated consistently with the remaining targets.
</details>

<h3>Confidence Score: 5/5</h3>

The changes are internally consistent and well-tested; no regressions were found.

All three changed files carry low risk. The boundary-semantics corrections are validated at every meaningful vpos (start−1, start, last-active, end) across every affected script type. The ban/seekDisable event refactor correctly reduces multiple per-range firings to a single edge transition, confirmed by the overlap and adjacency test cases. The `含まない` rewrite is a clean re-implementation whose before/after table is fully enumerated in the parameterised tests. The exported public API is unchanged, and no shared types or interfaces in the related repositories are affected.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/eventHandler.ts | Renames lowerBoundStart → upperBoundStart (inclusive), adds hasActiveRange for edge detection, and refactors ban/seekDisable processing to fire events at most once per collective activation/deactivation transition. |
| src/utils/comment.ts | Adds TimedDuration type and isDurationRangeActive/durationEndsAfter helpers; corrects getActiveRangeState start/end boundary conditions; fixes nicoscriptReplaceIgnoreable to properly implement 含まない semantics for both viewer and owner comments. |
| tests/unit/nicoscript-range.spec.ts | New test file providing focused unit coverage of [start, end) boundary semantics, event transition behaviour, zero-length ranges, reverse/ban targets, overlap/adjacency, and all @置換 target×condition combinations. |

</details>

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["trigger(vpos, lastVpos)"] --> B["_processCommentDisable"]
    A --> C["_processSeekDisable"]
    A --> D["_processJump"]

    B --> E["hasActiveRange(ban, lastVpos)"]
    B --> F["hasActiveRange(ban, vpos)"]
    E & F --> G{{"wasActive → active?"}}
    G -- "false → true" --> H["fire commentDisable"]
    G -- "true → false" --> I["fire commentEnable"]
    G -- "no change" --> J["(no event)"]

    C --> K["hasActiveRange(seekDisable, lastVpos)"]
    C --> L["hasActiveRange(seekDisable, vpos)"]
    K & L --> M{{"wasActive → active?"}}
    M -- "false → true" --> N["fire seekDisable"]
    M -- "true → false" --> O["fire seekEnable"]

    D --> P["getTransitionRanges(jump, vpos, lastVpos)"]
    P --> Q["for each entered range: fire jump"]

    subgraph "hasActiveRange [start,end) check"
        R["upperBoundStart(sortedByStart, vpos): count ranges where start ≤ vpos"]
        S["upperBoundEnd(sortedByEnd, vpos): count ranges where end ≤ vpos"]
        R & S --> T["active = S_count > E_count"]
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["trigger(vpos, lastVpos)"] --> B["_processCommentDisable"]
    A --> C["_processSeekDisable"]
    A --> D["_processJump"]

    B --> E["hasActiveRange(ban, lastVpos)"]
    B --> F["hasActiveRange(ban, vpos)"]
    E & F --> G{{"wasActive → active?"}}
    G -- "false → true" --> H["fire commentDisable"]
    G -- "true → false" --> I["fire commentEnable"]
    G -- "no change" --> J["(no event)"]

    C --> K["hasActiveRange(seekDisable, lastVpos)"]
    C --> L["hasActiveRange(seekDisable, vpos)"]
    K & L --> M{{"wasActive → active?"}}
    M -- "false → true" --> N["fire seekDisable"]
    M -- "true → false" --> O["fire seekEnable"]

    D --> P["getTransitionRanges(jump, vpos, lastVpos)"]
    P --> Q["for each entered range: fire jump"]

    subgraph "hasActiveRange [start,end) check"
        R["upperBoundStart(sortedByStart, vpos): count ranges where start ≤ vpos"]
        S["upperBoundEnd(sortedByEnd, vpos): count ranges where end ≤ vpos"]
        R & S --> T["active = S_count > E_count"]
    end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["Address NicoScript review hook findings"](https://github.com/xpadev-net/niconicomments/commit/1222872708512fdcf2cab773728538fcecdd154e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37893421)</sub>

<!-- /greptile_comment -->