### PR TITLE
fix: FormattedComment を公開APIの入力型に戻し、内部の確定済み型を ResolvedFormattedComment に分離

### DIFF
--- a/src/@types/config.ts
+++ b/src/@types/config.ts
@@ -1,8 +1,8 @@
 import type {
   CommentSize,
-  FormattedComment,
   IPluginConstructor,
   PlatformFont,
+  ResolvedFormattedComment,
 } from "@/@types/";
 import type { BaseComment } from "@/comments/";
 import type { BaseOptions } from "./options";
@@ -77,7 +77,7 @@ export type BaseConfig = {
   commentPlugins: {
     class: typeof BaseComment;
     condition: (
-      comment: FormattedComment,
+      comment: ResolvedFormattedComment,
       config: BaseConfig,
       options: BaseOptions,
     ) => boolean;

--- a/src/@types/format.formatted.ts
+++ b/src/@types/format.formatted.ts
@@ -54,12 +54,16 @@ export const ZFormattedComment = pipe(
     };
   }),
 );
-export type FormattedComment = InferOutput<typeof ZFormattedComment>;
 /**
- * `FormattedComment` の入力用の型。`id` や `ignoreScale` など default 付きの
- * フィールドは省略できる。`addComments` など公開APIの引数型として使う。
+ * 公開APIの入出力型。`id` や `ignoreScale` など default 付きのフィールドは
+ * 省略できる。`addComments` やコンストラクタなど公開APIの引数型として使う。
  */
-export type FormattedCommentInput = InferInput<typeof ZFormattedComment>;
+export type FormattedComment = InferInput<typeof ZFormattedComment>;
+/**
+ * パース済み・正規化済みのコメントの型。default 付きのフィールドも含めて
+ * 全プロパティが確定している。ライブラリ内部でのみ使う。
+ */
+export type ResolvedFormattedComment = InferOutput<typeof ZFormattedComment>;
 
 /**
  * @deprecated
@@ -73,13 +77,11 @@ export const ZFormattedLegacyComment = omit(ZFormattedCommentEntries, [
 /**
  * @deprecated
  */
-export type FormattedLegacyComment = InferOutput<
-  typeof ZFormattedLegacyComment
->;
+export type FormattedLegacyComment = InferInput<typeof ZFormattedLegacyComment>;
 /**
  * @deprecated
  */
-export type FormattedLegacyCommentInput = InferInput<
+export type ResolvedFormattedLegacyComment = InferOutput<
   typeof ZFormattedLegacyComment
 >;
 

--- a/src/@types/input-parser.ts
+++ b/src/@types/input-parser.ts
@@ -1,6 +1,6 @@
-import type { FormattedComment } from "@/@types/";
+import type { ResolvedFormattedComment } from "@/@types/";
 
 export interface InputParser {
   key: string[];
-  parse: (input: unknown) => FormattedComment[];
+  parse: (input: unknown) => ResolvedFormattedComment[];
 }

--- a/src/@types/options.ts
+++ b/src/@types/options.ts
@@ -3,8 +3,8 @@ import { literal, union } from "valibot";
 
 import type {
   Config,
-  FormattedCommentInput,
-  FormattedLegacyCommentInput,
+  FormattedComment,
+  FormattedLegacyComment,
   OwnerComment,
   RawApiResponse,
   V1Thread,
@@ -28,8 +28,8 @@ export type InputFormatType = InferOutput<typeof ZInputFormatType>;
 export type InputFormat =
   | XMLDocument
   | Xml2jsPacket
-  | FormattedCommentInput[]
-  | FormattedLegacyCommentInput[]
+  | FormattedComment[]
+  | FormattedLegacyComment[]
   | RawApiResponse[]
   | OwnerComment[]
   | V1Thread[]

--- a/src/comments/BaseComment.ts
+++ b/src/comments/BaseComment.ts
@@ -1,6 +1,5 @@
 import type {
   BaseConfig,
-  FormattedComment,
   FormattedCommentWithFont,
   FormattedCommentWithSize,
   FrameActiveState,
@@ -10,6 +9,7 @@ import type {
   MeasureTextResult,
   ParseContentResult,
   Position,
+  ResolvedFormattedComment,
 } from "@/@types/";
 import type { CommentInstanceContext } from "@/contexts";
 import { NotImplementedError } from "@/errors/";
@@ -98,7 +98,7 @@ class BaseComment implements IComment {
    * @param ctx インスタンスコンテキスト
    */
   constructor(
-    comment: FormattedComment,
+    comment: ResolvedFormattedComment,
     renderer: IRenderer,
     index: number,
     ctx: CommentInstanceContext,
@@ -171,7 +171,7 @@ class BaseComment implements IComment {
    * @returns 処理結果
    */
   protected parseCommandAndNicoscript(
-    comment: FormattedComment,
+    comment: ResolvedFormattedComment,
   ): FormattedCommentWithFont {
     console.error(
       "parseCommandAndNicoscript method is not implemented",
@@ -207,7 +207,7 @@ class BaseComment implements IComment {
    * @returns 描画サイズを含むコメント
    */
   protected convertComment(
-    comment: FormattedComment,
+    comment: ResolvedFormattedComment,
   ): FormattedCommentWithSize {
     console.error("convertComment method is not implemented", comment);
     throw new NotImplementedError(this.pluginName, "convertComment");

--- a/src/comments/FlashComment.ts
+++ b/src/comments/FlashComment.ts
@@ -3,13 +3,13 @@ import type {
   ButtonParams,
   CommentContentItem,
   CommentSize,
-  FormattedComment,
   FormattedCommentWithFont,
   FormattedCommentWithSize,
   IRenderer,
   MeasureTextInput,
   MeasureTextResult,
   Position,
+  ResolvedFormattedComment,
 } from "@/@types/";
 import type { CommentInstanceContext } from "@/contexts/";
 import { TypeGuardError } from "@/errors/TypeGuardError";
@@ -69,7 +69,7 @@ class FlashComment extends BaseComment {
   };
   override readonly pluginName: string = "FlashComment";
   constructor(
-    comment: FormattedComment,
+    comment: ResolvedFormattedComment,
     renderer: IRenderer,
     index: number,
     ctx: CommentInstanceContext,
@@ -119,7 +119,9 @@ class FlashComment extends BaseComment {
     this._buttonImageState = undefined;
   }
 
-  override convertComment(comment: FormattedComment): FormattedCommentWithSize {
+  override convertComment(
+    comment: ResolvedFormattedComment,
+  ): FormattedCommentWithSize {
     this._globalScale = getConfig(this.config.commentScale, true);
     return getButtonParts(
       this.getCommentSize(this.parseCommandAndNicoscript(comment)),
@@ -186,7 +188,7 @@ class FlashComment extends BaseComment {
   }
 
   override parseCommandAndNicoscript(
-    comment: FormattedComment,
+    comment: ResolvedFormattedComment,
   ): FormattedCommentWithFont {
     const data = parseCommandAndNicoScript(comment, this.ctx);
     const { content, lineCount, lineOffset } = this.parseContent(

--- a/src/comments/HTML5Comment.ts
+++ b/src/comments/HTML5Comment.ts
@@ -1,6 +1,5 @@
 import type {
   CommentContentItemText,
-  FormattedComment,
   FormattedCommentWithFont,
   FormattedCommentWithSize,
   HTML5Fonts,
@@ -9,6 +8,7 @@ import type {
   MeasureTextInput,
   MeasureTextResult,
   Position,
+  ResolvedFormattedComment,
 } from "@/@types/";
 import type { CommentInstanceContext } from "@/contexts/";
 import { TypeGuardError } from "@/errors/TypeGuardError";
@@ -83,7 +83,7 @@ class HTML5Comment extends BaseComment {
   >();
 
   constructor(
-    comment: FormattedComment,
+    comment: ResolvedFormattedComment,
     context: IRenderer,
     index: number,
     ctx: CommentInstanceContext,
@@ -109,7 +109,9 @@ class HTML5Comment extends BaseComment {
     this.image = undefined;
   }
 
-  override convertComment(comment: FormattedComment): FormattedCommentWithSize {
+  override convertComment(
+    comment: ResolvedFormattedComment,
+  ): FormattedCommentWithSize {
     return this.getCommentSize(this.parseCommandAndNicoscript(comment));
   }
   override getCommentSize(
@@ -164,7 +166,7 @@ class HTML5Comment extends BaseComment {
   }
 
   override parseCommandAndNicoscript(
-    comment: FormattedComment,
+    comment: ResolvedFormattedComment,
   ): FormattedCommentWithFont {
     const data = parseCommandAndNicoScript(comment, this.ctx);
     const { content, lineCount, lineOffset } = this.parseContent(

--- a/src/input/empty.ts
+++ b/src/input/empty.ts
@@ -1,8 +1,8 @@
-import type { FormattedComment, InputParser } from "@/@types";
+import type { InputParser, ResolvedFormattedComment } from "@/@types";
 
 export const EmptyParser: InputParser = {
   key: ["empty"],
-  parse: (): FormattedComment[] => {
+  parse: (): ResolvedFormattedComment[] => {
     return [];
   },
 };

--- a/src/input/formatted.ts
+++ b/src/input/formatted.ts
@@ -1,11 +1,11 @@
 import { array, parse } from "valibot";
 
-import type { FormattedComment, InputParser } from "@/@types";
+import type { InputParser, ResolvedFormattedComment } from "@/@types";
 import { ZFormattedComment } from "@/@types";
 
 export const FormattedParser: InputParser = {
   key: ["formatted", "niconicome"],
-  parse: (input: unknown): FormattedComment[] => {
+  parse: (input: unknown): ResolvedFormattedComment[] => {
     return parse(array(ZFormattedComment), input);
   },
 };

--- a/src/input/legacy.ts
+++ b/src/input/legacy.ts
@@ -1,9 +1,9 @@
 import { array, parse, safeParse, unknown as unknownSchema } from "valibot";
 
 import {
-  type FormattedComment,
   type InputParser,
   OWNER_DEFAULT_COLLISION_LAYER,
+  type ResolvedFormattedComment,
   VIEWER_DEFAULT_COLLISION_LAYER,
   ZApiChat,
 } from "@/@types";
@@ -22,8 +22,8 @@ export const LegacyParser: InputParser = {
  * @param data legacy apiから帰ってきたデータ
  * @returns 変換後のデータ
  */
-const fromLegacy = (data: unknown[]): FormattedComment[] => {
-  const data_: FormattedComment[] = [];
+const fromLegacy = (data: unknown[]): ResolvedFormattedComment[] => {
+  const data_: ResolvedFormattedComment[] = [];
   const userIdMap = new Map<string, number>();
   for (const _val of data) {
     const chat =
@@ -35,7 +35,7 @@ const fromLegacy = (data: unknown[]): FormattedComment[] => {
     const value = val.output;
     if (value.deleted !== 1) {
       const owner = !value.user_id;
-      const tmpParam: FormattedComment = {
+      const tmpParam: ResolvedFormattedComment = {
         id: value.no,
         vpos: value.vpos,
         content: value.content || "",

--- a/src/input/legacyOwner.ts
+++ b/src/input/legacyOwner.ts
@@ -1,7 +1,7 @@
 import {
-  type FormattedComment,
   type InputParser,
   OWNER_DEFAULT_COLLISION_LAYER,
+  type ResolvedFormattedComment,
   toFiniteNumberInRange,
 } from "@/@types";
 import { InvalidFormatError } from "@/errors";
@@ -20,8 +20,8 @@ export const LegacyOwnerParser: InputParser = {
  * @param data 旧投米のテキストデータ
  * @returns 変換後のデータ
  */
-const fromLegacyOwner = (data: string): FormattedComment[] => {
-  const data_: FormattedComment[] = [];
+const fromLegacyOwner = (data: string): ResolvedFormattedComment[] => {
+  const data_: ResolvedFormattedComment[] = [];
   const comments = data.split(/\r\n|\r|\n/);
   for (let i = 0, n = comments.length; i < n; i++) {
     const value = comments[i] ?? "";
@@ -39,7 +39,7 @@ const fromLegacyOwner = (data: string): FormattedComment[] => {
       max: Math.floor(Number.MAX_SAFE_INTEGER / 100),
     });
     if (seconds === undefined) continue;
-    const tmpParam: FormattedComment = {
+    const tmpParam: ResolvedFormattedComment = {
       id: i,
       vpos: seconds * 100,
       content: commentData[2] ?? "",

--- a/src/input/owner.ts
+++ b/src/input/owner.ts
@@ -1,10 +1,10 @@
 import { array, parse } from "valibot";
 
 import {
-  type FormattedComment,
   type InputParser,
   OWNER_DEFAULT_COLLISION_LAYER,
   type OwnerComment,
+  type ResolvedFormattedComment,
   toFiniteNumberInRange,
   ZOwnerComment,
 } from "@/@types";
@@ -21,14 +21,14 @@ export const OwnerParser: InputParser = {
  * @param data 投米のデータ
  * @returns 変換後のデータ
  */
-const fromOwner = (data: OwnerComment[]): FormattedComment[] => {
-  const data_: FormattedComment[] = [];
+const fromOwner = (data: OwnerComment[]): ResolvedFormattedComment[] => {
+  const data_: ResolvedFormattedComment[] = [];
   for (let i = 0, n = data.length; i < n; i++) {
     const value = data[i];
     if (!value) continue;
     const vpos = time2vpos(value.time);
     if (vpos === undefined) continue;
-    const tmpParam: FormattedComment = {
+    const tmpParam: ResolvedFormattedComment = {
       id: i,
       vpos,
       content: value.comment,

--- a/src/input/v1.ts
+++ b/src/input/v1.ts
@@ -2,8 +2,8 @@ import { array, parse } from "valibot";
 
 import type { InputParser } from "@/@types";
 import {
-  type FormattedComment,
   OWNER_DEFAULT_COLLISION_LAYER,
+  type ResolvedFormattedComment,
   type V1Thread,
   VIEWER_DEFAULT_COLLISION_LAYER,
   ZV1Thread,
@@ -24,8 +24,8 @@ export const V1Parser: InputParser = {
  * @param data v1 apiから帰ってきたデータ
  * @returns 変換後のデータ
  */
-const fromV1 = (data: V1Thread[]): FormattedComment[] => {
-  const data_: FormattedComment[] = [];
+const fromV1 = (data: V1Thread[]): ResolvedFormattedComment[] => {
+  const data_: ResolvedFormattedComment[] = [];
   const userIdMap = new Map<string, number>();
   for (const item of data) {
     const val = item.comments;
@@ -34,7 +34,7 @@ const fromV1 = (data: V1Thread[]): FormattedComment[] => {
     for (const value of val) {
       const date = date2time(value.postedAt);
       if (date === undefined) continue;
-      const tmpParam: FormattedComment = {
+      const tmpParam: ResolvedFormattedComment = {
         id: value.no,
         vpos: Math.floor(value.vposMs / 10),
         content: value.body,

--- a/src/input/xml2js.ts
+++ b/src/input/xml2js.ts
@@ -1,9 +1,9 @@
 import { parse } from "valibot";
 
 import {
-  type FormattedComment,
   type InputParser,
   OWNER_DEFAULT_COLLISION_LAYER,
+  type ResolvedFormattedComment,
   toFiniteNumberInRange,
   VIEWER_DEFAULT_COLLISION_LAYER,
   type Xml2jsPacket,
@@ -19,8 +19,8 @@ export const Xml2jsParser: InputParser = {
   },
 };
 
-const fromXml2js = (data: Xml2jsPacket): FormattedComment[] => {
-  const data_: FormattedComment[] = [];
+const fromXml2js = (data: Xml2jsPacket): ResolvedFormattedComment[] => {
+  const data_: ResolvedFormattedComment[] = [];
   const userIdMap = new Map<string, number>();
   let index = data.packet.chat.length;
   for (const item of data.packet.chat) {
@@ -45,7 +45,7 @@ const fromXml2js = (data: Xml2jsPacket): FormattedComment[] => {
       continue;
     }
     const owner = !(item.$.owner === "0" || item.$.user_id);
-    const tmpParam: FormattedComment = {
+    const tmpParam: ResolvedFormattedComment = {
       id,
       vpos,
       content: item._,

--- a/src/input/xmlDocument.ts
+++ b/src/input/xmlDocument.ts
@@ -1,7 +1,7 @@
 import {
-  type FormattedComment,
   type InputParser,
   OWNER_DEFAULT_COLLISION_LAYER,
+  type ResolvedFormattedComment,
   toFiniteNumberInRange,
   VIEWER_DEFAULT_COLLISION_LAYER,
 } from "@/@types";
@@ -22,7 +22,7 @@ export const assignUserId = (
 
 export const XmlDocumentParser: InputParser = {
   key: ["XMLDocument", "niconicome"],
-  parse: (input: unknown): FormattedComment[] => {
+  parse: (input: unknown): ResolvedFormattedComment[] => {
     let isXmlDocument = false;
     if (typeof input === "object" && input !== null) {
       try {
@@ -43,8 +43,8 @@ export const XmlDocumentParser: InputParser = {
  * @param data 吐き出されたxmlをDOMParserでparseFromStringしたもの
  * @returns 変換後のデータ
  */
-const parseXMLDocument = (data: XMLDocument): FormattedComment[] => {
-  const data_: FormattedComment[] = [];
+const parseXMLDocument = (data: XMLDocument): ResolvedFormattedComment[] => {
+  const data_: ResolvedFormattedComment[] = [];
   const userIdMap = new Map<string, number>();
   let index = Array.from(data.documentElement.children).length;
   for (const item of Array.from(data.documentElement.children)) {
@@ -71,7 +71,7 @@ const parseXMLDocument = (data: XMLDocument): FormattedComment[] => {
       continue;
     }
     const owner = !item.getAttribute("user_id");
-    const tmpParam: FormattedComment = {
+    const tmpParam: ResolvedFormattedComment = {
       id,
       vpos,
       content: item.textContent ?? "",

--- a/src/inputParser.ts
+++ b/src/inputParser.ts
@@ -1,6 +1,6 @@
 import { ValiError } from "valibot";
 
-import type { FormattedComment, InputFormatType } from "@/@types/";
+import type { InputFormatType, ResolvedFormattedComment } from "@/@types/";
 import { InvalidFormatError } from "@/errors";
 import { parsers } from "@/input";
 
@@ -13,7 +13,7 @@ import { parsers } from "@/input";
 const convert2formattedComment = (
   data: unknown,
   type: InputFormatType,
-): FormattedComment[] => {
+): ResolvedFormattedComment[] => {
   const targetParsers = parsers.filter((parser) => parser.key.includes(type));
   if (targetParsers.length === 0) throw new InvalidFormatError();
 
@@ -41,7 +41,7 @@ const convert2formattedComment = (
  * @param data ソート対象の配列
  * @returns ソート後の配列
  */
-const sort = (data: FormattedComment[]): FormattedComment[] => {
+const sort = (data: ResolvedFormattedComment[]): ResolvedFormattedComment[] => {
   data.sort(
     (a, b) => a.vpos - b.vpos || a.date - b.date || a.date_usec - b.date_usec,
   );

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,6 @@ import type {
   Collision,
   CommentEventHandlerMap,
   FormattedComment,
-  FormattedCommentInput,
   FrameActiveState,
   IComment,
   InputFormat,
@@ -12,6 +11,7 @@ import type {
   IRenderer,
   Options,
   Position,
+  ResolvedFormattedComment,
   Timeline,
 } from "@/@types/";
 import { ZFormattedComment } from "@/@types/";
@@ -380,7 +380,7 @@ class NiconiComments {
    * @param _rawData コメントデータ
    * @returns コメントのインスタンス配列
    */
-  private preRendering(_rawData: FormattedComment[]) {
+  private preRendering(_rawData: ResolvedFormattedComment[]) {
     let rawData = _rawData;
     const preRenderingStart = performance.now();
     if (this.ctx.options.keepCA) {
@@ -533,12 +533,15 @@ class NiconiComments {
    * ※すでに存在するコメントの位置はvposに関係なく更新されません
    * @param rawComments コメントデータ
    */
-  public addComments(...rawComments: FormattedCommentInput[]) {
-    const validComments = rawComments.reduce<FormattedComment[]>((pv, val) => {
-      const parsedComment = safeParse(ZFormattedComment, val);
-      if (parsedComment.success) pv.push(parsedComment.output);
-      return pv;
-    }, []);
+  public addComments(...rawComments: FormattedComment[]) {
+    const validComments = rawComments.reduce<ResolvedFormattedComment[]>(
+      (pv, val) => {
+        const parsedComment = safeParse(ZFormattedComment, val);
+        if (parsedComment.success) pv.push(parsedComment.output);
+        return pv;
+      },
+      [],
+    );
     if (validComments.length === 0) return;
     this.ctx.rangeCache.reset();
     const touchedTimeline = new Set<number>();

--- a/src/utils/comment.ts
+++ b/src/utils/comment.ts
@@ -9,7 +9,6 @@ import type {
   CommentLoc,
   CommentSize,
   DefaultCommand,
-  FormattedComment,
   FormattedCommentWithSize,
   IComment,
   MeasureTextInput,
@@ -17,6 +16,7 @@ import type {
   NicoScriptReplace,
   ParseCommandAndNicoScriptResult,
   ParsedCommand,
+  ResolvedFormattedComment,
   Timeline,
 } from "@/@types/";
 import {
@@ -595,7 +595,7 @@ const getDefaultCommand = (
  * @returns コメントが@置換の処理対象かどうか
  */
 const nicoscriptReplaceIgnoreable = (
-  comment: FormattedComment,
+  comment: ResolvedFormattedComment,
   item: NicoScriptReplace,
 ) => {
   const targetMatches =
@@ -621,7 +621,7 @@ const nicoscriptReplaceIgnoreable = (
  * @param nicoScripts ニコスクリプト
  */
 const applyNicoScriptReplace = (
-  comment: FormattedComment,
+  comment: ResolvedFormattedComment,
   commands: ParsedCommand,
   nicoScripts: NicoScript,
 ) => {
@@ -666,7 +666,7 @@ const applyNicoScriptReplace = (
  * @returns パース後のコメント
  */
 const parseCommandAndNicoScript = (
-  comment: FormattedComment,
+  comment: ResolvedFormattedComment,
   ctx: CommentInstanceContext,
 ): ParseCommandAndNicoScriptResult => {
   const { config, options, nicoScripts, rangeCache } = ctx;
@@ -745,7 +745,7 @@ const parseBrackets = (input: string) => {
  * @param nicoScripts ニコスクリプト
  */
 const addNicoscriptReplace = (
-  comment: FormattedComment,
+  comment: ResolvedFormattedComment,
   commands: ParsedCommand,
   nicoScripts: NicoScript,
   commandInput: string,
@@ -801,7 +801,7 @@ const sortNicoscriptReplace = (nicoScripts: NicoScript) => {
  * @param rangeCache レンジキャッシュ
  */
 const processNicoscript = (
-  comment: FormattedComment,
+  comment: ResolvedFormattedComment,
   commands: ParsedCommand,
   nicoScripts: NicoScript,
   rangeCache: RangeCacheContext,
@@ -858,7 +858,7 @@ const processNicoscript = (
  * @param nicoScripts ニコスクリプト
  */
 const processDefaultScript = (
-  comment: FormattedComment,
+  comment: ResolvedFormattedComment,
   commands: ParsedCommand,
   nicoScripts: NicoScript,
 ) => {
@@ -880,7 +880,7 @@ const processDefaultScript = (
  * @param rangeCache レンジキャッシュ
  */
 const processReverseScript = (
-  comment: FormattedComment,
+  comment: ResolvedFormattedComment,
   commands: ParsedCommand,
   nicoScripts: NicoScript,
   rangeCache: RangeCacheContext,
@@ -907,7 +907,7 @@ const processReverseScript = (
  * @param rangeCache レンジキャッシュ
  */
 const processBanScript = (
-  comment: FormattedComment,
+  comment: ResolvedFormattedComment,
   commands: ParsedCommand,
   nicoScripts: NicoScript,
   rangeCache: RangeCacheContext,
@@ -927,7 +927,7 @@ const processBanScript = (
  * @param nicoScripts ニコスクリプト
  */
 const processSeekDisableScript = (
-  comment: FormattedComment,
+  comment: ResolvedFormattedComment,
   commands: ParsedCommand,
   nicoScripts: NicoScript,
 ) => {
@@ -946,7 +946,7 @@ const processSeekDisableScript = (
  * @param nicoScripts ニコスクリプト
  */
 const processJumpScript = (
-  comment: FormattedComment,
+  comment: ResolvedFormattedComment,
   commands: ParsedCommand,
   input: string,
   nicoScripts: NicoScript,
@@ -969,7 +969,7 @@ const processJumpScript = (
  * @param commands 対象のコマンド
  */
 const processAtButton = (
-  comment: FormattedComment,
+  comment: ResolvedFormattedComment,
   commands: ParsedCommand,
 ) => {
   const args = parseBrackets(
@@ -1008,7 +1008,7 @@ const processAtButton = (
  * @returns パースしたコマンド
  */
 const parseCommands = (
-  comment: FormattedComment,
+  comment: ResolvedFormattedComment,
   config: BaseConfig,
   options: BaseOptions,
 ): ParsedCommand => {
@@ -1049,7 +1049,7 @@ const parseCommands = (
  * @param config インスタンス設定
  */
 const parseCommand = (
-  comment: FormattedComment,
+  comment: ResolvedFormattedComment,
   _command: string,
   result: ParsedCommand,
   isFlash: boolean,
@@ -1169,7 +1169,7 @@ const getScale = (match: RegExpMatchArray | null) => {
  * @returns Flash適用対象かどうか
  */
 const isFlashComment = (
-  comment: FormattedComment,
+  comment: ResolvedFormattedComment,
   config: BaseConfig,
   options: BaseOptions,
 ): boolean =>

--- a/src/utils/commentArt.ts
+++ b/src/utils/commentArt.ts
@@ -1,4 +1,4 @@
-import type { BaseConfig, FormattedComment } from "@/@types";
+import type { BaseConfig, ResolvedFormattedComment } from "@/@types";
 
 const RE_CA_FILTER = /@[\d.]+|184|device:.+|patissier|ca/;
 const HASH_OFFSET_A = 0x811c9dc5;
@@ -8,7 +8,7 @@ const HASH_PRIME_B = 0x85ebca6b;
 const HASH_SEPARATOR = 0x1f;
 
 type GroupedByUser = {
-  comments: FormattedComment[];
+  comments: ResolvedFormattedComment[];
   userId: number;
 }[];
 type GroupedByTime = {
@@ -16,7 +16,7 @@ type GroupedByTime = {
   userId: number;
 }[];
 type GroupedByTimeItem = {
-  comments: FormattedComment[];
+  comments: ResolvedFormattedComment[];
   range: {
     start: number;
     end: number;
@@ -35,9 +35,9 @@ type IndexedGroupedByTimeItem = GroupedByTimeItem & {
  * @returns レイヤー分離後のコメントデータ
  */
 const changeCALayer = (
-  rawData: FormattedComment[],
+  rawData: ResolvedFormattedComment[],
   config: BaseConfig,
-): FormattedComment[] => {
+): ResolvedFormattedComment[] => {
   const userScoreList = getUsersScore(rawData);
   const filteredComments = removeDuplicateCommentArt(rawData, config);
   const commentArts = filteredComments.filter(
@@ -60,7 +60,7 @@ const changeCALayer = (
  * @returns ユーザーIDごとのスコア
  */
 const getUsersScore = (
-  comments: FormattedComment[],
+  comments: ResolvedFormattedComment[],
 ): { [key: string]: number } => {
   const userScoreList: { [key: number]: number } = {};
   for (const comment of comments) {
@@ -91,10 +91,10 @@ const getUsersScore = (
  * @returns 重複を排除したコメントデータ
  */
 const removeDuplicateCommentArt = (
-  comments: FormattedComment[],
+  comments: ResolvedFormattedComment[],
   config: BaseConfig,
 ) => {
-  const index = new Map<string, FormattedComment>();
+  const index = new Map<string, ResolvedFormattedComment>();
   return comments.filter((comment) => {
     const key = getCommentArtDuplicateKey(comment);
     const lastComment = index.get(key);
@@ -113,7 +113,7 @@ const removeDuplicateCommentArt = (
   });
 };
 
-const getCommentArtDuplicateKey = (comment: FormattedComment) => {
+const getCommentArtDuplicateKey = (comment: ResolvedFormattedComment) => {
   const normalizedMail = Array.from(
     new Set(comment.mail.filter((mail) => !RE_CA_FILTER.test(mail))),
   ).sort((a, b) => a.localeCompare(b));
@@ -181,10 +181,12 @@ const updateLayerId = (filteredComments: GroupedByTime) => {
  * @param comments コメントデータ
  * @returns ユーザーごとにグループ化したコメントデータ
  */
-const groupCommentsByUser = (comments: FormattedComment[]): GroupedByUser => {
+const groupCommentsByUser = (
+  comments: ResolvedFormattedComment[],
+): GroupedByUser => {
   const userMap = new Map<
     number,
-    { comments: FormattedComment[]; userId: number }
+    { comments: ResolvedFormattedComment[]; userId: number }
   >();
   for (const comment of comments) {
     let user = userMap.get(comment.user_id);
@@ -217,7 +219,7 @@ const groupCommentsByTime = (comments: GroupedByUser, config: BaseConfig) => {
  * @returns 時間ごとにグループ化したコメントデータ
  */
 const groupUserCommentsByTime = (
-  comments: FormattedComment[],
+  comments: ResolvedFormattedComment[],
   config: BaseConfig,
 ) => {
   const result: IndexedGroupedByTimeItem[] = [];

--- a/src/utils/flash.ts
+++ b/src/utils/flash.ts
@@ -6,8 +6,8 @@ import type {
   CommentContentItem,
   CommentFlashFont,
   CommentFlashFontParsed,
-  FormattedComment,
   FormattedCommentWithSize,
+  ResolvedFormattedComment,
 } from "@/@types";
 import { VIEWER_DEFAULT_COLLISION_LAYER } from "@/@types";
 import { getConfig } from "@/utils/config";
@@ -467,7 +467,7 @@ const getButtonParts = (
 const buildAtButtonComment = (
   comment: FormattedCommentWithSize,
   vpos: number,
-): FormattedComment | undefined => {
+): ResolvedFormattedComment | undefined => {
   if (!comment.button || comment.button.limit <= 0) return;
   comment.button.limit -= 1;
   const mail = [...comment.button.commentMail, "from_button"];

--- a/src/utils/plugins.ts
+++ b/src/utils/plugins.ts
@@ -1,4 +1,4 @@
-import type { FormattedComment, IRenderer } from "@/@types";
+import type { IRenderer, ResolvedFormattedComment } from "@/@types";
 import { HTML5Comment } from "@/comments";
 import type { CommentInstanceContext } from "@/contexts/";
 
@@ -11,7 +11,7 @@ import type { CommentInstanceContext } from "@/contexts/";
  * @returns プラグインまたは内臓のコメントインスタンス
  */
 const createCommentInstance = (
-  comment: FormattedComment,
+  comment: ResolvedFormattedComment,
   renderer: IRenderer,
   index: number,
   ctx: CommentInstanceContext,


### PR DESCRIPTION
## Summary

PR #413 (Release v0.3.2) の Greptile レビューで指摘された、`FormattedComment` の互換性破壊が未解消の問題を修正します。

- `#410` で `FormattedComment.ignoreScale` が新規追加され、`InferOutput` ベースの `FormattedComment` 型ではこれが必須プロパティになった
- `#414` で `FormattedCommentInput` (InferInput) を新設したが、これは `addComments` / `InputFormat` など公開APIの引数型のみに適用されており、`FormattedComment` 自体は変更されなかった
- `niconicomments-convert` の `electron/lib/niconico/comments/utils.ts` のように、`FormattedComment` 型で直接オブジェクトリテラルを組み立てている外部consumerは、`ignoreScale` を省略すると型エラーになる状態が残っていた

## Changes

- `FormattedComment` (および `FormattedLegacyComment`) を `InferInput` ベースに戻し、default 付きフィールドを省略可能にした（公開APIの型名は変えず、以前と同じ書き方で使える）
- パース後に全フィールドが確定した内部表現は `ResolvedFormattedComment` (`FormattedLegacyComment` は `ResolvedFormattedLegacyComment`) という別名に切り出し、ライブラリ内部でのみ使用
- 新設した `FormattedCommentInput` / `FormattedLegacyCommentInput` は不要になったため削除
- 内部の呼び出し箇所（main.ts, inputParser.ts, input/*.ts, comments/*.ts, utils/comment.ts, utils/commentArt.ts, utils/flash.ts, utils/plugins.ts, @types/config.ts, @types/input-parser.ts, @types/options.ts）を `ResolvedFormattedComment` を使うよう追従

## Test plan

- [x] `npm run check-types` — エラーなし
- [x] `npx biome check src` — エラーなし
- [x] `npx vitest run tests/unit` — 210件全てpass
- [x] `niconicomments-convert` の `convertV3ToFormatted`（`ignoreScale` を含まない `FormattedComment` オブジェクトリテラル構築）を再現して単独コンパイル確認し、型エラーが解消されたことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR separates permissive public comment input types from fully resolved internal comment types and migrates the rendering pipeline to the resolved aliases. The internal boundary is consistently applied, but redefining the established FormattedComment name as the permissive input shape breaks downstream code that uses it as a normalized output model.
- Restores optional schema-defaulted fields on FormattedComment and FormattedLegacyComment.
- Introduces ResolvedFormattedComment and ResolvedFormattedLegacyComment for parsed internal values.
- Migrates parsers, rendering classes, plugins, and comment utilities to the resolved type.
- Keeps constructor and addComments inputs permissive while validating them before internal use.
</details>

<h3>Confidence Score: 4/5</h3>

The PR should not merge until the public permissive-input type is separated without weakening FormattedComment for downstream consumers that use it as a resolved output model.

Internal normalization is consistently preserved, but the public type rename makes defaulted fields optional and causes concrete downstream TypeScript failures when existing consumers read those fields as always present.

**Files Needing Attention:** src/@types/format.formatted.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/@types/format.formatted.ts | Splits permissive and resolved comment types, but reuses FormattedComment for the permissive shape despite existing consumers treating it as complete output. |
| src/main.ts | Correctly accepts permissive FormattedComment values and converts successful schema outputs to ResolvedFormattedComment before internal processing. |
| src/@types/options.ts | Updates formatted constructor input variants to use the restored permissive public type. |
| src/@types/input-parser.ts | Accurately declares that parser implementations return fully resolved comments. |
| src/input/formatted.ts | Validates permissive formatted input through ZFormattedComment so defaults are applied before returning resolved comments. |
| src/utils/plugins.ts | Migrates plugin selection and comment construction to the resolved internal model. |
| src/comments/BaseComment.ts | Migrates the base rendering contract to consume only normalized comments. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Consumer[Public consumer]
  Input[FormattedComment<br/>InferInput]
  Schema[ZFormattedComment validation]
  Resolved[ResolvedFormattedComment<br/>InferOutput]
  Internal[Parsers, plugins, and renderers]
  Consumer --> Input --> Schema --> Resolved --> Internal
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20xpadev-net%2Fniconicomments%20PR%20%23417%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=xpadev-net%2Fniconicomments&pr=417&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2F%40types%2Fformat.formatted.ts%3A61%0A**FormattedComment%20output%20contract%20breaks**%0A%0AWhen%20a%20downstream%20consumer%20uses%20%60FormattedComment%60%20for%20normalized%20output%2C%20changing%20it%20to%20%60InferInput%60%20makes%20defaulted%20fields%20optional%2C%20causing%20TypeScript%20failures%20at%20existing%20reads%20such%20as%20%5B%60comment.mail.join%28%22%20%22%29%60%5D%28https%3A%2F%2Fgithub.com%2Fxpadev-net%2Fniconicomments-convert%2Fblob%2FHEAD%2Felectron%2Flib%2Fniconico%2Fcomments%2Fcomments.ts%29.%20Keep%20the%20established%20output%20contract%20available%20under%20%60FormattedComment%60%2C%20or%20migrate%20supported%20output%20consumers%20to%20a%20separate%20public%20resolved%20type%20without%20weakening%20their%20field%20guarantees.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=xpadev-net%2Fniconicomments&pr=417&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/@types/format.formatted.ts:61
**FormattedComment output contract breaks**

When a downstream consumer uses `FormattedComment` for normalized output, changing it to `InferInput` makes defaulted fields optional, causing TypeScript failures at existing reads such as [`comment.mail.join(" ")`](https://github.com/xpadev-net/niconicomments-convert/blob/HEAD/electron/lib/niconico/comments/comments.ts). Keep the established output contract available under `FormattedComment`, or migrate supported output consumers to a separate public resolved type without weakening their field guarantees.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: FormattedComment を再び緩い入力型に戻し、内部の確定済..."](https://github.com/xpadev-net/niconicomments/commit/a77610beed41f1b14475ebbe0500cc5eaa77782b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53749963)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Input parsing](https://app.greptile.com/xpa/-/custom-context/knowledge-base/xpadev-net/niconicomments/-/docs/input-parsing.md)
- Knowledge Base — [Comment Model](https://app.greptile.com/xpa/-/custom-context/knowledge-base/xpadev-net/niconicomments/-/docs/comment-model.md)
- Knowledge Base — [Main entrypoint: constructing and driving `NiconiComments`](https://app.greptile.com/xpa/-/custom-context/knowledge-base/xpadev-net/niconicomments/-/docs/main-entrypoint.md)
</details>

<!-- /greptile_comment -->