### PR TITLE
Harden release workflow and renderer clear

### DIFF
--- a/.github/workflows/release-create-release.yml
+++ b/.github/workflows/release-create-release.yml
@@ -14,12 +14,13 @@ on:
         default: 'patch'
 
 jobs:
-  create-release:
+  calculate-version:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
-      actions: write
+      contents: read
+    outputs:
+      base_sha: ${{ steps.base.outputs.sha }}
+      new_version: ${{ steps.version.outputs.new_version }}
 
     steps:
       - name: Checkout code
@@ -27,26 +28,11 @@ jobs:
         with:
           fetch-depth: 0
           ref: develop
+          persist-credentials: false
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
-        with:
-          version: 11
-          run_install: false
-
-      - name: Install Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
-        with:
-          node-version: 24
-          cache: 'pnpm'
-
-      - name: Configure Git
-        run: |
-          git config --global user.name 'GitHub Actions'
-          git config --global user.email 'actions@github.com'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Capture base revision
+        id: base
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - name: Calculate new version
         id: version
@@ -66,19 +52,92 @@ jobs:
           echo "New version: $new_version"
           echo "new_version=$new_version" >> $GITHUB_OUTPUT
 
-      - name: Update package.json version
+  create-release:
+    runs-on: ubuntu-latest
+    needs: calculate-version
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.calculate-version.outputs.base_sha }}
+          persist-credentials: false
+
+      - name: Configure Git
         run: |
-          pnpm version ${{ steps.version.outputs.new_version }} --no-git-tag-version
+          git config --global user.name 'GitHub Actions'
+          git config --global user.email 'actions@github.com'
+
+      - name: Update package.json version
+        env:
+          NEW_VERSION: ${{ needs.calculate-version.outputs.new_version }}
+        run: |
+          node <<'NODE'
+          const { readFileSync, writeFileSync } = require('node:fs');
+          const version = process.env.NEW_VERSION;
+          if (!/^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(version)) {
+            throw new Error(`Unsupported semver: ${version}`);
+          }
+
+          const packageJson = JSON.parse(readFileSync('package.json', 'utf8'));
+          packageJson.version = version;
+          writeFileSync('package.json', `${JSON.stringify(packageJson, null, 2)}\n`);
+
+          const replaceExpected = (path, pattern, replacement) => {
+            const content = readFileSync(path, 'utf8');
+            const matches = [...content.matchAll(pattern)];
+            if (matches.length !== 1) {
+              throw new Error(`${path}: expected exactly one version target, found ${matches.length}`);
+            }
+            writeFileSync(path, content.replace(pattern, replacement));
+          };
+
+          const packageCdnUrl = `https://cdn.jsdelivr.net/npm/@xpadev-net/niconicomments@${version}/dist/bundle.js`;
+          replaceExpected(
+            'README.md',
+            /https:\/\/cdn\.jsdelivr\.net\/npm\/@xpadev-net\/niconicomments@[^/"'<>]+\/dist\/bundle\.js/g,
+            packageCdnUrl,
+          );
+          replaceExpected(
+            'README.en.md',
+            /https:\/\/cdn\.jsdelivr\.net\/npm\/@xpadev-net\/niconicomments@[^/"'<>]+\/dist\/bundle\.js/g,
+            packageCdnUrl,
+          );
+          replaceExpected(
+            'docs/index.html',
+            /https:\/\/cdn\.jsdelivr\.net\/npm\/@xpadev-net\/niconicomments@[^/"'<>]+\/dist\/bundle\.js/g,
+            packageCdnUrl,
+          );
+          replaceExpected(
+            'docs/sample/sample.js',
+            /^const DEFAULT_NC_VERSION = "[^"]+";(\r?)$/m,
+            `const DEFAULT_NC_VERSION = "${version}";$1`,
+          );
+          replaceExpected(
+            'docs/sample/index.html',
+            /(<select name="nc-version" id="nc-version" autocomplete="off">\r?\n\s*)<option value="[^"]+">[^<]+<\/option>/,
+            `$1<option value="${version}">${version}</option>`,
+          );
+          NODE
           git add package.json pnpm-lock.yaml README.md README.en.md docs/index.html docs/sample/sample.js docs/sample/index.html
-          git commit -m "chore: bump version to v${{ steps.version.outputs.new_version }}"
-          git push origin develop
+          git commit -m "chore: bump version to v${{ needs.calculate-version.outputs.new_version }}"
+
+      - name: Push version bump
+        run: |
+          git -c "http.https://github.com/.extraheader=AUTHORIZATION: bearer ${GITHUB_TOKEN}" push origin HEAD:develop
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           
       - name: Create PR from develop to release
         id: create-pr
         run: |
           PR_URL=$(gh pr create --base master --head develop \
-            --title "Release v${{ steps.version.outputs.new_version }}" \
-            --body "## Release v${{ steps.version.outputs.new_version }}\n\nThis PR was automatically created by the release workflow.\n\nRelease type: ${{ github.event.inputs.release_type }}")
+            --title "Release v${{ needs.calculate-version.outputs.new_version }}" \
+            --body "## Release v${{ needs.calculate-version.outputs.new_version }}\n\nThis PR was automatically created by the release workflow.\n\nRelease type: ${{ github.event.inputs.release_type }}")
           echo "PR URL: $PR_URL"
           PR_NUMBER=$(echo $PR_URL | grep -o '[0-9]\+$')
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-create-release.yml
+++ b/.github/workflows/release-create-release.yml
@@ -114,16 +114,16 @@ jobs:
           );
           replaceExpected(
             'docs/sample/sample.js',
-            /^const DEFAULT_NC_VERSION = "[^"]+";(\r?)$/m,
+            /^const DEFAULT_NC_VERSION = "[^"]+";(\r?)$/gm,
             `const DEFAULT_NC_VERSION = "${version}";$1`,
           );
           replaceExpected(
             'docs/sample/index.html',
-            /(<select name="nc-version" id="nc-version" autocomplete="off">\r?\n\s*)<option value="[^"]+">[^<]+<\/option>/,
+            /(<select name="nc-version" id="nc-version" autocomplete="off">\r?\n\s*)<option value="[^"]+">[^<]+<\/option>/g,
             `$1<option value="${version}">${version}</option>`,
           );
           NODE
-          git add package.json pnpm-lock.yaml README.md README.en.md docs/index.html docs/sample/sample.js docs/sample/index.html
+          git add package.json README.md README.en.md docs/index.html docs/sample/sample.js docs/sample/index.html
           git commit -m "chore: bump version to v${{ needs.calculate-version.outputs.new_version }}"
 
       - name: Push version bump
@@ -136,12 +136,14 @@ jobs:
         id: create-pr
         run: |
           PR_URL=$(gh pr create --base master --head develop \
-            --title "Release v${{ needs.calculate-version.outputs.new_version }}" \
-            --body "## Release v${{ needs.calculate-version.outputs.new_version }}\n\nThis PR was automatically created by the release workflow.\n\nRelease type: ${{ github.event.inputs.release_type }}")
+            --title "Release v${NEW_VERSION}" \
+            --body "## Release v${NEW_VERSION}\n\nThis PR was automatically created by the release workflow.\n\nRelease type: ${RELEASE_TYPE}")
           echo "PR URL: $PR_URL"
           PR_NUMBER=$(echo $PR_URL | grep -o '[0-9]\+$')
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_VERSION: ${{ needs.calculate-version.outputs.new_version }}
+          RELEASE_TYPE: ${{ github.event.inputs.release_type }}
 
       # GitHub release will only be created after the PR is merged manually

--- a/src/main.ts
+++ b/src/main.ts
@@ -123,8 +123,10 @@ const rendererHasVideoSurface = (renderer: IRenderer) =>
   "video" in renderer &&
   (renderer as IRenderer & { readonly video?: unknown }).video != null;
 
-const getRendererClear = (renderer: IRenderer) =>
-  (renderer as IRenderer & { clear?: () => void }).clear;
+const getRendererClear = (renderer: IRenderer): (() => void) | undefined => {
+  const clear = (renderer as IRenderer & { clear?: unknown }).clear;
+  return typeof clear === "function" ? (clear as () => void) : undefined;
+};
 
 const removeUndefinedConfigValues = (
   config: NonNullable<Options["config"]>,

--- a/tests/unit/canvas-renderer-clear.spec.ts
+++ b/tests/unit/canvas-renderer-clear.spec.ts
@@ -192,6 +192,34 @@ describe("CanvasRenderer.clearRect", () => {
     ]);
   });
 
+  test("falls back to clearRect when a custom renderer has a non-function clear property", () => {
+    if (!("HTMLCanvasElement" in globalThis)) {
+      Object.defineProperty(globalThis, "HTMLCanvasElement", {
+        configurable: true,
+        value: class HTMLCanvasElement {},
+      });
+    }
+    const { context, renderer } = createRenderer();
+    Object.defineProperty(renderer, "clear", {
+      configurable: true,
+      value: true,
+    });
+    const flush = vi.spyOn(renderer, "flush");
+    const niconiComments = new NiconiComments(renderer, [], {
+      format: "formatted",
+    });
+    context.calls = [];
+
+    expect(() => niconiComments.clear()).not.toThrow();
+    expect(context.calls).toEqual([
+      "save",
+      "setTransform(1,0,0,1,0,0)",
+      "clearRect(0,0,213.33333333333331,120)",
+      "restore",
+    ]);
+    expect(flush).toHaveBeenCalledTimes(1);
+  });
+
   test("draws padded sub-renderers without shifting their content origin", () => {
     const { context, renderer } = createRenderer();
     const { renderer: image } = createRenderer(4);


### PR DESCRIPTION
## Summary
- split release version calculation into a read-only job and remove dependency/package lifecycle execution from the release workflow
- keep checkout credentials out of git config and push with an explicit token only at the push step
- make NiconiComments.clear call renderer.clear only when it is a function, with clearRect+flush fallback coverage

## Validation
- pnpm vitest run tests/unit/canvas-renderer-clear.spec.ts --hideSkippedTests
- pnpm run check-types
- pnpm exec biome check src/main.ts tests/unit/canvas-renderer-clear.spec.ts
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release-create-release.yml'); puts 'ok'"
- git diff --check

## Review
- Subagent workflow/security review: NO_FINDINGS after iteration
- Subagent TS/API/test review: NO_FINDINGS after iteration

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR hardens the release workflow by splitting it into a read-only `calculate-version` job and a write-capable `create-release` job, and fixes a type-safety bug in `NiconiComments.clear` where a non-function `clear` property on a custom renderer would cause a `TypeError`.

- **Workflow split**: `calculate-version` runs with `contents: read` only and captures both the version and base SHA as job outputs; `create-release` checks out that exact SHA, applies all file updates via an inline Node.js script, then pushes with a token injected only at the `git push` step — credentials never stored in git config.
- **`getRendererClear` hardening**: The helper now guards `typeof clear === \"function\"` before returning it, so renderers that accidentally expose a non-callable `clear` property fall through to the `clearRect`/`flush` fallback rather than throwing at call time.
- **Test coverage**: A new unit test exercises the non-function `clear` property path, confirming `clearRect`/`flush` runs without error.
</details>

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are well-scoped, the previously flagged issues (non-global regex flags, stale pnpm-lock.yaml staging) are addressed, and the TypeScript fix has direct test coverage.

The workflow restructuring is conservative: credentials are narrowed to the exact steps that need them, the TOCTOU window is handled correctly by pinning a base SHA across jobs, and the inline Node.js script uses global regex flags consistently so matchAll will not throw. The getRendererClear type guard is a minimal, correct fix for a real call-time crash path, and the new unit test directly exercises the fallback branch.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-create-release.yml | Job split into read-only version calculation and write-capable release creation; credentials handled via per-command git -c instead of persist-credentials; inline Node.js script replaces pnpm version with proper regex guards (all patterns now carry the g flag, addressing the previously flagged matchAll issue); pnpm-lock.yaml correctly removed from git add. |
| src/main.ts | getRendererClear now performs a typeof === "function" check before returning the clear accessor, preventing a TypeError when a renderer exposes a truthy but non-callable clear property. |
| tests/unit/canvas-renderer-clear.spec.ts | New test validates clearRect+flush fallback when renderer.clear is a non-function (boolean true); assertions cover both the canvas call sequence and the flush invocation count. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/dev..."](https://github.com/xpadev-net/niconicomments/commit/113a0b75da31808c9f1528c9acbba45f8095029f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38772299)</sub>

<!-- /greptile_comment -->