### PR TITLE
refactor: PR #413 レビュー指摘の効率性・重複コードを解消

### DIFF
--- a/src/@types/format.numeric.ts
+++ b/src/@types/format.numeric.ts
@@ -40,6 +40,8 @@ export const ZCommentUserId = rangedNumber({ min: -1 });
 // changeCALayer (see src/utils/commentArt.ts).
 export const VIEWER_DEFAULT_COLLISION_LAYER = -1;
 export const OWNER_DEFAULT_COLLISION_LAYER = -2;
+export const getDefaultCollisionLayer = (owner: boolean) =>
+  owner ? OWNER_DEFAULT_COLLISION_LAYER : VIEWER_DEFAULT_COLLISION_LAYER;
 export const ZCommentLayer = union([
   literal(VIEWER_DEFAULT_COLLISION_LAYER),
   literal(OWNER_DEFAULT_COLLISION_LAYER),

--- a/src/comments/BaseComment.ts
+++ b/src/comments/BaseComment.ts
@@ -140,6 +140,12 @@ class BaseComment implements IComment {
   get ignoreScale() {
     return this.comment.ignoreScale;
   }
+  protected getLayerScale(parsedData: FormattedCommentWithFont) {
+    return (
+      (parsedData.ignoreScale ? 1 : this.ctx.options.scale) *
+      (parsedData.commandScale ?? 1)
+    );
+  }
   get owner() {
     return this.comment.owner;
   }

--- a/src/comments/FlashComment.ts
+++ b/src/comments/FlashComment.ts
@@ -135,9 +135,7 @@ class FlashComment extends BaseComment {
   override getCommentSize(
     parsedData: FormattedCommentWithFont,
   ): FormattedCommentWithSize {
-    const layerScale =
-      (parsedData.ignoreScale ? 1 : this.ctx.options.scale) *
-      (parsedData.commandScale ?? 1);
+    const layerScale = this.getLayerScale(parsedData);
     if (parsedData.invisible) {
       return {
         ...parsedData,

--- a/src/comments/HTML5Comment.ts
+++ b/src/comments/HTML5Comment.ts
@@ -115,9 +115,7 @@ class HTML5Comment extends BaseComment {
   override getCommentSize(
     parsedData: FormattedCommentWithFont,
   ): FormattedCommentWithSize {
-    const layerScale =
-      (parsedData.ignoreScale ? 1 : this.ctx.options.scale) *
-      (parsedData.commandScale ?? 1);
+    const layerScale = this.getLayerScale(parsedData);
     if (parsedData.invisible) {
       return {
         ...parsedData,

--- a/src/input/legacy.ts
+++ b/src/input/legacy.ts
@@ -2,9 +2,8 @@ import { array, parse, safeParse, unknown as unknownSchema } from "valibot";
 
 import {
   type FormattedComment,
+  getDefaultCollisionLayer,
   type InputParser,
-  OWNER_DEFAULT_COLLISION_LAYER,
-  VIEWER_DEFAULT_COLLISION_LAYER,
   ZApiChat,
 } from "@/@types";
 
@@ -45,9 +44,7 @@ const fromLegacy = (data: unknown[]): FormattedComment[] => {
         premium: value.premium === 1,
         mail: [],
         user_id: -1,
-        layer: owner
-          ? OWNER_DEFAULT_COLLISION_LAYER
-          : VIEWER_DEFAULT_COLLISION_LAYER,
+        layer: getDefaultCollisionLayer(owner),
         ignoreScale: false,
         is_my_post: false,
       };

--- a/src/input/v1.ts
+++ b/src/input/v1.ts
@@ -3,9 +3,8 @@ import { array, parse } from "valibot";
 import type { InputParser } from "@/@types";
 import {
   type FormattedComment,
-  OWNER_DEFAULT_COLLISION_LAYER,
+  getDefaultCollisionLayer,
   type V1Thread,
-  VIEWER_DEFAULT_COLLISION_LAYER,
   ZV1Thread,
 } from "@/@types";
 
@@ -44,9 +43,7 @@ const fromV1 = (data: V1Thread[]): FormattedComment[] => {
         premium: value.isPremium,
         mail: value.commands,
         user_id: -1,
-        layer: owner
-          ? OWNER_DEFAULT_COLLISION_LAYER
-          : VIEWER_DEFAULT_COLLISION_LAYER,
+        layer: getDefaultCollisionLayer(owner),
         ignoreScale: false,
         is_my_post: value.isMyPost,
       };

--- a/src/input/xml2js.ts
+++ b/src/input/xml2js.ts
@@ -2,10 +2,9 @@ import { parse } from "valibot";
 
 import {
   type FormattedComment,
+  getDefaultCollisionLayer,
   type InputParser,
-  OWNER_DEFAULT_COLLISION_LAYER,
   toFiniteNumberInRange,
-  VIEWER_DEFAULT_COLLISION_LAYER,
   type Xml2jsPacket,
 } from "@/@types";
 import { ZXml2jsPacket } from "@/@types/";
@@ -55,9 +54,7 @@ const fromXml2js = (data: Xml2jsPacket): FormattedComment[] => {
       premium: item.$.premium === "1",
       mail: item.$.mail.split(/\s+/g),
       user_id: -1,
-      layer: owner
-        ? OWNER_DEFAULT_COLLISION_LAYER
-        : VIEWER_DEFAULT_COLLISION_LAYER,
+      layer: getDefaultCollisionLayer(owner),
       ignoreScale: false,
       is_my_post: false,
     };

--- a/src/input/xmlDocument.ts
+++ b/src/input/xmlDocument.ts
@@ -1,9 +1,8 @@
 import {
   type FormattedComment,
+  getDefaultCollisionLayer,
   type InputParser,
-  OWNER_DEFAULT_COLLISION_LAYER,
   toFiniteNumberInRange,
-  VIEWER_DEFAULT_COLLISION_LAYER,
 } from "@/@types";
 import { InvalidFormatError } from "@/errors";
 import typeGuard from "@/typeGuard";
@@ -81,9 +80,7 @@ const parseXMLDocument = (data: XMLDocument): FormattedComment[] => {
       premium: item.getAttribute("premium") === "1",
       mail: [],
       user_id: -1,
-      layer: owner
-        ? OWNER_DEFAULT_COLLISION_LAYER
-        : VIEWER_DEFAULT_COLLISION_LAYER,
+      layer: getDefaultCollisionLayer(owner),
       ignoreScale: false,
       is_my_post: false,
     };

--- a/src/utils/comment.ts
+++ b/src/utils/comment.ts
@@ -188,6 +188,7 @@ type MovableCollisionIndex = {
   buckets: Map<number, IComment[]>;
   durations: Set<number>;
   registeredComments: WeakSet<IComment>;
+  pending: IComment[];
 };
 
 const movableCollisionIndexes = new WeakMap<Collision, MovableCollisionIndex>();
@@ -199,6 +200,7 @@ const getMovableCollisionIndex = (collision: Collision) => {
     buckets: new Map(),
     durations: new Set(),
     registeredComments: new WeakSet(),
+    pending: [],
   };
   movableCollisionIndexes.set(collision, created);
   return created;
@@ -249,14 +251,10 @@ const forEachMovableCollisionBucket = (
   }
 };
 
-const registerMovableCollisionComment = (
-  collision: Collision,
+const addMovableCollisionCommentToBuckets = (
+  index: MovableCollisionIndex,
   comment: IComment,
 ) => {
-  const index = getMovableCollisionIndex(collision);
-  if (index.registeredComments.has(comment)) return;
-  index.registeredComments.add(comment);
-  index.durations.add(comment.long);
   forEachMovableCollisionBucket(comment, (bucket) => {
     const comments = index.buckets.get(bucket);
     if (comments) {
@@ -265,6 +263,32 @@ const registerMovableCollisionComment = (
       index.buckets.set(bucket, [comment]);
     }
   });
+};
+
+// durations が1種類しかない間はバケットへの登録を遅延させ、
+// 異なる長さのコメントが現れて実際に候補検索が必要になった時点でまとめてバケット化する
+const flushPendingMovableCollisionComments = (index: MovableCollisionIndex) => {
+  if (index.pending.length === 0) return;
+  for (const comment of index.pending) {
+    addMovableCollisionCommentToBuckets(index, comment);
+  }
+  index.pending = [];
+};
+
+const registerMovableCollisionComment = (
+  collision: Collision,
+  comment: IComment,
+) => {
+  const index = getMovableCollisionIndex(collision);
+  if (index.registeredComments.has(comment)) return;
+  index.registeredComments.add(comment);
+  index.durations.add(comment.long);
+  if (index.durations.size === 1) {
+    index.pending.push(comment);
+    return;
+  }
+  flushPendingMovableCollisionComments(index);
+  addMovableCollisionCommentToBuckets(index, comment);
 };
 
 const doMovableTrajectoriesIntersect = (
@@ -319,6 +343,7 @@ const getAnalyticMovableCollisionCandidates = (
   if (index.durations.size === 1 && index.durations.has(comment.long)) {
     return undefined;
   }
+  flushPendingMovableCollisionComments(index);
   const commentRange = getMovableCommentActiveRange(comment);
   const commentSpeed =
     (config.commentDrawRange + comment.width * config.nakaCommentSpeedOffset) /


### PR DESCRIPTION
## Summary
`/code-review high` による PR #413 のレビューで指摘された、優先度の低い(コンパイルは通るが将来の保守性・効率性に関わる)3件を修正。

- `src/utils/comment.ts`: naka コメントの衝突判定バケットを、登録済みコメントの再生時間(duration)が単一種類の間は構築せず、異なる長さのコメントが現れて実際に候補検索が必要になった時点でまとめてバケット化するよう変更。典型的な単一 duration の動画で不要だったバケット構築コストを削減。
- `src/input/{legacy,v1,xml2js,xmlDocument}.ts`: `owner ? OWNER_DEFAULT_COLLISION_LAYER : VIEWER_DEFAULT_COLLISION_LAYER` という同一ロジックが4ファイルに重複していたため `getDefaultCollisionLayer()`(`src/@types/format.numeric.ts`)に集約。
- `src/comments/{FlashComment,HTML5Comment}.ts`: `layerScale` の計算式が両ファイルで重複していたため `BaseComment.getLayerScale()` に集約。

なお PR #413 のレビューで指摘された以下2件は今回のスコープ外(ユーザー判断により対応不要):
- `FormattedComment.ignoreScale` が公開出力型で必須化された件(0.4.0 の semver bump で許容範囲と判断)
- `getPosY` の衝突判定が owner フラグではなく layer に集約された件(意図的な設計変更)

## Test plan
- [x] `npm run check-types`
- [x] `npm run lint`
- [x] `npm run build`
- [ ] `npm test`(Playwright 視覚回帰テスト、サンドボックス環境の Docker ボリューム権限問題により未実行。CI での確認が必要)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR consolidates duplicated collision-layer and rendering-scale calculations while deferring movable-comment bucket construction until mixed durations require indexed lookup.
- Adds a shared helper for selecting owner and viewer collision layers across four input parsers.
- Moves the common Flash/HTML5 layer-scale formula into `BaseComment`.
- Introduces pending movable comments to avoid unnecessary bucket construction for single-duration timelines.
</details>

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code defect identified.

The shared helpers preserve their replaced expressions, and the deferred collision index flushes all pending comments before mixed-duration candidate searches without duplicating or omitting registrations.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/utils/comment.ts | Defers collision-bucket population while preserving lookup-before-registration ordering and complete mixed-duration candidate indexing. |
| src/@types/format.numeric.ts | Adds a barrel-exported helper that exactly preserves the existing owner/viewer collision-layer selection. |
| src/comments/BaseComment.ts | Centralizes the unchanged layer-scale expression for built-in comment implementations. |
| src/comments/FlashComment.ts | Replaces the inline scale calculation with the behaviorally equivalent base-class helper. |
| src/comments/HTML5Comment.ts | Replaces the inline scale calculation with the behaviorally equivalent base-class helper. |
| src/input/legacy.ts | Uses the shared collision-layer helper without changing legacy owner inference. |
| src/input/v1.ts | Uses the shared collision-layer helper without changing v1 fork-based owner inference. |
| src/input/xml2js.ts | Uses the shared collision-layer helper without changing XML owner inference. |
| src/input/xmlDocument.ts | Uses the shared collision-layer helper without changing DOM-based XML owner inference. |

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: PR #413 レビュー指摘の効率性・重複コードを解消"](https://github.com/xpadev-net/niconicomments/commit/0e8773511980a022b304dc71f7e1e1a7017fcf2a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53756458)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Input parsing](https://app.greptile.com/xpa/-/custom-context/knowledge-base/xpadev-net/niconicomments/-/docs/input-parsing.md)
- Knowledge Base — [Comment Model](https://app.greptile.com/xpa/-/custom-context/knowledge-base/xpadev-net/niconicomments/-/docs/comment-model.md)
- Knowledge Base — [Utils and error hierarchy](https://app.greptile.com/xpa/-/custom-context/knowledge-base/xpadev-net/niconicomments/-/docs/utils.md)
</details>

<!-- /greptile_comment -->