### PR TITLE
[codex] Fix release workflow push auth

### DIFF
--- a/.github/workflows/release-create-release.yml
+++ b/.github/workflows/release-create-release.yml
@@ -128,7 +128,8 @@ jobs:
 
       - name: Push version bump
         run: |
-          git -c "http.https://github.com/.extraheader=AUTHORIZATION: bearer ${GITHUB_TOKEN}" push origin HEAD:develop
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git push origin HEAD:develop
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           


### PR DESCRIPTION
## Summary
- Fix the release workflow's version-bump push authentication.
- Replace the manual `http.extraheader` push with the repository's existing `x-access-token:${GITHUB_TOKEN}` remote URL pattern.

## Root Cause
The release job checks out with `persist-credentials: false`, so checkout removes its temporary Git credentials. The later `git -c http.https://github.com/.extraheader=AUTHORIZATION: bearer ... push` did not authenticate the Git HTTPS push, causing `fatal: could not read Username for 'https://github.com'`.

## Validation
- Parsed `.github/workflows/release-create-release.yml` with Ruby YAML loader.
- Ran `git diff --check`.

## Notes
`pnpm exec prettier --check .github/workflows/release-create-release.yml` was attempted, but this repository's `pnpm-workspace.yaml` currently causes `packages field missing or empty`, so it could not be used as validation for this YAML-only change.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates the release workflow push authentication. The main changes are:

- Sets `origin` to an authenticated `x-access-token` GitHub URL.
- Pushes the version-bump commit to `develop` with a normal `git push`.
- Keeps the existing `GITHUB_TOKEN` environment wiring for the push step.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The job already grants write access for the version-bump push.
- The checkout step still provides an `origin` remote for `git remote set-url`.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-create-release.yml | Changes the release job's version-bump push to authenticate through the `origin` remote URL before pushing to `develop`. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix release workflow push auth"](https://github.com/xpadev-net/niconicomments/commit/429277d9bc94d3b0c9f225f6e4b0192e368547ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41807447)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/xpa/github/xpadev-net/niconicomments/-/custom-context?memory=aa0ade2c-f87c-4416-ac50-e2b011bdabee))

<!-- /greptile_comment -->