### PR TITLE
[codex] Fix release tag target

### DIFF
--- a/.github/workflows/release-publish-package.yml
+++ b/.github/workflows/release-publish-package.yml
@@ -47,6 +47,10 @@ jobs:
     permissions:
       contents: write # Create the GitHub release for the published ref.
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
       - name: Validate release ref
         run: |
           if [ "${GITHUB_REF}" != "refs/heads/master" ]; then
@@ -54,11 +58,24 @@ jobs:
             exit 1
           fi
 
+      - name: Resolve release tag
+        id: release-meta
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ ! "${VERSION}" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+            echo "::error::Unsupported package version ${VERSION}"
+            exit 1
+          fi
+
+          echo "tag=v${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "name=Release v${VERSION}" >> "${GITHUB_OUTPUT}"
+
       - name: Create GitHub release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b
         with:
-          tag_name: ${{ github.ref_name }}
-          name: Release ${{ github.ref_name }}
+          tag_name: ${{ steps.release-meta.outputs.tag }}
+          name: ${{ steps.release-meta.outputs.name }}
+          target_commitish: ${{ github.sha }}
           draft: false
           prerelease: false
           generate_release_notes: true


### PR DESCRIPTION
## Summary
- Resolve the GitHub release tag from package.json instead of github.ref_name.
- Set target_commitish to the pushed commit SHA so releases are tied to the published commit.

## Root cause
The publish workflow runs on master pushes, so github.ref_name resolves to master. Passing that value to softprops/action-gh-release can create or target a release from the branch name instead of the package version tag.

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-publish-package.yml"); puts "yaml ok"'\n- git diff --check\n- bash release tag resolution check using package.json version\n\n## Notes\n- actionlint was not available in this environment.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes how the publish workflow names GitHub releases. The main changes are:

- Adds a checkout step before release metadata is read.
- Resolves the release tag and name from `package.json` version.
- Sets `target_commitish` to the pushed commit SHA.
</details>

<h3>Confidence Score: 4/5</h3>

The changed workflow is mostly safe, but repeated release versions can leave release metadata pointing at an old tag commit.

- The new tag is derived from `package.json`, which fixes the branch-name release issue.
- `target_commitish` only affects new tags, so an existing `v<VERSION>` tag can keep pointing at its original commit.
- The normal version-bump flow reduces the chance of this path, but the workflow does not guard against it.

.github/workflows/release-publish-package.yml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-publish-package.yml | Updates the release job to derive the GitHub release tag from `package.json` and target the pushed commit; repeated use of an existing version tag can still update release metadata without moving the tag. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0A.github%2Fworkflows%2Frelease-publish-package.yml%3A76%0A**Existing%20Tags%20Keep%20Old%20Commits**%0A%0AWhen%20%60package.json%60%20keeps%20a%20version%20that%20already%20has%20a%20Git%20tag%2C%20%60action-gh-release%60%20updates%20the%20existing%20release%20for%20%60v%3CVERSION%3E%60%20but%20does%20not%20move%20that%20tag%20to%20%60github.sha%60.%20The%20release%20name%20and%20notes%20can%20be%20refreshed%20for%20the%20new%20master%20push%20while%20downloads%20and%20the%20release%20commit%20still%20point%20at%20the%20old%20tagged%20commit.%0A%0A&repo=xpadev-net%2Fniconicomments&pr=386&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/release-publish-package.yml:76
**Existing Tags Keep Old Commits**

When `package.json` keeps a version that already has a Git tag, `action-gh-release` updates the existing release for `v<VERSION>` but does not move that tag to `github.sha`. The release name and notes can be refreshed for the new master push while downloads and the release commit still point at the old tagged commit.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix release tag target"](https://github.com/xpadev-net/niconicomments/commit/046f5dad92ccda8a0b99b344c02e4220bf8c25db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41811402)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/xpa/github/xpadev-net/niconicomments/-/custom-context?memory=aa0ade2c-f87c-4416-ac50-e2b011bdabee))

<!-- /greptile_comment -->