### PR TITLE
feat: nico:scale / nico:ignore-global-scale コマンドを追加

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -524,7 +524,7 @@ nico:opacity:1</code></pre>
         <div class="item">
           <h4>format</h4>
           <div class="item">
-            <pre><code>nico:scale:(float &gt; 0)</code></pre>
+            <pre><code>nico:scale:(0.01 &lt;= float &lt;= 10)</code></pre>
           </div>
           <h4>example</h4>
           <div class="item">

--- a/docs/index.html
+++ b/docs/index.html
@@ -520,6 +520,34 @@ nico:opacity:1</code></pre>
             <p>1で不透明、0で透明になります</p>
           </div>
         </div>
+        <h3 id="c_scale">Scale</h3>
+        <div class="item">
+          <h4>format</h4>
+          <div class="item">
+            <pre><code>nico:scale:(float &gt; 0)</code></pre>
+          </div>
+          <h4>example</h4>
+          <div class="item">
+            <pre><code>nico:scale:0.5
+nico:scale:1.5
+nico:scale:2</code></pre>
+          </div>
+          <div class="item" data-i18n="c_scale">
+            <p>コメント単位で拡大率を制御できます</p>
+            <p>optionsのscale(全体の拡大率)と乗算されます</p>
+          </div>
+        </div>
+        <h3 id="c_ignore_global_scale">Ignore Global Scale</h3>
+        <div class="item">
+          <h4>format</h4>
+          <div class="item">
+            <pre><code>nico:ignore-global-scale</code></pre>
+          </div>
+          <div class="item" data-i18n="c_ignore_global_scale">
+            <p>optionsのscale(全体の拡大率)の適用を対象コメントのみ除外します</p>
+            <p>nico:scaleと併用した場合、nico:scaleの倍率のみが適用されます</p>
+          </div>
+        </div>
       </section>
     </main>
   </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -524,7 +524,7 @@ nico:opacity:1</code></pre>
         <div class="item">
           <h4>format</h4>
           <div class="item">
-            <pre><code>nico:scale:(0.01 &lt;= float &lt;= 10)</code></pre>
+            <pre><code>nico:scale:(0 &lt; float &lt;= 8)</code></pre>
           </div>
           <h4>example</h4>
           <div class="item">

--- a/docs/localize.js
+++ b/docs/localize.js
@@ -320,6 +320,18 @@ const localize = {
     `<p>コメント単位で不透明度を制御できます</p>
 <p>1で不透明、0で透明になります</p>`,
   ],
+  c_scale: [
+    `<p>You can control the scale per comment.</p>
+<p>This is multiplied with options.scale (the global scale).</p>`,
+    `<p>コメント単位で拡大率を制御できます</p>
+<p>optionsのscale(全体の拡大率)と乗算されます</p>`,
+  ],
+  c_ignore_global_scale: [
+    `<p>Excludes the target comment from options.scale (the global scale).</p>
+<p>When used together with nico:scale, only the nico:scale factor is applied.</p>`,
+    `<p>optionsのscale(全体の拡大率)の適用を対象コメントのみ除外します</p>
+<p>nico:scaleと併用した場合、nico:scaleの倍率のみが適用されます</p>`,
+  ],
 };
 const resources = { en: { translation: {} }, ja: { translation: {} } };
 for (const key in localize) {
@@ -332,6 +344,6 @@ i18next.use(i18nextBrowserLanguageDetector).init({
   resources: resources,
 });
 const i18nList = document.querySelectorAll("[data-i18n]");
-i18nList.forEach(function (v) {
+i18nList.forEach((v) => {
   v.innerHTML = i18next.t(v.dataset.i18n);
 });

--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -33,6 +33,7 @@ export type FormattedCommentWithFont = {
   wakuColor?: string;
   fillColor?: string;
   opacity?: number;
+  scale?: number;
   full: boolean;
   ender: boolean;
   _live: boolean;
@@ -75,6 +76,8 @@ export type ParseCommandAndNicoScriptResult = {
   wakuColor?: string;
   fillColor?: string;
   opacity?: number;
+  scale?: number;
+  ignoreScale: boolean;
   font: CommentFont;
   full: boolean;
   ender: boolean;
@@ -290,6 +293,8 @@ export type ParsedCommand = {
   wakuColor?: string;
   fillColor?: string;
   opacity?: number;
+  scale?: number;
+  ignoreScale?: boolean;
   font: CommentFont | undefined;
   full: boolean;
   ender: boolean;

--- a/src/comments/FlashComment.ts
+++ b/src/comments/FlashComment.ts
@@ -135,7 +135,9 @@ class FlashComment extends BaseComment {
   override getCommentSize(
     parsedData: FormattedCommentWithFont,
   ): FormattedCommentWithSize {
-    const layerScale = parsedData.ignoreScale ? 1 : this.ctx.options.scale;
+    const layerScale =
+      (parsedData.ignoreScale ? 1 : this.ctx.options.scale) *
+      (parsedData.scale ?? 1);
     if (parsedData.invisible) {
       return {
         ...parsedData,

--- a/src/comments/HTML5Comment.ts
+++ b/src/comments/HTML5Comment.ts
@@ -115,7 +115,9 @@ class HTML5Comment extends BaseComment {
   override getCommentSize(
     parsedData: FormattedCommentWithFont,
   ): FormattedCommentWithSize {
-    const layerScale = parsedData.ignoreScale ? 1 : this.ctx.options.scale;
+    const layerScale =
+      (parsedData.ignoreScale ? 1 : this.ctx.options.scale) *
+      (parsedData.scale ?? 1);
     if (parsedData.invisible) {
       return {
         ...parsedData,

--- a/src/typeGuard.ts
+++ b/src/typeGuard.ts
@@ -68,7 +68,7 @@ import {
 } from "@/@types/";
 import { colors } from "@/definition/colors";
 
-const MAX_OPTION_SCALE = 8;
+export const MAX_OPTION_SCALE = 8;
 const MAX_CANVAS_DIMENSION = 8192;
 const MAX_CANVAS_AREA = 16_777_216;
 const MAX_FONT_SIZE = 512;

--- a/src/utils/comment.ts
+++ b/src/utils/comment.ts
@@ -61,6 +61,8 @@ export const MAX_AT_BUTTON_TEXT_CHARS = 4096;
 export const MAX_AT_BUTTON_MAIL_ENTRIES = 16;
 export const MAX_AT_BUTTON_MAIL_CHARS = 64;
 export const MAX_AT_BUTTON_LIMIT = 100;
+export const MIN_NICO_SCALE = 0.01;
+export const MAX_NICO_SCALE = 10;
 export const MAX_PARSED_COMMAND_MAIL_ENTRIES = 64;
 export const MAX_PARSED_COMMAND_MAIL_CHARS = 128;
 export const MAX_NICOSCRIPT_COMMAND_CHARS = 16_384;
@@ -1151,7 +1153,11 @@ const getOpacity = (match: RegExpMatchArray | null) => {
 const getScale = (match: RegExpMatchArray | null) => {
   if (!match) return;
   const value = Number(match[1]);
-  if (Number.isFinite(value) && value > 0) {
+  if (
+    Number.isFinite(value) &&
+    value >= MIN_NICO_SCALE &&
+    value <= MAX_NICO_SCALE
+  ) {
     return value;
   }
   return;

--- a/src/utils/comment.ts
+++ b/src/utils/comment.ts
@@ -49,6 +49,8 @@ const RE_STROKE = /^nico:stroke:(.+)$/;
 const RE_WAKU = /^nico:waku:(.+)$/;
 const RE_FILL = /^nico:fill:(.+)$/;
 const RE_OPACITY = /^nico:opacity:(.+)$/;
+const RE_SCALE = /^nico:scale:(.+)$/;
+const RE_IGNORE_SCALE = /^nico:ignore-global-scale$/;
 const RE_COLOR_CODE = /^#(?:[0-9a-z]{3}|[0-9a-z]{6})$/;
 export const DEFAULT_COMMENT_LONG = 300;
 export const DEFAULT_NICOSCRIPT_LONG = 30 * 100;
@@ -691,6 +693,8 @@ const parseCommandAndNicoScript = (
     wakuColor: commands.wakuColor,
     fillColor: commands.fillColor,
     opacity: commands.opacity,
+    scale: commands.scale,
+    ignoreScale: comment.ignoreScale || !!commands.ignoreScale,
     button: commands.button,
   };
 };
@@ -1077,6 +1081,15 @@ const parseCommand = (
     result.opacity ??= opacity;
     return;
   }
+  const scale = getScale(RE_SCALE.exec(command));
+  if (typeof scale === "number") {
+    result.scale ??= scale;
+    return;
+  }
+  if (RE_IGNORE_SCALE.test(command)) {
+    result.ignoreScale = true;
+    return;
+  }
   if (is(ZCommentLoc, command)) {
     result.loc ??= command;
     return;
@@ -1130,6 +1143,15 @@ const getOpacity = (match: RegExpMatchArray | null) => {
   if (!match) return;
   const value = Number(match[1]);
   if (!Number.isNaN(value) && value >= 0) {
+    return value;
+  }
+  return;
+};
+
+const getScale = (match: RegExpMatchArray | null) => {
+  if (!match) return;
+  const value = Number(match[1]);
+  if (Number.isFinite(value) && value > 0) {
     return value;
   }
   return;

--- a/src/utils/comment.ts
+++ b/src/utils/comment.ts
@@ -27,7 +27,7 @@ import {
 } from "@/@types/";
 import type { CommentInstanceContext } from "@/contexts/";
 import { colors } from "@/definition/colors";
-import typeGuard from "@/typeGuard";
+import typeGuard, { MAX_OPTION_SCALE } from "@/typeGuard";
 
 import { arrayPush } from "./array";
 import { getConfig } from "./config";
@@ -61,8 +61,6 @@ export const MAX_AT_BUTTON_TEXT_CHARS = 4096;
 export const MAX_AT_BUTTON_MAIL_ENTRIES = 16;
 export const MAX_AT_BUTTON_MAIL_CHARS = 64;
 export const MAX_AT_BUTTON_LIMIT = 100;
-export const MIN_NICO_SCALE = 0.01;
-export const MAX_NICO_SCALE = 10;
 export const MAX_PARSED_COMMAND_MAIL_ENTRIES = 64;
 export const MAX_PARSED_COMMAND_MAIL_CHARS = 128;
 export const MAX_NICOSCRIPT_COMMAND_CHARS = 16_384;
@@ -1155,8 +1153,8 @@ const getScale = (match: RegExpMatchArray | null) => {
   const value = Number(match[1]);
   if (
     Number.isFinite(value) &&
-    value >= MIN_NICO_SCALE &&
-    value <= MAX_NICO_SCALE
+    value >= Number.MIN_VALUE &&
+    value <= MAX_OPTION_SCALE
   ) {
     return value;
   }


### PR DESCRIPTION
## Summary
- コメント単位で拡大率を制御できる`nico:scale:<float>`コマンドを追加(既存の`nico:stroke`等と同じmailコマンド方式)
- `options.scale`(全体スケール)の適用のみを対象コメントから除外する`nico:ignore-global-scale`コマンドを追加。`nico:scale`と併用した場合は`nico:scale`の倍率のみが乗算される
- 入力フォーマット/Zodスキーマには変更なし。`docs/index.html`・`docs/localize.js`にコマンドドキュメント(日英)を追加

## Test plan
- [x] `npm run check-types`
- [x] `npm run lint`
- [ ] Playwrightでの視覚回帰テスト(必要であれば実施)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds per-comment scaling and an option to bypass the global scale, applying the behavior consistently to Flash and HTML5 comments.
- Parses and propagates `nico:scale:<float>` and `nico:ignore-global-scale`.
- Multiplies valid per-comment scale values with the configured global scale.
- Documents both commands in Japanese and English.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/utils/comment.ts | Adds command parsing, validation, and propagation for per-comment scale and global-scale bypass. |
| src/comments/FlashComment.ts | Incorporates the per-comment factor into Flash comment sizing. |
| src/comments/HTML5Comment.ts | Incorporates the per-comment factor into HTML5 comment sizing. |
| src/@types/types.ts | Extends internal parsed and formatted comment shapes with scale metadata. |
| src/typeGuard.ts | Exports the existing maximum option scale so command validation can share the same bound. |
| docs/index.html | Documents the syntax and interaction of both new commands. |
| docs/localize.js | Adds Japanese and English descriptions for the new commands. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Mail[Comment mail commands] --> Parser[parseCommand]
    Parser --> Scale[nico:scale factor]
    Parser --> Ignore[nico:ignore-global-scale]
    Scale --> Model[Formatted comment]
    Ignore --> Model
    Global[options.scale] --> Effective{Ignore global scale?}
    Effective -->|No| Multiply[Global scale × comment scale]
    Effective -->|Yes| LocalOnly[Comment scale only]
    Model --> Effective
    Multiply --> Flash[FlashComment sizing]
    Multiply --> HTML5[HTML5Comment sizing]
    LocalOnly --> Flash
    LocalOnly --> HTML5
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: align nico:scale bounds with option..."](https://github.com/xpadev-net/niconicomments/commit/03cb0fc79934b697484b30fa0b1cad9569e08381) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53624661)</sub>

<!-- /greptile_comment -->