### PR TITLE
fix: 公開APIの入力型に InferInput ベースの型を使う

### DIFF
--- a/src/@types/format.formatted.ts
+++ b/src/@types/format.formatted.ts
@@ -1,4 +1,4 @@
-import type { InferOutput } from "valibot";
+import type { InferInput, InferOutput } from "valibot";
 import {
   array,
   boolean,
@@ -55,6 +55,11 @@ export const ZFormattedComment = pipe(
   }),
 );
 export type FormattedComment = InferOutput<typeof ZFormattedComment>;
+/**
+ * `FormattedComment` の入力用の型。`id` や `ignoreScale` など default 付きの
+ * フィールドは省略できる。`addComments` など公開APIの引数型として使う。
+ */
+export type FormattedCommentInput = InferInput<typeof ZFormattedComment>;
 
 /**
  * @deprecated
@@ -69,6 +74,12 @@ export const ZFormattedLegacyComment = omit(ZFormattedCommentEntries, [
  * @deprecated
  */
 export type FormattedLegacyComment = InferOutput<
+  typeof ZFormattedLegacyComment
+>;
+/**
+ * @deprecated
+ */
+export type FormattedLegacyCommentInput = InferInput<
   typeof ZFormattedLegacyComment
 >;
 

--- a/src/@types/options.ts
+++ b/src/@types/options.ts
@@ -3,8 +3,8 @@ import { literal, union } from "valibot";
 
 import type {
   Config,
-  FormattedComment,
-  FormattedLegacyComment,
+  FormattedCommentInput,
+  FormattedLegacyCommentInput,
   OwnerComment,
   RawApiResponse,
   V1Thread,
@@ -28,8 +28,8 @@ export type InputFormatType = InferOutput<typeof ZInputFormatType>;
 export type InputFormat =
   | XMLDocument
   | Xml2jsPacket
-  | FormattedComment[]
-  | FormattedLegacyComment[]
+  | FormattedCommentInput[]
+  | FormattedLegacyCommentInput[]
   | RawApiResponse[]
   | OwnerComment[]
   | V1Thread[]

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import type {
   Collision,
   CommentEventHandlerMap,
   FormattedComment,
+  FormattedCommentInput,
   FrameActiveState,
   IComment,
   InputFormat,
@@ -532,7 +533,7 @@ class NiconiComments {
    * ※すでに存在するコメントの位置はvposに関係なく更新されません
    * @param rawComments コメントデータ
    */
-  public addComments(...rawComments: FormattedComment[]) {
+  public addComments(...rawComments: FormattedCommentInput[]) {
     const validComments = rawComments.reduce<FormattedComment[]>((pv, val) => {
       const parsedComment = safeParse(ZFormattedComment, val);
       if (parsedComment.success) pv.push(parsedComment.output);


### PR DESCRIPTION
## Summary
- `ZFormattedCommentEntries` は default 付きフィールド（`id`, `vpos`, `ignoreScale` 等）を持つが、`FormattedComment`（`InferOutput`）をそのまま公開APIの入力型として使っていたため、default 付きフィールドを省略した呼び出しが型エラーになっていた（#410 で `ignoreScale` が追加されたことで顕在化）
- `FormattedCommentInput` / `FormattedLegacyCommentInput`（`InferInput`）を新設し、公開APIの入力境界（`NiconiComments#addComments` の引数、`InputFormat`＝constructor の `data` 引数）はこちらを使うよう変更
- 内部で完全に解決済みのコメントを扱う箇所（`comments/`, `utils/`, `input/` パーサ内部の組み立て等）は引き続き `FormattedComment`（`InferOutput`）を使用

## Test plan
- [x] `npm run check-types`
- [x] `npm run lint`

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR introduces Valibot `InferInput` aliases for formatted comments and uses them at public input boundaries, allowing callers to omit schema-defaulted fields while retaining normalized `InferOutput` types internally.
- Adds `FormattedCommentInput` and deprecated `FormattedLegacyCommentInput`.
- Updates constructor input typing through `InputFormat`.
- Updates `addComments` typing while preserving runtime schema normalization.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the broadened public input types remain normalized through the existing Valibot schemas before internal use.

The new input aliases are publicly exported, and both constructor parsing and `addComments` convert accepted inputs into complete `FormattedComment` outputs with defaults applied before rendering or plugin processing.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/@types/format.formatted.ts | Adds exported InferInput aliases alongside the existing normalized InferOutput types. |
| src/@types/options.ts | Broadens formatted constructor inputs to permit omission of schema-defaulted fields. |
| src/main.ts | Broadens `addComments` typing while continuing to validate and normalize every input before internal use. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Caller["Public API caller<br/>FormattedCommentInput"] --> Parse["ZFormattedComment validation"]
  Parse --> Defaults["Apply schema defaults"]
  Defaults --> Internal["FormattedComment<br/>InferOutput"]
  Internal --> Render["Comment creation and rendering"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: FormattedComment を公開APIの入力型として使わず I..."](https://github.com/xpadev-net/niconicomments/commit/04a89c2c68cee015fa9c8bdc400baa31f83b3e32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53741337)</sub>

**Context used:**

- Knowledge Base — [Main entrypoint: constructing and driving `NiconiComments`](https://app.greptile.com/xpa/-/custom-context/knowledge-base/xpadev-net/niconicomments/-/docs/main-entrypoint.md)

<!-- /greptile_comment -->