### PR TITLE
fix: nico:scale コマンドの倍率が content 再設定で失われるバグを修正

### DIFF
--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -33,7 +33,7 @@ export type FormattedCommentWithFont = {
   wakuColor?: string;
   fillColor?: string;
   opacity?: number;
-  scale?: number;
+  commandScale?: number;
   full: boolean;
   ender: boolean;
   _live: boolean;
@@ -76,7 +76,7 @@ export type ParseCommandAndNicoScriptResult = {
   wakuColor?: string;
   fillColor?: string;
   opacity?: number;
-  scale?: number;
+  commandScale?: number;
   ignoreScale: boolean;
   font: CommentFont;
   full: boolean;
@@ -293,7 +293,7 @@ export type ParsedCommand = {
   wakuColor?: string;
   fillColor?: string;
   opacity?: number;
-  scale?: number;
+  commandScale?: number;
   ignoreScale?: boolean;
   font: CommentFont | undefined;
   full: boolean;

--- a/src/comments/FlashComment.ts
+++ b/src/comments/FlashComment.ts
@@ -137,7 +137,7 @@ class FlashComment extends BaseComment {
   ): FormattedCommentWithSize {
     const layerScale =
       (parsedData.ignoreScale ? 1 : this.ctx.options.scale) *
-      (parsedData.scale ?? 1);
+      (parsedData.commandScale ?? 1);
     if (parsedData.invisible) {
       return {
         ...parsedData,

--- a/src/comments/HTML5Comment.ts
+++ b/src/comments/HTML5Comment.ts
@@ -117,7 +117,7 @@ class HTML5Comment extends BaseComment {
   ): FormattedCommentWithSize {
     const layerScale =
       (parsedData.ignoreScale ? 1 : this.ctx.options.scale) *
-      (parsedData.scale ?? 1);
+      (parsedData.commandScale ?? 1);
     if (parsedData.invisible) {
       return {
         ...parsedData,

--- a/src/utils/comment.ts
+++ b/src/utils/comment.ts
@@ -693,7 +693,7 @@ const parseCommandAndNicoScript = (
     wakuColor: commands.wakuColor,
     fillColor: commands.fillColor,
     opacity: commands.opacity,
-    scale: commands.scale,
+    commandScale: commands.commandScale,
     ignoreScale: comment.ignoreScale || !!commands.ignoreScale,
     button: commands.button,
   };
@@ -1083,7 +1083,7 @@ const parseCommand = (
   }
   const scale = getScale(RE_SCALE.exec(command));
   if (typeof scale === "number") {
-    result.scale ??= scale;
+    result.commandScale ??= scale;
     return;
   }
   if (RE_IGNORE_SCALE.test(command)) {

--- a/tests/unit/flash-resource-bounds.spec.ts
+++ b/tests/unit/flash-resource-bounds.spec.ts
@@ -242,6 +242,25 @@ describe("Flash and at-button resource bounds", () => {
     expect(image?.strokeTextCalls).toBeLessThanOrEqual(8);
   });
 
+  test("keeps nico:scale commandScale in layerScale after content setter re-measurement", () => {
+    const renderer = new RecordingRenderer();
+    const comment = new TestFlashComment(
+      formattedComment("one\ntwo\nthree\nfour\nfive", ["nico:scale:2"]),
+      renderer,
+      0,
+      createContext(),
+    );
+
+    expect(comment.comment.commandScale).toBe(2);
+    expect(comment.comment.scale).not.toBe(comment.comment.commandScale);
+    expect(comment.comment.layerScale).toBe(2);
+
+    comment.content = "six\nseven\neight\nnine\nten";
+
+    expect(comment.comment.commandScale).toBe(2);
+    expect(comment.comment.layerScale).toBe(2);
+  });
+
   test("reports Flash comments as Flash instances", () => {
     const comment = new TestFlashComment(
       formattedComment("flash"),

--- a/tests/unit/html5-resource-bounds.spec.ts
+++ b/tests/unit/html5-resource-bounds.spec.ts
@@ -394,60 +394,60 @@ describe("HTML5 comment resource bounds", () => {
     );
   });
 
-  test.each(["ue", "shita"] as const)(
-    "keeps %s fixed-comment resize measurement bounded for huge text",
-    (loc) => {
-      const renderer = new RecordingRenderer();
-      const comment = new TestHTML5Comment(
-        formattedComment(1, "x".repeat(5000), [loc]),
-        renderer,
-        0,
-        createContext(),
-      );
-      const widthLimit =
-        defaultConfig.commentStageSize.html5.width *
-        defaultConfig.commentScale.html5;
+  test.each([
+    "ue",
+    "shita",
+  ] as const)("keeps %s fixed-comment resize measurement bounded for huge text", (loc) => {
+    const renderer = new RecordingRenderer();
+    const comment = new TestHTML5Comment(
+      formattedComment(1, "x".repeat(5000), [loc]),
+      renderer,
+      0,
+      createContext(),
+    );
+    const widthLimit =
+      defaultConfig.commentStageSize.html5.width *
+      defaultConfig.commentScale.html5;
 
-      expect(comment.comment.resizedX).toBe(true);
-      expect(comment.comment.charSize).toBeLessThan(1);
-      expect(comment.comment.width).toBeLessThanOrEqual(widthLimit);
-      expect(renderer.measureCalls).toBeLessThanOrEqual(80);
+    expect(comment.comment.resizedX).toBe(true);
+    expect(comment.comment.charSize).toBeLessThan(1);
+    expect(comment.comment.width).toBeLessThanOrEqual(widthLimit);
+    expect(renderer.measureCalls).toBeLessThanOrEqual(80);
 
-      const image = comment.exposeTextImage() as RecordingRenderer | null;
+    const image = comment.exposeTextImage() as RecordingRenderer | null;
 
-      expect(image).not.toBeNull();
-      expect(image?.getSize().width).toBeLessThanOrEqual(widthLimit);
-      expect(image?.getSize().height).toBeGreaterThan(0);
-    },
-  );
+    expect(image).not.toBeNull();
+    expect(image?.getSize().width).toBeLessThanOrEqual(widthLimit);
+    expect(image?.getSize().height).toBeGreaterThan(0);
+  });
 
-  test.each(["ue", "shita"] as const)(
-    "reserves and offsets HTML5 offscreen top padding for long %s comments",
-    (loc) => {
-      const renderer = new RecordingRenderer();
-      const comment = new TestHTML5Comment(
-        formattedComment(1, "x".repeat(5000), [loc]),
-        renderer,
-        0,
-        createContext(),
-      );
+  test.each([
+    "ue",
+    "shita",
+  ] as const)("reserves and offsets HTML5 offscreen top padding for long %s comments", (loc) => {
+    const renderer = new RecordingRenderer();
+    const comment = new TestHTML5Comment(
+      formattedComment(1, "x".repeat(5000), [loc]),
+      renderer,
+      0,
+      createContext(),
+    );
 
-      const image = comment.exposeTextImage() as RecordingRenderer | null;
+    const image = comment.exposeTextImage() as RecordingRenderer | null;
 
-      expect(image).not.toBeNull();
-      const paddingHeight =
-        (image?.getSize().height ?? 0) - comment.comment.height;
-      expect(paddingHeight).toBeGreaterThan(0);
-      expect(image?.fillTextCallsByPosition[0]?.y).toBeGreaterThan(0);
+    expect(image).not.toBeNull();
+    const paddingHeight =
+      (image?.getSize().height ?? 0) - comment.comment.height;
+    expect(paddingHeight).toBeGreaterThan(0);
+    expect(image?.fillTextCallsByPosition[0]?.y).toBeGreaterThan(0);
 
-      comment.drawBodyForTest();
+    comment.drawBodyForTest();
 
-      expect(renderer.drawImageCalls).toHaveLength(1);
-      expect(renderer.drawImageCalls[0]?.image).toBe(image);
-      expect(renderer.drawImageCalls[0]?.x).toBe(0);
-      expect(renderer.drawImageCalls[0]?.y).toBeCloseTo(-paddingHeight, 5);
-    },
-  );
+    expect(renderer.drawImageCalls).toHaveLength(1);
+    expect(renderer.drawImageCalls[0]?.image).toBe(image);
+    expect(renderer.drawImageCalls[0]?.x).toBe(0);
+    expect(renderer.drawImageCalls[0]?.y).toBeCloseTo(-paddingHeight, 5);
+  });
 
   test("uses v0.2.76 fixed-comment resize step when scaled text still exceeds the stage", () => {
     const renderer = new ThresholdWidthRenderer();
@@ -744,6 +744,25 @@ describe("HTML5 comment resource bounds", () => {
     expect(commaImage).not.toBeNull();
     expect(separateImage).not.toBeNull();
     expect(commaImage).not.toBe(separateImage);
+  });
+
+  test("keeps nico:scale commandScale in layerScale after content setter re-measurement", () => {
+    const renderer = new RecordingRenderer();
+    const comment = new TestHTML5Comment(
+      formattedComment(1, "before", ["nico:scale:2"]),
+      renderer,
+      0,
+      createContext(),
+    );
+
+    expect(comment.comment.commandScale).toBe(2);
+    expect(comment.comment.scale).not.toBe(comment.comment.commandScale);
+    expect(comment.comment.layerScale).toBe(2);
+
+    comment.content = "after";
+
+    expect(comment.comment.commandScale).toBe(2);
+    expect(comment.comment.layerScale).toBe(2);
   });
 
   test("clamps backing canvas dimensions including padding", () => {


### PR DESCRIPTION
## Summary
- `FormattedCommentWithSize.scale` が「nico:scale コマンド由来の倍率」と「measureText の計測用スケール」の2つの意味を兼用しており、`getCommentSize` が計測結果で上書きすることでコマンド倍率が失われていた
- `content` setter で `parsedData` を再構築する際にこの壊れた値を引き継ぐため、`content` 書き換え後に `nico:scale` の効果が消えるバグがあった (ultrareview / #413 で確認)
- コマンド由来の倍率を `commandScale` という専用フィールドに分離し、計測用の `scale` と衝突しないようにした

## Test plan
- [x] `npm run check-types`
- [x] `npm run lint`
- [ ] `test-server` での手動確認（nico:scale コメント表示 → content 書き換え後も倍率が維持されるか）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR separates the multiplier supplied by `nico:scale` from the internal text-measurement scale so content reassignment no longer discards the command multiplier.
- Renames the parsed command field to `commandScale` throughout the shared comment types and parser.
- Applies `commandScale` when calculating `layerScale` in both Flash and HTML5 comment implementations.
- Adds regression coverage for preserving the multiplier after content reassignment in both rendering modes.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/@types/types.ts | Renames the command-derived multiplier in the shared parsed-comment types without affecting identified related-repository consumers. |
| src/utils/comment.ts | Produces and propagates `commandScale` consistently through command parsing. |
| src/comments/FlashComment.ts | Uses the dedicated command multiplier when calculating Flash comment layer scale. |
| src/comments/HTML5Comment.ts | Uses the dedicated command multiplier when calculating HTML5 comment layer scale. |
| tests/unit/flash-resource-bounds.spec.ts | Adds Flash regression coverage for retaining command scale across content reassignment. |
| tests/unit/html5-resource-bounds.spec.ts | Adds HTML5 regression coverage for retaining command scale across content reassignment. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Mail["nico:scale command"] --> Parser["parseCommand"]
  Parser --> CommandScale["commandScale"]
  CommandScale --> LayerScale["global scale × commandScale"]
  Content["content reassignment"] --> Measure["text remeasurement"]
  Measure --> MeasurementScale["measurement scale"]
  CommandScale --> Preserve["preserved comment state"]
  Preserve --> LayerScale
  MeasurementScale --> Render["rendered dimensions"]
  LayerScale --> Render
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test: nico:scale の commandScale が conten..."](https://github.com/xpadev-net/niconicomments/commit/6981c83c9cc6e6e659fca39d475f66c406deb560) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53745194)</sub>

**Context used:**

- Knowledge Base — [Comment Model](https://app.greptile.com/xpa/-/custom-context/knowledge-base/xpadev-net/niconicomments/-/docs/comment-model.md)
- Knowledge Base — [Utils and error hierarchy](https://app.greptile.com/xpa/-/custom-context/knowledge-base/xpadev-net/niconicomments/-/docs/utils.md)

<!-- /greptile_comment -->