### PR TITLE
異なる表示時間のコメントが中央で重なる問題を修正

### DIFF
--- a/docs/coding-agent/lessons.md
+++ b/docs/coding-agent/lessons.md
@@ -1,0 +1,47 @@
+# Lessons Log (Coding Agent)
+
+Purpose:
+- capture recurring mistakes and the prevention mechanism
+- enable “read once, don’t repeat” improvements
+
+## How to use
+- Append a new entry after any user correction or significant miss.
+- Keep entries short and actionable.
+- Promote repeated/high-severity lessons into repo rules, harness migration candidates, troubleshooting notes, or accepted residual-risk records.
+
+## Tags (recommended)
+- planning
+- validation
+- delegation
+- review
+- ui-e2e
+- tooling
+- ci
+- scope-owns
+
+## Entries
+
+## 2026-07-16 — Derive relative-coordinate signs before changing asymmetric bounds  [tags: review, validation]
+
+Context:
+- Plan: `docs/coding-agent/plans/active/mixed-duration-collision-review-fixes-plan.md`
+- Task/Wave: Task_1 / Wave 1
+- Roles involved: Orchestrator | Worker
+
+Symptom:
+- The first unequal-width fix swapped the two width bounds without also correcting the sign of the relative-coordinate expression.
+
+Root cause:
+- The inequality was reviewed from its helper name and hook description without expanding the rendering equation `left = initialLeft - displacement` and checking operand order.
+
+Fix applied:
+- Renamed and inverted the helper to explicitly compute candidate left minus comment left, then added an asymmetric regression case that fails when the sign is inverted.
+
+Prevention:
+- Dispatch/plan guardrail:
+  - For asymmetric geometry bounds, derive the relative quantity from the rendering equation, encode operand order in the helper name, and require a sign-sensitive asymmetric regression before integration.
+- Residual risk / waiver:
+  - none
+
+Evidence:
+- Focused movable-collision tests pass 10/10, including widths 200/20 with asymmetric start times; TypeScript and Biome checks pass.

--- a/docs/coding-agent/plans/completed/mixed-duration-collision-plan.md
+++ b/docs/coding-agent/plans/completed/mixed-duration-collision-plan.md
@@ -1,0 +1,153 @@
+# Plan: Mixed-duration movable comment collision detection
+
+- status: done
+- generated: 2026-07-15
+- last_updated: 2026-07-15
+- work_type: code
+
+## Goal
+- Prevent movable comments with different normalized durations from overlapping between the existing left/right collision lines while preserving the current fast path for equal-duration comments.
+
+## Definition of Done
+- Equal-`long` pairs retain the existing left/right collision behavior.
+- Different-`long` pairs are separated when their continuous horizontal trajectories intersect during their shared active interval.
+- Public types and exported function signatures remain unchanged.
+- Required correctness, performance, build, and visual validations pass and an independent Reviewer approves the change.
+
+## Scope / Non-goals
+- Scope: movable `naka` comment positioning, targeted unit coverage, and collision benchmarks.
+- Non-goals: changing fixed comment placement, `@逆` semantics, public configuration, or public collision types.
+
+## Context (workspace)
+- Related files/areas: `src/utils/comment.ts`, `tests/unit/`, `tests/bench/collision.bench.ts`.
+- Existing pattern: speed is derived from width and normalized `long`; collision placement currently samples occupancy at two vertical lines.
+- Repo reference docs consulted: repository rule suite absent; validation inferred from `package.json` and `.github/workflows/`.
+
+## Open Questions (max 3)
+- None.
+
+## Assumptions
+- Normalized `comment.long`, not computed pixel velocity, selects the fast path.
+- Missing `@` and `@3` both normalize to `300` and use the existing path.
+- Existing reverse-direction collision semantics remain unchanged.
+
+## Tasks
+
+### Task_1: Implement hybrid movable collision detection
+- type: impl
+- owns:
+  - `src/utils/comment.ts`
+- depends_on: []
+- description: |
+  Add a private, collision-instance-scoped temporal candidate index. Keep existing left/right placement for equal-duration comments and add analytic shared-interval trajectory collision checks only for different-duration candidates.
+- acceptance:
+  - Same-`long` candidates do not enter the analytic full-interval path.
+  - Different-`long` candidates that overlap horizontally anywhere in their shared active interval participate in vertical placement.
+  - Candidate lookup avoids all-comment scans by using 100-centisecond temporal buckets with per-comment deduplication.
+  - Existing collision padding, owner/layer filtering, lazy reprocessing, timeline population, collision visualization buckets, and `addComments()` behavior remain intact.
+  - No exported signature or public type changes.
+- validation:
+  - kind: command
+    required: true
+    owner: worker
+    detail: `pnpm check-types`
+  - kind: review
+    required: true
+    owner: reviewer
+    detail: Review analytic interval correctness, hot-path behavior, index lifetime, and public API compatibility.
+
+### Task_2: Add regression and performance coverage
+- type: test
+- owns:
+  - `tests/unit/movable-collision.spec.ts`
+  - `tests/bench/collision.bench.ts`
+- depends_on: [Task_1]
+- description: |
+  Add focused regression cases for mixed durations and benchmark equal-duration and dense mixed-duration workloads.
+- acceptance:
+  - A slow short leading comment and later normal comment that meet only in the center are placed on different rows.
+  - Different-duration trajectories that do not intersect may share a row.
+  - Equal-duration, default-versus-`@3`, owner/layer, lazy reprocessing, and dynamic-order cases preserve expected behavior.
+  - Benchmarks cover 1000 equal-duration comments and 1000 dense mixed-duration comments.
+- validation:
+  - kind: command
+    required: true
+    owner: worker
+    detail: `pnpm test:unit` with a positive executed-test count.
+  - kind: performance
+    required: true
+    owner: orchestrator
+    detail: Compare collision benchmark results across five comparable runs; equal-duration median regression must be <=10%, mixed-duration must remain <=2x baseline.
+
+### Task_3: Independent review and visual acceptance
+- type: review
+- owns: []
+- depends_on: [Task_1, Task_2]
+- description: |
+  Independently review the diff, run required repository checks, and visually validate the mixed-duration scenario.
+- acceptance:
+  - Reviewer status is APPROVED.
+  - Required command checks pass.
+  - Required visual artifact exists and shows separate rows at the center-intersection timestamp.
+- validation:
+  - kind: command
+    required: true
+    owner: reviewer
+    detail: `pnpm check-types`, `pnpm test:unit`, `pnpm lint`, and `pnpm build`.
+  - kind: e2e
+    required: true
+    owner: reviewer
+    detail: Run the E2E specification below and verify the artifact on disk.
+
+## Task Waves (explicit parallel dispatch sets)
+- Wave 1 (parallel): [Task_1]
+- Wave 2 (parallel): [Task_2]
+- Wave 3 (parallel): [Task_3]
+
+## E2E / Visual Validation Spec
+- provider: playwright-cli
+- artifact_root: `.playwright-cli`
+- base_url: `http://127.0.0.1:8080`
+- app_start_command: `pnpm build`, then `pnpm test-server -- -p 8080`
+- readiness_check: `http://127.0.0.1:8080/docs/sample/test.html?video=-1&time=0` returns and `#loaded` appears.
+- flows: Inject a deterministic `@10` short leading comment plus a later default-duration comment into the sample canvas, draw at their center-intersection timestamp, and confirm they occupy separate rows.
+- viewports: desktop 1920x1080.
+- evidence_requirements: `.playwright-cli/mixed-duration-collision.png`, no console errors, and no failed local asset requests.
+- known_flakiness: Wait for BrowserSync notification detachment before capture.
+
+## Rollback / Safety
+- Revert the implementation and its focused tests; no persisted data, migrations, or public contracts are involved.
+
+## Progress Log (append-only)
+- 2026-07-15 15:45 Plan approved and execution started.
+  - Summary: User approved the hybrid `long`-based strategy.
+  - Validation evidence: Baseline `pnpm check-types` and `pnpm test:unit` passed before execution.
+  - Notes: Repository rule suite is absent; existing untracked `.serena/` is preserved.
+- 2026-07-15 16:05 Wave 1 completed: [Task_1].
+  - Summary: Added a private Collision-keyed 100-centisecond temporal index and analytic mixed-duration trajectory checks in the existing fixed-point placement loop.
+  - Validation evidence: Worker `pnpm check-types`, file-scoped Biome check, and orchestrator scope/diff inspection passed.
+  - Notes: Only `src/utils/comment.ts` changed; public exports and signatures remain unchanged; no blockers or rule candidates.
+- 2026-07-15 16:25 Wave 2 completed: [Task_2].
+  - Summary: Added eight focused movable-collision regression tests and explicit 1000-comment equal/mixed-duration benchmarks.
+  - Validation evidence: Focused 8/8, full unit suite 197/197, `pnpm check-types`, file-scoped Biome, and benchmark smoke passed. Five-run medians: equal-duration baseline 32.8791ms versus current 32.8042ms (-0.23%); mixed-duration baseline 39.5354ms versus current 60.3396ms (1.53x).
+  - Notes: Performance gates passed. The initial non-intersection fixture also hit the legacy sampled line and was corrected without a plan or scope change; no durable rule promotion is needed.
+- 2026-07-15 16:45 Wave 3 completed: [Task_3].
+  - Summary: Independent deep review found no findings and returned APPROVED after command and visual validation.
+  - Validation evidence: Reviewer `pnpm check-types`, 197/197 unit tests, `pnpm lint`, and `pnpm build` passed. `.playwright-cli/mixed-duration-collision.png` is a readable 1920x1084 PNG showing separate rows; positions were 0 and 92.3174 with no console errors or failed requests.
+  - Notes: The existing Playwright Firefox suite could not launch reliably in this environment, so the required deterministic browser flow was completed with installed headless Chromium against the same built bundle; no source or snapshot files were changed for the probe.
+
+## Decision Log (append-only; re-plans and major discoveries)
+- 2026-07-15 15:45 Decision: use normalized `comment.long` as the fast-path discriminator.
+  - Trigger / new insight: Computed pixel speed also varies with comment width, so speed equality would route normal comments into the expensive path.
+  - Plan delta (what changed): Analytic full-interval checks apply only to different normalized durations.
+  - Tradeoffs considered: Full scanning, adding a center point, and targeted duration-based analytic checks.
+  - User approval: yes.
+- 2026-07-15 16:45 Decision: complete the deterministic visual flow with installed headless Chromium.
+  - Trigger / new insight: The configured Firefox runner and initial standalone Firefox/Chromium attempts could not complete in the sandbox, while a minimal same-origin Chromium probe was reliable.
+  - Plan delta (what changed): The same 1920x1080 flow and artifact requirements were executed through the local Playwright library instead of the `playwright-cli` wrapper.
+  - Tradeoffs considered: Waiving visual evidence versus preserving the required flow with an equivalent local browser engine.
+  - User approval: no; Orchestrator-approved validation-provider substitution with equivalent evidence and independent Reviewer approval.
+
+## Notes
+- Risks: hot-path allocations, candidate-index lifetime, fixed-point interaction between legacy and analytic collisions, and accidental public declaration changes.
+- Edge cases: equal normalized duration, no shared active interval, coincident trajectories, lazy reprocessing, owner/layer separation, and comments wider than the canvas.

--- a/docs/coding-agent/plans/completed/mixed-duration-collision-review-fixes-plan.md
+++ b/docs/coding-agent/plans/completed/mixed-duration-collision-review-fixes-plan.md
@@ -1,0 +1,119 @@
+# Plan: Mixed-duration collision review fixes
+
+- status: done
+- generated: 2026-07-16
+- last_updated: 2026-07-16
+- work_type: code
+
+## Goal
+- Resolve every actionable finding from the first `gh-review-hook` run for PR #392 without regressing the existing same-speed fast path.
+
+## Definition of Done
+- Unequal-width trajectory overlap uses the correct comment width on each relative-position boundary.
+- Mixed-duration trajectories are compared only while both comments intersect the configured collision judgment region.
+- Per-comment invariant trajectory values are not recomputed for every candidate.
+- Focused unit tests, type checking, formatting/lint checks, independent review, commit, push, and a new blocking `gh-review-hook` run succeed.
+
+## Scope / Non-goals
+- Scope: mixed-duration movable-comment trajectory intersection and its focused regression tests.
+- Non-goals: changing fixed-comment behavior, replacing the existing same-duration fast path, or redesigning row allocation.
+
+## Context (workspace)
+- Related files/areas: `src/utils/comment.ts`, `tests/unit/movable-collision.spec.ts`.
+- Existing patterns or references: existing movable-comment position formula and `config.collisionRange` boundary checks.
+- Repo reference docs consulted: root `AGENTS.md`; no repository rule suite is present.
+
+## Open Questions (max 3)
+- None.
+
+## Assumptions
+- The collision judgment region contains a comment while its rectangle intersects the interval from `collisionRange.left` to `collisionRange.right`, including configured collision padding on its trailing edge.
+- Existing repository scripts remain the canonical local validation commands for this TypeScript-only change.
+
+## Tasks
+
+### Task_1: Correct mixed-duration trajectory intersection
+- type: impl
+- owns:
+  - src/utils/comment.ts
+  - tests/unit/movable-collision.spec.ts
+- depends_on: []
+- description: |
+  Fix the relative-width boundaries, clip trajectory comparison to the collision judgment region, hoist invariant values from the candidate loop, and add focused behavioral regression tests.
+- acceptance:
+  - Relative-position upper and lower bounds use the geometrically correct comment widths.
+  - Trajectories that overlap only outside the configured collision judgment region do not consume separate rows.
+  - Mixed-duration comments that intersect inside the judgment region still collide.
+  - Invariant range and speed values for the current comment are computed once per placement attempt.
+- validation:
+  - kind: command
+    required: true
+    owner: worker
+    detail: "Run the focused movable-collision unit test file and report a positive executed-test count."
+  - kind: command
+    required: true
+    owner: worker
+    detail: "Run repository TypeScript type checking."
+  - kind: command
+    required: true
+    owner: worker
+    detail: "Run repository formatting/lint validation for changed files."
+
+### Task_2: Independently review the review-hook fixes
+- type: review
+- owns: []
+- depends_on: [Task_1]
+- description: |
+  Review the integrated diff for collision geometry, range clipping, hot-path cost, and regression-test coverage.
+- acceptance:
+  - No correctness issue remains in relative-position bounds or collision-region timing.
+  - Existing same-duration behavior remains unchanged.
+  - Focused tests cover both a collision inside the judgment region and a non-collision outside it.
+- validation:
+  - kind: review
+    required: true
+    owner: reviewer
+    detail: "Perform read-only diff review against the acceptance criteria and report APPROVED or actionable findings."
+
+## Task Waves (explicit parallel dispatch sets)
+
+- Wave 1 (parallel): [Task_1]
+- Wave 2 (parallel): [Task_2]
+
+## Rollback / Safety
+- Revert the new follow-up commit; do not rewrite branch history or force push because PR #392 is open.
+
+## Progress Log (append-only)
+
+- 2026-07-16 00:00 Plan started.
+  - Summary: Recorded the three actionable findings from the first `gh-review-hook` run.
+  - Validation evidence: `gh-review-hook` exited 2 after all CI checks passed.
+  - Notes: Research dispatch waived because the hook supplied exact code anchors and expected behavior.
+
+- 2026-07-16 01:58 Wave 1 completed: [Task_1]
+  - Summary: Corrected collision-region clipping, relative-coordinate sign and unequal-width bounds, and hoisted current-comment invariants.
+  - Validation evidence: Focused Vitest 10/10, TypeScript check, Biome check, and diff whitespace check passed.
+  - Notes: Initial integration review caught a relative-coordinate sign mismatch; the helper and asymmetric regression were corrected before Reviewer dispatch. Worker process cleanup is unavailable in this runtime after completion.
+
+- 2026-07-16 02:02 Wave 2 completed: [Task_2]
+  - Summary: Independent read-only review approved the collision geometry, region clipping, unchanged fast path, hot-path cost, and regression coverage.
+  - Validation evidence: Reviewer reran focused Vitest 10/10, TypeScript check, Biome check, and `git diff --check`; all passed.
+  - Notes: No actionable findings. Reviewer process cleanup is unavailable in this runtime after completion.
+
+## Decision Log (append-only; re-plans and major discoveries)
+
+- 2026-07-16 00:00 Decision: Handle all findings as one bounded collision-geometry change.
+  - Trigger / new insight: Width bounds, region clipping, and invariant calculation affect the same trajectory-intersection path.
+  - Plan delta (what changed): Added focused implementation/testing and independent review tasks.
+  - Tradeoffs considered: Separate commits would split one mathematical invariant across dependent changes.
+  - User approval: yes; the user requested repeated fixes through a clean hook result.
+
+- 2026-07-16 01:58 Decision: Express the relative coordinate as candidate left minus comment left.
+  - Trigger / new insight: The first bound-only correction used the opposite sign from the helper's actual displacement expression.
+  - Plan delta (what changed): Inverted and renamed the helper and strengthened the regression with asymmetric widths and start times.
+  - Tradeoffs considered: Reverting to the old bounds would be mathematically equivalent but would not align the helper name and hook finding with the rendered coordinate definition.
+  - User approval: yes; this remains within the requested review-fix loop.
+
+## Notes
+- Risks: Off-by-one behavior at region boundaries and accidental changes to the same-duration fast path.
+- Edge cases: Unequal widths, unequal durations, overlap only before region entry, and overlap at a judgment boundary.

--- a/src/utils/comment.ts
+++ b/src/utils/comment.ts
@@ -210,6 +210,31 @@ const getMovableCommentActiveRange = (comment: IComment) => ({
   end: comment.vpos + comment.long + 125,
 });
 
+const getMovableCommentCollisionRange = (
+  comment: IComment,
+  activeRange: ReturnType<typeof getMovableCommentActiveRange>,
+  config: BaseConfig,
+  speed: number,
+) => {
+  const initialLeft = config.commentDrawPadding + config.commentDrawRange;
+  return {
+    start: Math.max(
+      activeRange.start,
+      comment.vpos - 100 + (initialLeft - config.collisionRange.right) / speed,
+    ),
+    end: Math.min(
+      activeRange.end,
+      comment.vpos -
+        100 +
+        (initialLeft +
+          comment.width +
+          config.collisionPadding -
+          config.collisionRange.left) /
+          speed,
+    ),
+  };
+};
+
 const forEachMovableCollisionBucket = (
   comment: IComment,
   callback: (bucket: number) => void,
@@ -242,34 +267,43 @@ const registerMovableCollisionComment = (
 
 const doMovableTrajectoriesIntersect = (
   comment: IComment,
+  commentCollisionRange: ReturnType<typeof getMovableCommentCollisionRange>,
+  commentSpeed: number,
   candidate: IComment,
   config: BaseConfig,
 ) => {
-  const commentRange = getMovableCommentActiveRange(comment);
-  const candidateRange = getMovableCommentActiveRange(candidate);
-  const sharedStart = Math.max(commentRange.start, candidateRange.start);
-  const sharedEnd = Math.min(commentRange.end, candidateRange.end);
-  if (sharedStart >= sharedEnd) return false;
-
-  const commentSpeed =
-    (config.commentDrawRange + comment.width * config.nakaCommentSpeedOffset) /
-    (comment.long + 100);
   const candidateSpeed =
     (config.commentDrawRange +
       candidate.width * config.nakaCommentSpeedOffset) /
     (candidate.long + 100);
-  const getRelativeLeft = (vpos: number) =>
-    (vpos - candidate.vpos + 100) * candidateSpeed -
-    (vpos - comment.vpos + 100) * commentSpeed;
-  const relativeAtStart = getRelativeLeft(sharedStart);
-  const relativeAtEnd = getRelativeLeft(sharedEnd);
+  const candidateCollisionRange = getMovableCommentCollisionRange(
+    candidate,
+    getMovableCommentActiveRange(candidate),
+    config,
+    candidateSpeed,
+  );
+  const sharedStart = Math.max(
+    commentCollisionRange.start,
+    candidateCollisionRange.start,
+  );
+  const sharedEnd = Math.min(
+    commentCollisionRange.end,
+    candidateCollisionRange.end,
+  );
+  if (sharedStart >= sharedEnd) return false;
+
+  const getCandidateLeftRelativeToComment = (vpos: number) =>
+    (vpos - comment.vpos + 100) * commentSpeed -
+    (vpos - candidate.vpos + 100) * candidateSpeed;
+  const relativeAtStart = getCandidateLeftRelativeToComment(sharedStart);
+  const relativeAtEnd = getCandidateLeftRelativeToComment(sharedEnd);
   const minRelativeLeft = Math.min(relativeAtStart, relativeAtEnd);
   const maxRelativeLeft = Math.max(relativeAtStart, relativeAtEnd);
   const padding = config.collisionPadding;
 
   return (
-    minRelativeLeft <= candidate.width + padding &&
-    maxRelativeLeft >= -(comment.width + padding)
+    minRelativeLeft <= comment.width + padding &&
+    maxRelativeLeft >= -(candidate.width + padding)
   );
 };
 
@@ -283,6 +317,16 @@ const getAnalyticMovableCollisionCandidates = (
   if (index.durations.size === 1 && index.durations.has(comment.long)) {
     return undefined;
   }
+  const commentRange = getMovableCommentActiveRange(comment);
+  const commentSpeed =
+    (config.commentDrawRange + comment.width * config.nakaCommentSpeedOffset) /
+    (comment.long + 100);
+  const commentCollisionRange = getMovableCommentCollisionRange(
+    comment,
+    commentRange,
+    config,
+    commentSpeed,
+  );
   const seen = new Set<IComment>();
   const candidates: IComment[] = [];
   forEachMovableCollisionBucket(comment, (bucket) => {
@@ -297,7 +341,15 @@ const getAnalyticMovableCollisionCandidates = (
         continue;
       }
       seen.add(candidate);
-      if (doMovableTrajectoriesIntersect(comment, candidate, config)) {
+      if (
+        doMovableTrajectoriesIntersect(
+          comment,
+          commentCollisionRange,
+          commentSpeed,
+          candidate,
+          config,
+        )
+      ) {
         candidates.push(candidate);
       }
     }

--- a/src/utils/comment.ts
+++ b/src/utils/comment.ts
@@ -180,6 +180,131 @@ const hasParsedMailCommand = (commands: string[], target: string) => {
 
 const processedTimelineComments = new WeakMap<IComment, WeakSet<Timeline>>();
 
+const MOVABLE_COLLISION_BUCKET_SIZE = 100;
+
+type MovableCollisionIndex = {
+  buckets: Map<number, IComment[]>;
+  durations: Set<number>;
+  registeredComments: WeakSet<IComment>;
+};
+
+const movableCollisionIndexes = new WeakMap<Collision, MovableCollisionIndex>();
+
+const getMovableCollisionIndex = (collision: Collision) => {
+  const current = movableCollisionIndexes.get(collision);
+  if (current) return current;
+  const created: MovableCollisionIndex = {
+    buckets: new Map(),
+    durations: new Set(),
+    registeredComments: new WeakSet(),
+  };
+  movableCollisionIndexes.set(collision, created);
+  return created;
+};
+
+const getMovableCommentBeforeVpos = (comment: IComment) =>
+  Math.round(-288 / ((1632 + comment.width) / (comment.long + 125))) - 100;
+
+const getMovableCommentActiveRange = (comment: IComment) => ({
+  start: comment.vpos + getMovableCommentBeforeVpos(comment),
+  end: comment.vpos + comment.long + 125,
+});
+
+const forEachMovableCollisionBucket = (
+  comment: IComment,
+  callback: (bucket: number) => void,
+) => {
+  const { start, end } = getMovableCommentActiveRange(comment);
+  const firstBucket = Math.floor(start / MOVABLE_COLLISION_BUCKET_SIZE);
+  const lastBucket = Math.floor((end - 1) / MOVABLE_COLLISION_BUCKET_SIZE);
+  for (let bucket = firstBucket; bucket <= lastBucket; bucket++) {
+    callback(bucket);
+  }
+};
+
+const registerMovableCollisionComment = (
+  collision: Collision,
+  comment: IComment,
+) => {
+  const index = getMovableCollisionIndex(collision);
+  if (index.registeredComments.has(comment)) return;
+  index.registeredComments.add(comment);
+  index.durations.add(comment.long);
+  forEachMovableCollisionBucket(comment, (bucket) => {
+    const comments = index.buckets.get(bucket);
+    if (comments) {
+      comments.push(comment);
+    } else {
+      index.buckets.set(bucket, [comment]);
+    }
+  });
+};
+
+const doMovableTrajectoriesIntersect = (
+  comment: IComment,
+  candidate: IComment,
+  config: BaseConfig,
+) => {
+  const commentRange = getMovableCommentActiveRange(comment);
+  const candidateRange = getMovableCommentActiveRange(candidate);
+  const sharedStart = Math.max(commentRange.start, candidateRange.start);
+  const sharedEnd = Math.min(commentRange.end, candidateRange.end);
+  if (sharedStart >= sharedEnd) return false;
+
+  const commentSpeed =
+    (config.commentDrawRange + comment.width * config.nakaCommentSpeedOffset) /
+    (comment.long + 100);
+  const candidateSpeed =
+    (config.commentDrawRange +
+      candidate.width * config.nakaCommentSpeedOffset) /
+    (candidate.long + 100);
+  const getRelativeLeft = (vpos: number) =>
+    (vpos - candidate.vpos + 100) * candidateSpeed -
+    (vpos - comment.vpos + 100) * commentSpeed;
+  const relativeAtStart = getRelativeLeft(sharedStart);
+  const relativeAtEnd = getRelativeLeft(sharedEnd);
+  const minRelativeLeft = Math.min(relativeAtStart, relativeAtEnd);
+  const maxRelativeLeft = Math.max(relativeAtStart, relativeAtEnd);
+  const padding = config.collisionPadding;
+
+  return (
+    minRelativeLeft <= candidate.width + padding &&
+    maxRelativeLeft >= -(comment.width + padding)
+  );
+};
+
+const getAnalyticMovableCollisionCandidates = (
+  comment: IComment,
+  collision: Collision,
+  config: BaseConfig,
+) => {
+  const index = getMovableCollisionIndex(collision);
+  if (index.durations.size === 0) return undefined;
+  if (index.durations.size === 1 && index.durations.has(comment.long)) {
+    return undefined;
+  }
+  const seen = new Set<IComment>();
+  const candidates: IComment[] = [];
+  forEachMovableCollisionBucket(comment, (bucket) => {
+    const bucketComments = index.buckets.get(bucket);
+    if (!bucketComments) return;
+    for (const candidate of bucketComments) {
+      if (
+        seen.has(candidate) ||
+        candidate === comment ||
+        candidate.long === comment.long
+      ) {
+        continue;
+      }
+      seen.add(candidate);
+      if (doMovableTrajectoriesIntersect(comment, candidate, config)) {
+        candidates.push(candidate);
+      }
+    }
+  });
+  return candidates;
+};
+
 type TimedRange = {
   start: number;
   end: number;
@@ -1108,8 +1233,7 @@ const processMovableComment = (
   const collisionRight = config.collisionRange.right;
   const collisionLeft = config.collisionRange.left;
 
-  const beforeVpos =
-    Math.round(-288 / ((1632 + commentWidth) / (commentLong + 125))) - 100;
+  const beforeVpos = getMovableCommentBeforeVpos(comment);
   const posY = lazy
     ? -1
     : getMovablePosY(comment, collision, beforeVpos, config, speed);
@@ -1136,6 +1260,7 @@ const processMovableComment = (
     markTimelineProcessed(timeline, comment);
   }
   comment.posY = posY;
+  registerMovableCollisionComment(collision, comment);
 };
 
 const getFixedPosY = (
@@ -1183,6 +1308,11 @@ const getMovablePosY = (
   const collisionRight = config.collisionRange.right;
   const collisionLeft = config.collisionRange.left;
   const n = commentLong + 125;
+  const analyticCandidates = getAnalyticMovableCollisionCandidates(
+    comment,
+    collision,
+    config,
+  );
 
   let posY = 0;
   let isChanged = true;
@@ -1191,6 +1321,10 @@ const getMovablePosY = (
   while (isChanged && count < 10) {
     isChanged = false;
     count++;
+    const analyticResult = getPosY(posY, comment, analyticCandidates, config);
+    posY = analyticResult.currentPos;
+    isChanged ||= analyticResult.isChanged;
+    if (analyticResult.isBreak) return posY;
     for (let j = beforeVpos; j < n; j += 5) {
       const vpos = commentVpos + j;
       const leftPos = drawPadding + drawRange - (j + 100) * speed;

--- a/tests/bench/collision.bench.ts
+++ b/tests/bench/collision.bench.ts
@@ -1,6 +1,7 @@
 import { bench, describe } from "vitest";
 
 import type { IComment } from "@/@types";
+import { defaultConfig } from "@/definition/config";
 import { processFixedComment, processMovableComment } from "@/utils/comment";
 
 import {
@@ -25,9 +26,23 @@ const fixed100 = generateCommentInstances(100, renderer, "ue", 1);
 const fixed1000 = generateCommentInstances(1000, renderer, "ue", 2);
 const movable100 = generateCommentInstances(100, renderer, "naka", 3);
 const movable1000 = generateCommentInstances(1000, renderer, "naka", 4);
+const equalDuration1000 = generateCommentInstances(1000, renderer, "naka", 8);
+const denseMixedDuration1000 = generateCommentInstances(
+  1000,
+  renderer,
+  "naka",
+  9,
+);
 const mixedNaka = generateCommentInstances(350, renderer, "naka", 5);
 const mixedUe = generateCommentInstances(100, renderer, "ue", 6);
 const mixedShita = generateCommentInstances(50, renderer, "shita", 7);
+
+for (let i = 0; i < denseMixedDuration1000.length; i++) {
+  const comment = denseMixedDuration1000[i];
+  if (!comment) continue;
+  comment.comment.vpos = i * 5;
+  comment.comment.long = i % 2 === 0 ? 300 : 1000;
+}
 
 describe("processFixedComment", () => {
   bench("100 fixed comments (ue)", () => {
@@ -35,7 +50,13 @@ describe("processFixedComment", () => {
     const timeline = createTimeline();
     const collision = createCollision();
     for (const comment of fixed100) {
-      processFixedComment(comment, collision.ue, timeline);
+      processFixedComment(
+        comment,
+        collision.ue,
+        timeline,
+        false,
+        defaultConfig,
+      );
     }
   });
 
@@ -44,7 +65,13 @@ describe("processFixedComment", () => {
     const timeline = createTimeline();
     const collision = createCollision();
     for (const comment of fixed1000) {
-      processFixedComment(comment, collision.ue, timeline);
+      processFixedComment(
+        comment,
+        collision.ue,
+        timeline,
+        false,
+        defaultConfig,
+      );
     }
   });
 });
@@ -55,7 +82,7 @@ describe("processMovableComment", () => {
     const timeline = createTimeline();
     const collision = createCollision();
     for (const comment of movable100) {
-      processMovableComment(comment, collision, timeline);
+      processMovableComment(comment, collision, timeline, false, defaultConfig);
     }
   });
 
@@ -64,7 +91,25 @@ describe("processMovableComment", () => {
     const timeline = createTimeline();
     const collision = createCollision();
     for (const comment of movable1000) {
-      processMovableComment(comment, collision, timeline);
+      processMovableComment(comment, collision, timeline, false, defaultConfig);
+    }
+  });
+
+  bench("1000 movable comments with long=300", () => {
+    resetPosY(equalDuration1000);
+    const timeline = createTimeline();
+    const collision = createCollision();
+    for (const comment of equalDuration1000) {
+      processMovableComment(comment, collision, timeline, false, defaultConfig);
+    }
+  });
+
+  bench("1000 dense movable comments with long=300/1000", () => {
+    resetPosY(denseMixedDuration1000);
+    const timeline = createTimeline();
+    const collision = createCollision();
+    for (const comment of denseMixedDuration1000) {
+      processMovableComment(comment, collision, timeline, false, defaultConfig);
     }
   });
 });
@@ -78,13 +123,25 @@ describe("mixed comments (preRendering equivalent)", () => {
     const collision = createCollision();
 
     for (const comment of mixedNaka) {
-      processMovableComment(comment, collision, timeline);
+      processMovableComment(comment, collision, timeline, false, defaultConfig);
     }
     for (const comment of mixedUe) {
-      processFixedComment(comment, collision.ue, timeline);
+      processFixedComment(
+        comment,
+        collision.ue,
+        timeline,
+        false,
+        defaultConfig,
+      );
     }
     for (const comment of mixedShita) {
-      processFixedComment(comment, collision.shita, timeline);
+      processFixedComment(
+        comment,
+        collision.shita,
+        timeline,
+        false,
+        defaultConfig,
+      );
     }
   });
 });

--- a/tests/unit/movable-collision.spec.ts
+++ b/tests/unit/movable-collision.spec.ts
@@ -90,6 +90,32 @@ describe("movable comment collision", () => {
     expect(muchLaterNormal.posY).toBe(0);
   });
 
+  test("allows comments that overlap only outside the collision judgment region to share a row", () => {
+    const collision = createCollision();
+    const timeline: Timeline = {};
+    const earlierSlow = createMovableComment(1, 0, 600, { width: 50 });
+    const laterNormal = createMovableComment(2, 365, 300, { width: 50 });
+
+    process(earlierSlow, collision, timeline);
+    process(laterNormal, collision, timeline);
+
+    expect(earlierSlow.posY).toBe(0);
+    expect(laterNormal.posY).toBe(0);
+  });
+
+  test("separates unequal-width mixed-duration comments that collide inside the judgment region", () => {
+    const collision = createCollision();
+    const timeline: Timeline = {};
+    const widerSlow = createMovableComment(1, 0, 600, { width: 200 });
+    const narrowNormal = createMovableComment(2, 305, 300, { width: 20 });
+
+    process(widerSlow, collision, timeline);
+    process(narrowNormal, collision, timeline);
+
+    expect(widerSlow.posY).toBe(0);
+    expect(narrowNormal.posY).toBe(widerSlow.height);
+  });
+
   test("preserves sampled-line collision placement for equal custom durations", () => {
     const collision = createCollision();
     const timeline: Timeline = {};

--- a/tests/unit/movable-collision.spec.ts
+++ b/tests/unit/movable-collision.spec.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, test } from "vitest";
+
+import type { Collision, IComment, Timeline } from "@/@types";
+import { defaultConfig } from "@/definition/config";
+import { initConfig } from "@/definition/initConfig";
+import { processMovableComment } from "@/utils/comment";
+
+const createCollision = (): Collision => ({
+  ue: {},
+  shita: {},
+  left: {},
+  right: {},
+});
+
+const createMovableComment = (
+  index: number,
+  vpos: number,
+  long: number,
+  options: { layer?: number; owner?: boolean; width?: number } = {},
+) =>
+  ({
+    comment: {},
+    invisible: false,
+    index,
+    loc: "naka",
+    width: options.width ?? 100,
+    long,
+    height: 24,
+    vpos,
+    flash: false,
+    posY: -1,
+    owner: options.owner ?? false,
+    layer: options.layer ?? -1,
+    mail: [],
+    content: `comment ${index}`,
+    draw() {},
+    isHovered: () => false,
+  }) as IComment;
+
+const process = (
+  comment: IComment,
+  collision: Collision,
+  timeline: Timeline,
+  lazy = false,
+) => processMovableComment(comment, collision, timeline, lazy, defaultConfig);
+
+const shareCollisionSample = (
+  collision: Collision["left"] | Collision["right"],
+  first: IComment,
+  second: IComment,
+) =>
+  Object.values(collision).some(
+    (comments) => comments.includes(first) && comments.includes(second),
+  );
+
+describe("movable comment collision", () => {
+  beforeEach(() => {
+    initConfig();
+  });
+
+  test("separates different-duration comments that collide only between the sampled lines", () => {
+    const collision = createCollision();
+    const timeline: Timeline = {};
+    const slowLeading = createMovableComment(1, 0, 1000);
+    const laterNormal = createMovableComment(2, 250, 300);
+
+    process(slowLeading, collision, timeline);
+    process(laterNormal, collision, timeline);
+
+    expect(shareCollisionSample(collision.left, slowLeading, laterNormal)).toBe(
+      false,
+    );
+    expect(
+      shareCollisionSample(collision.right, slowLeading, laterNormal),
+    ).toBe(false);
+    expect(slowLeading.posY).toBe(0);
+    expect(laterNormal.posY).toBe(slowLeading.height);
+  });
+
+  test("allows different-duration comments with overlapping active ranges but non-intersecting trajectories to share a row", () => {
+    const collision = createCollision();
+    const timeline: Timeline = {};
+    const slowLeading = createMovableComment(1, 0, 1000);
+    const muchLaterNormal = createMovableComment(2, 900, 300);
+
+    process(slowLeading, collision, timeline);
+    process(muchLaterNormal, collision, timeline);
+
+    expect(slowLeading.posY).toBe(0);
+    expect(muchLaterNormal.posY).toBe(0);
+  });
+
+  test("preserves sampled-line collision placement for equal custom durations", () => {
+    const collision = createCollision();
+    const timeline: Timeline = {};
+    const first = createMovableComment(1, 0, 1000);
+    const second = createMovableComment(2, 0, 1000);
+
+    process(first, collision, timeline);
+    process(second, collision, timeline);
+
+    expect(first.posY).toBe(0);
+    expect(second.posY).toBe(first.height);
+  });
+
+  test("treats default and explicit @3 normalized durations as the same-duration path", () => {
+    const collision = createCollision();
+    const timeline: Timeline = {};
+    const defaultDuration = createMovableComment(1, 0, 300);
+    const explicitAtThree = createMovableComment(2, 0, 300);
+
+    process(defaultDuration, collision, timeline);
+    process(explicitAtThree, collision, timeline);
+
+    expect(defaultDuration.posY).toBe(0);
+    expect(explicitAtThree.posY).toBe(defaultDuration.height);
+  });
+
+  test.each([
+    ["owner", { owner: true }],
+    ["layer", { layer: 0 }],
+  ])("does not separate intersecting mixed-duration comments with a different %s", (_, differingIdentity) => {
+    const collision = createCollision();
+    const timeline: Timeline = {};
+    const slowLeading = createMovableComment(1, 0, 1000);
+    const laterNormal = createMovableComment(2, 250, 300, differingIdentity);
+
+    process(slowLeading, collision, timeline);
+    process(laterNormal, collision, timeline);
+
+    expect(slowLeading.posY).toBe(0);
+    expect(laterNormal.posY).toBe(0);
+  });
+
+  test("does not duplicate timeline or analytic candidates when a lazy comment is reprocessed", () => {
+    const collision = createCollision();
+    const timeline: Timeline = {};
+    const slowLeading = createMovableComment(1, 0, 1000);
+    const laterNormal = createMovableComment(2, 250, 300);
+
+    process(slowLeading, collision, timeline, true);
+    expect(slowLeading.posY).toBe(-1);
+    process(slowLeading, collision, timeline);
+    process(laterNormal, collision, timeline);
+
+    expect(
+      timeline[0]?.filter((comment) => comment === slowLeading),
+    ).toHaveLength(1);
+    expect(slowLeading.posY).toBe(0);
+    expect(laterNormal.posY).toBe(slowLeading.height);
+  });
+
+  test("detects a mixed-duration collision when comments are inserted out of chronological order", () => {
+    const collision = createCollision();
+    const timeline: Timeline = {};
+    const slowLeading = createMovableComment(1, 0, 1000);
+    const laterNormal = createMovableComment(2, 250, 300);
+
+    process(laterNormal, collision, timeline);
+    process(slowLeading, collision, timeline);
+
+    expect(laterNormal.posY).toBe(0);
+    expect(slowLeading.posY).toBe(laterNormal.height);
+  });
+});


### PR DESCRIPTION
## チケットへのリンク

- 無し

## やったこと

- 正規化後の表示時間（`comment.long`）が異なる流れるコメント同士について、同時表示区間の軌道を解析し、左右の判定線の間で発生する重なりを検出するようにしました。
- 表示時間が同じコメント同士は既存の左右判定ロジックを維持し、通常ケースの性能回帰を抑えました。
- 100センチ秒単位の時間バケットと重複排除を用いて、速度混在時の比較候補を限定しました。
- 中央でのみ衝突するケース、非衝突、同一表示時間、owner/layer、lazy再処理、時系列外挿入を対象とする回帰テストを追加しました。
- 同一表示時間1000件と表示時間混在1000件のベンチマークを追加しました。

## やらないこと

- 固定コメントの配置ロジックは変更しません。
- `@逆` 適用中の衝突判定仕様は変更しません。
- 公開API、公開型、設定項目は変更しません。

## できるようになること（ユーザ目線）

- `@秒` で送り速度を遅くした短いコメントと通常コメントが画面中央で追いつく場合でも、別の行へ配置され、コメント同士の重なりを防げます。

## できなくなること（ユーザ目線）

- 無し

## 動作確認

- `pnpm check-types`: 成功
- `pnpm test:unit`: 197件すべて成功
- `pnpm lint`: 成功
- `pnpm build`: 成功
- 追加した衝突判定テスト: 8件すべて成功
- 同一表示時間1000件の5回中央値: 変更前 32.8791ms / 変更後 32.8042ms
- 表示時間混在1000件の5回中央値: 変更前 39.5354ms / 変更後 60.3396ms（1.53倍）
- 1920×1080のブラウザ描画で、`@10` と通常コメントが中央交差時に別行へ配置されることを確認
- 独立レビュー: APPROVED（指摘なし）

## その他

- 不具合の原因は、速度の異なるコメント同士でも左右2本の判定線を同時刻に通過するという前提で縦位置を決めており、判定線の間だけで発生する追いつきを検出できなかったことです。
- 表示時間が同じ通常ケースは解析的な全区間判定へ入らないため、従来の処理経路を維持しています。

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents moving comments with different display durations from overlapping in the middle of the screen. The main changes are:

- Adds analytic trajectory checks for comments with different normalized durations.
- Limits candidate comparisons with time buckets and duplicate removal.
- Preserves the existing fast path for comments with equal durations.
- Adds collision tests for asymmetric widths, identity boundaries, lazy processing, and insertion order.
- Adds benchmarks for equal-duration and mixed-duration workloads.
</details>

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The relative-position bounds now use the correct width for each comment.
- The collision interval follows the configured judgment region.
- No blocking issue remains in the updated collision path.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/utils/comment.ts | Adds indexed trajectory collision detection and corrects the asymmetric-width bounds. |
| tests/unit/movable-collision.spec.ts | Adds focused tests for mixed-duration collision behavior and placement boundaries. |
| tests/bench/collision.bench.ts | Adds equal-duration and mixed-duration collision benchmarks. |

</details>

<sub>Reviews (2): Last reviewed commit: ["軌道交差判定の境界計算を修正"](https://github.com/xpadev-net/niconicomments/commit/d5dee1c7155c1c014b1fa01e341f016a5d325013) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44409256)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/xpa/github/xpadev-net/niconicomments/-/custom-context?memory=aa0ade2c-f87c-4416-ac50-e2b011bdabee))

<!-- /greptile_comment -->